### PR TITLE
feat: implement rank value resolver

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -9,6 +9,7 @@ import {
   StandardCardRank,
   StandardCardSuit,
 } from './state.js';
+import { rankValue } from './rank.js';
 
 const STANDARD_RANKS: readonly StandardCardRank[] = [
   'A',
@@ -36,36 +37,13 @@ const SUIT_ID: Record<CardSuit, string> = {
   joker: 'J',
 };
 
-const computeCardValue = (rank: CardRank): number => {
-  if (rank === 'JOKER') {
-    return 0;
-  }
-  if (rank === 'A') {
-    return 1;
-  }
-  const parsed = Number.parseInt(rank, 10);
-  if (Number.isNaN(parsed)) {
-    switch (rank) {
-      case 'J':
-        return 11;
-      case 'Q':
-        return 12;
-      case 'K':
-        return 13;
-      default:
-        throw new Error(`不明なランク値です: ${rank}`);
-    }
-  }
-  return parsed;
-};
-
 const createCardId = (suit: CardSuit, rank: CardRank): string => `${SUIT_ID[suit]}-${rank}`;
 
 const createCardSnapshot = (suit: CardSuit, rank: CardRank): CardSnapshot => ({
   id: createCardId(suit, rank),
   suit,
   rank,
-  value: computeCardValue(rank),
+  value: rankValue(rank),
   face: 'down',
 });
 

--- a/src/rank.ts
+++ b/src/rank.ts
@@ -1,0 +1,69 @@
+import type { CardDefinition, CardRank } from './state.js';
+
+export type RankValueRuleId = string;
+
+export type RankValueResolver = (rank: CardRank) => number;
+
+export const DEFAULT_RANK_VALUE_RULE = 'rulebook_default';
+
+const STANDARD_RANK_VALUES: Readonly<Record<CardRank, number>> = {
+  A: 1,
+  '2': 2,
+  '3': 3,
+  '4': 4,
+  '5': 5,
+  '6': 6,
+  '7': 7,
+  '8': 8,
+  '9': 9,
+  '10': 10,
+  J: 11,
+  Q: 12,
+  K: 13,
+  JOKER: 0,
+};
+
+const registry = new Map<RankValueRuleId, RankValueResolver>();
+registry.set(DEFAULT_RANK_VALUE_RULE, (rank: CardRank) => {
+  const value = STANDARD_RANK_VALUES[rank];
+  if (typeof value !== 'number') {
+    throw new Error(`未対応のランクです: ${rank}`);
+  }
+  return value;
+});
+
+let activeRuleId: RankValueRuleId = DEFAULT_RANK_VALUE_RULE;
+
+const resolveRule = (ruleId: RankValueRuleId): RankValueResolver => {
+  const resolver = registry.get(ruleId);
+  if (!resolver) {
+    throw new Error(`未登録のランク変換ルールです: ${ruleId}`);
+  }
+  return resolver;
+};
+
+export const listRankValueRules = (): RankValueRuleId[] => Array.from(registry.keys());
+
+export const registerRankValueRule = (
+  ruleId: RankValueRuleId,
+  resolver: RankValueResolver,
+): void => {
+  registry.set(ruleId, resolver);
+};
+
+export const setActiveRankValueRule = (ruleId: RankValueRuleId): void => {
+  resolveRule(ruleId);
+  activeRuleId = ruleId;
+};
+
+export const getActiveRankValueRule = (): RankValueRuleId => activeRuleId;
+
+export type RankValueTarget = CardRank | Pick<CardDefinition, 'rank'>;
+
+const extractRank = (target: RankValueTarget): CardRank =>
+  typeof target === 'string' ? target : target.rank;
+
+export const rankValue = (target: RankValueTarget): number => {
+  const resolver = resolveRule(activeRuleId);
+  return resolver(extractRank(target));
+};


### PR DESCRIPTION
## Summary
- add a dedicated rank value module with a configurable rule registry
- expose helpers to manage the active rank rule and compute card values
- reuse the shared rankValue helper when constructing card snapshots

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3c0f0fca0832ab10f5c923d479012