### PR TITLE
fix: router.go のフォールバック処理を改善

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -48,10 +48,18 @@ export class Router {
 
   go(path: string): void {
     const normalized = this.normalize(path);
-    if (normalized === this.currentPath) {
+    const currentHash = window.location.hash || this.fallback;
+
+    if (normalized === this.currentPath && currentHash === normalized) {
       this.renderCurrent();
       return;
     }
+
+    if (currentHash === normalized) {
+      this.renderCurrent();
+      return;
+    }
+
     window.location.hash = normalized;
   }
 


### PR DESCRIPTION
## Summary
- router.go が現在のハッシュとフォールバックを比較して適切にレンダリングを行うよう調整
- 未登録のハッシュに遷移した際に HOME へ戻れない問題を防止

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3bb66acd8832abac18e28626519a4