### PR TITLE
feat: introduce local storage persistence

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { Router, RouteDefinition } from './router.js';
+import { saveLatestGame } from './storage.js';
 import { createInitialState, gameStore, PhaseKey } from './state.js';
 import { ModalController } from './ui/modal.js';
 import { ToastManager } from './ui/toast.js';
@@ -190,12 +191,24 @@ const initializeApp = (): void => {
     if (current.route === path) {
       return;
     }
+    const phase = inferPhaseFromPath(path);
+    const timestamp = Date.now();
     gameStore.patch({
       route: path,
-      phase: inferPhaseFromPath(path),
+      phase,
       revision: current.revision + 1,
-      updatedAt: Date.now(),
+      updatedAt: timestamp,
+      resume: {
+        at: timestamp,
+        phase,
+        player: current.activePlayer,
+        route: path,
+      },
     });
+  });
+
+  gameStore.subscribe((state) => {
+    saveLatestGame(state);
   });
 
   router.start();

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,209 @@
+import { GameState, PhaseKey, PlayerId, TurnState } from './state.js';
+
+const STORAGE_VERSION = 1;
+
+const STORAGE_KEYS = {
+  latest: 'cc:save:latest',
+  slotPrefix: 'cc:save:slots:',
+  history: 'cc:history:list',
+} as const;
+
+const RESUME_GATE_PATH = '#/resume/gate';
+
+const STORAGE_TEST_KEY = '__cc:storage:test__';
+
+export interface SaveMetadata {
+  savedAt: number;
+  phase: PhaseKey;
+  activePlayer: PlayerId;
+  turn: TurnState;
+  route: string;
+  revision: number;
+}
+
+export interface StoredGamePayload {
+  version: number;
+  state: GameState;
+  meta: SaveMetadata;
+}
+
+export interface LoadOptions {
+  /**
+   * true の場合、`#/resume/gate` 以外のパスからでも復元を許可します。
+   * テスト用途や内部処理向けの抜け道です。
+   */
+  allowUnsafe?: boolean;
+  /** 現在のハッシュ。省略時は `window.location.hash` を参照します。 */
+  currentPath?: string | null;
+}
+
+let cachedStorage: Storage | null | undefined;
+let lastSavedSignature: string | null = null;
+
+const getStorage = (): Storage | null => {
+  if (cachedStorage !== undefined) {
+    return cachedStorage;
+  }
+  if (typeof window === 'undefined' || !window.localStorage) {
+    cachedStorage = null;
+    return cachedStorage;
+  }
+  try {
+    const { localStorage } = window;
+    localStorage.setItem(STORAGE_TEST_KEY, 'ok');
+    localStorage.removeItem(STORAGE_TEST_KEY);
+    cachedStorage = localStorage;
+  } catch (error) {
+    console.warn('localStorage が利用できません。', error);
+    cachedStorage = null;
+  }
+  return cachedStorage;
+};
+
+const normalizePath = (path: string): string => {
+  if (!path) {
+    return '#/';
+  }
+  if (path === '#') {
+    return '#/';
+  }
+  if (path.startsWith('#')) {
+    if (path.length === 1) {
+      return '#/';
+    }
+    return path;
+  }
+  if (path.startsWith('/')) {
+    return `#${path}`;
+  }
+  return `#/${path}`;
+};
+
+const cloneValue = <T>(value: T): T => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+const createSaveMetadata = (state: GameState): SaveMetadata => ({
+  savedAt: state.updatedAt,
+  phase: state.phase,
+  activePlayer: state.activePlayer,
+  turn: { ...state.turn },
+  route: state.route,
+  revision: state.revision,
+});
+
+const readLatestPayload = (): StoredGamePayload | null => {
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
+  const raw = storage.getItem(STORAGE_KEYS.latest);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as StoredGamePayload;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    if (parsed.version !== STORAGE_VERSION) {
+      return null;
+    }
+    if (!parsed.state || !parsed.meta) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('セーブデータの解析に失敗しました。', error);
+    return null;
+  }
+};
+
+const enforceResumeGate = (options: LoadOptions): void => {
+  if (options.allowUnsafe) {
+    return;
+  }
+  const currentPath =
+    options.currentPath ?? (typeof window !== 'undefined' ? window.location.hash : null);
+  if (!currentPath) {
+    return;
+  }
+  const normalized = normalizePath(currentPath);
+  if (normalized !== RESUME_GATE_PATH) {
+    throw new Error('レジュームゲート以外からの復元は許可されていません。');
+  }
+};
+
+export const saveLatestGame = (state: GameState): void => {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+  const signature = `${state.matchId}:${state.revision}:${state.updatedAt}`;
+  if (lastSavedSignature === signature) {
+    return;
+  }
+  const meta = createSaveMetadata(state);
+  const resume =
+    state.resume ?? ({
+      at: meta.savedAt,
+      phase: state.phase,
+      player: state.activePlayer,
+      route: state.route,
+    } as const);
+  const payload: StoredGamePayload = {
+    version: STORAGE_VERSION,
+    state: cloneValue({
+      ...state,
+      resume,
+    }),
+    meta: { ...meta, turn: { ...meta.turn } },
+  };
+  try {
+    storage.setItem(STORAGE_KEYS.latest, JSON.stringify(payload));
+    lastSavedSignature = signature;
+  } catch (error) {
+    console.warn('セーブデータの保存に失敗しました。', error);
+  }
+};
+
+export const loadLatestGame = (options: LoadOptions = {}): StoredGamePayload | null => {
+  enforceResumeGate(options);
+  const payload = readLatestPayload();
+  if (!payload) {
+    return null;
+  }
+  return {
+    version: payload.version,
+    state: cloneValue(payload.state),
+    meta: { ...payload.meta, turn: { ...payload.meta.turn } },
+  };
+};
+
+export const clearLatestGame = (): void => {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.removeItem(STORAGE_KEYS.latest);
+    lastSavedSignature = null;
+  } catch (error) {
+    console.warn('セーブデータの削除に失敗しました。', error);
+  }
+};
+
+export const getLatestSaveMetadata = (): SaveMetadata | null => {
+  const payload = readLatestPayload();
+  if (!payload) {
+    return null;
+  }
+  return { ...payload.meta, turn: { ...payload.meta.turn } };
+};
+
+export const hasLatestSave = (): boolean => readLatestPayload() !== null;
+
+export const getStorageKeys = () => ({ ...STORAGE_KEYS });


### PR DESCRIPTION
## Summary
- localStorageを扱う永続化ユーティリティを実装し、最新オートセーブの保存・復元・クリアAPIを提供
- レジュームゲート以外からの復元を禁止するガードを追加し、ゲーム状態をメタデータ付きで保存
- ルーター遷移に応じたレジュームスナップショット更新とstore監視による自動保存を組み込み

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3c219d2f8832ab4ec44942ed0f0ef