### PR TITLE
feat: 状態モデルの定義を拡充

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -8,11 +8,179 @@ export type PhaseKey =
   | 'intermission'
   | 'curtaincall';
 
+export const PLAYER_IDS = ['lumina', 'nox'] as const;
+
+export type PlayerId = (typeof PLAYER_IDS)[number];
+export type PlayerRole = PlayerId;
+
+export type CardRank =
+  | 'A'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | 'J'
+  | 'Q'
+  | 'K'
+  | 'JOKER';
+
+export type StandardCardRank = Exclude<CardRank, 'JOKER'>;
+
+export type CardSuit = 'spades' | 'hearts' | 'diamonds' | 'clubs' | 'joker';
+export type StandardCardSuit = Exclude<CardSuit, 'joker'>;
+
+export type CardFace = 'up' | 'down';
+
+export interface CardDefinition {
+  id: string;
+  rank: CardRank;
+  suit: CardSuit;
+  value: number;
+}
+
+export interface CardSnapshot extends CardDefinition {
+  face: CardFace;
+  annotation?: string;
+}
+
+export type StageCardOrigin = 'hand' | 'set' | 'jokerBonus';
+
+export interface StageCardPlacement {
+  card: CardSnapshot;
+  from: StageCardOrigin;
+  placedAt: number;
+  revealedAt?: number;
+}
+
+export type StagePairOrigin = 'action' | 'spotlight' | 'joker';
+export type StageJudgeResult = 'match' | 'mismatch';
+
+export interface StagePair {
+  id: string;
+  owner: PlayerId;
+  origin: StagePairOrigin;
+  actor?: StageCardPlacement;
+  kuroko?: StageCardPlacement;
+  judge?: StageJudgeResult;
+  createdAt: number;
+  resolvedAt?: number;
+}
+
+export interface StageArea {
+  pairs: StagePair[];
+}
+
+export interface PlayerScore {
+  sumKami: number;
+  sumHand: number;
+  penalty: number;
+  final: number;
+}
+
+export interface PlayerHand {
+  cards: CardSnapshot[];
+  maxSize: number;
+}
+
+export interface PlayerState {
+  id: PlayerId;
+  name: string;
+  role: PlayerRole;
+  hand: PlayerHand;
+  stage: StageArea;
+  booCount: number;
+  clapCount: number;
+  takenByOpponent: CardSnapshot[];
+  score: PlayerScore;
+}
+
+export interface SetCardState {
+  id: string;
+  card: CardSnapshot;
+  position: number;
+}
+
+export type SetRevealBonus = 'joker' | 'pair' | 'secretPair';
+
+export interface SetReveal {
+  id: string;
+  card: CardSnapshot;
+  position: number;
+  openedBy: PlayerId;
+  openedAt: number;
+  assignedTo?: PlayerId;
+  bonus?: SetRevealBonus;
+  pairId?: string;
+}
+
+export interface SetState {
+  cards: SetCardState[];
+  opened: SetReveal[];
+}
+
+export type HistoryEntryType =
+  | 'setup'
+  | 'standby'
+  | 'scout'
+  | 'action'
+  | 'watch'
+  | 'spotlight'
+  | 'intermission'
+  | 'curtaincall'
+  | 'result';
+
+export interface HistoryEntry {
+  id: string;
+  type: HistoryEntryType;
+  turn: number;
+  actor: PlayerId;
+  payload?: Record<string, unknown>;
+  createdAt: number;
+}
+
+export interface TurnState {
+  count: number;
+  startedAt: number;
+}
+
+export interface GameMeta {
+  createdAt: number;
+  composition: {
+    total: number;
+    joker: number;
+    set: number;
+    perHand: number;
+  };
+  seed?: string;
+}
+
+export interface ResumeSnapshot {
+  at: number;
+  phase: PhaseKey;
+  player: PlayerId;
+  route: string;
+}
+
 export interface GameState extends Record<string, unknown> {
+  matchId: string;
   phase: PhaseKey;
   route: string;
   revision: number;
   updatedAt: number;
+  players: Record<PlayerId, PlayerState>;
+  firstPlayer: PlayerId;
+  activePlayer: PlayerId;
+  turn: TurnState;
+  set: SetState;
+  history: HistoryEntry[];
+  meta: GameMeta;
+  resume?: ResumeSnapshot;
+  recentScoutedCard: CardSnapshot | null;
 }
 
 export type StateListener<TState> = (state: TState) => void;
@@ -61,11 +229,84 @@ export class Store<TState extends Record<string, unknown>> {
   }
 }
 
-export const createInitialState = (): GameState => ({
-  phase: 'home',
-  route: '#/',
-  revision: 0,
-  updatedAt: Date.now(),
+export const CARD_COMPOSITION = Object.freeze({
+  total: 53,
+  joker: 1,
+  set: 13,
+  perHand: 20,
 });
+
+const DEFAULT_PLAYER_NAMES: Record<PlayerId, string> = {
+  lumina: 'ルミナ',
+  nox: 'ノクス',
+};
+
+const createInitialScore = (): PlayerScore => ({
+  sumKami: 0,
+  sumHand: 0,
+  penalty: 0,
+  final: 0,
+});
+
+const createEmptyStage = (): StageArea => ({
+  pairs: [],
+});
+
+const createEmptyHand = (): PlayerHand => ({
+  cards: [],
+  maxSize: CARD_COMPOSITION.perHand,
+});
+
+const createPlayerState = (id: PlayerId): PlayerState => ({
+  id,
+  name: DEFAULT_PLAYER_NAMES[id],
+  role: id,
+  hand: createEmptyHand(),
+  stage: createEmptyStage(),
+  booCount: 0,
+  clapCount: 0,
+  takenByOpponent: [],
+  score: createInitialScore(),
+});
+
+const createMatchId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const random = Math.random().toString(16).slice(2, 10);
+  return `match-${Date.now()}-${random}`;
+};
+
+export const createInitialState = (): GameState => {
+  const timestamp = Date.now();
+  return {
+    matchId: createMatchId(),
+    phase: 'home',
+    route: '#/',
+    revision: 0,
+    updatedAt: timestamp,
+    players: {
+      lumina: createPlayerState('lumina'),
+      nox: createPlayerState('nox'),
+    },
+    firstPlayer: 'lumina',
+    activePlayer: 'lumina',
+    turn: {
+      count: 1,
+      startedAt: timestamp,
+    },
+    set: {
+      cards: [],
+      opened: [],
+    },
+    history: [],
+    meta: {
+      createdAt: timestamp,
+      composition: { ...CARD_COMPOSITION },
+    },
+    resume: undefined,
+    recentScoutedCard: null,
+  };
+};
 
 export const gameStore = new Store<GameState>(createInitialState());

--- a/src/ui/card.ts
+++ b/src/ui/card.ts
@@ -1,6 +1,7 @@
+import type { CardSuit } from '../state.js';
 import { UIComponent } from './component.js';
 
-export type CardSuit = 'hearts' | 'diamonds' | 'clubs' | 'spades' | 'joker';
+export type { CardSuit };
 
 export interface CardOptions {
   rank: string;


### PR DESCRIPTION
## Summary
- カード・プレイヤー・ステージ・履歴などドメインに合わせた型を整備し、GameState に集約
- マッチID生成やカード構成定数を追加し、初期状態生成ロジックを強化
- カードUIコンポーネントで状態モデルの CardSuit 型を再利用

## Testing
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68d3bcf7e748832a89f8b4897abbe025