### PR TITLE
feat: add interaction lock for core UI components

### DIFF
--- a/src/ui/button.ts
+++ b/src/ui/button.ts
@@ -1,4 +1,5 @@
 import { UIComponent } from './component.js';
+import { InteractionLock, clampInteractionLockDuration } from './interaction-lock.js';
 
 export type ButtonVariant = 'primary' | 'ghost' | 'danger';
 
@@ -7,11 +8,23 @@ export interface ButtonOptions {
   type?: 'button' | 'submit' | 'reset';
   variant?: ButtonVariant;
   disabled?: boolean;
+  preventRapid?: boolean;
+  lockDuration?: number;
   onClick?: (event: MouseEvent) => void;
+}
+
+export interface ButtonClickOptions {
+  preventRapid?: boolean;
+  lockDuration?: number;
 }
 
 export class UIButton extends UIComponent<HTMLButtonElement> {
   private variant: ButtonVariant;
+  private preventRapid: boolean;
+  private lockDuration: number;
+  private readonly clickLock: InteractionLock;
+  private readonly listeners: { handler: (event: MouseEvent) => void; usesLock: boolean }[] = [];
+  private readonly boundHandleClick: (event: MouseEvent) => void;
 
   constructor(options: ButtonOptions) {
     const element = document.createElement('button');
@@ -19,12 +32,21 @@ export class UIButton extends UIComponent<HTMLButtonElement> {
     element.classList.add('button');
     super(element);
     this.variant = options.variant ?? 'primary';
+    this.preventRapid = options.preventRapid ?? true;
+    this.lockDuration = clampInteractionLockDuration(options.lockDuration);
+    this.clickLock = new InteractionLock({
+      duration: this.lockDuration,
+      onLock: () => this.applyBusyState(true),
+      onUnlock: () => this.applyBusyState(false),
+    });
+    this.boundHandleClick = (event) => this.handleDomClick(event);
+    this.element.addEventListener('click', this.boundHandleClick);
     this.applyVariant(this.variant);
     this.setLabel(options.label);
     this.setDisabled(Boolean(options.disabled));
 
     if (options.onClick) {
-      this.element.addEventListener('click', options.onClick);
+      this.onClick(options.onClick);
     }
   }
 
@@ -34,6 +56,10 @@ export class UIButton extends UIComponent<HTMLButtonElement> {
 
   setDisabled(disabled: boolean): void {
     this.element.disabled = disabled;
+    if (disabled) {
+      this.clickLock.unlock();
+      this.applyBusyState(false);
+    }
   }
 
   setVariant(variant: ButtonVariant): void {
@@ -45,14 +71,62 @@ export class UIButton extends UIComponent<HTMLButtonElement> {
     this.applyVariant(variant);
   }
 
-  onClick(handler: (event: MouseEvent) => void): this {
-    this.element.addEventListener('click', handler);
+  onClick(handler: (event: MouseEvent) => void, options?: ButtonClickOptions): this {
+    if (options?.lockDuration !== undefined) {
+      const normalized = clampInteractionLockDuration(options.lockDuration);
+      this.lockDuration = normalized;
+      this.clickLock.duration = normalized;
+    }
+
+    const usesLock = options?.preventRapid ?? this.preventRapid;
+    this.listeners.push({ handler, usesLock });
     return this;
+  }
+
+  lock(duration?: number): void {
+    this.clickLock.lock(duration ?? this.lockDuration);
+  }
+
+  unlock(): void {
+    this.clickLock.unlock();
+  }
+
+  get locked(): boolean {
+    return this.clickLock.isLocked;
   }
 
   private applyVariant(variant: ButtonVariant): void {
     if (variant !== 'primary') {
       this.element.classList.add(`button--${variant}`);
     }
+  }
+
+  private applyBusyState(isBusy: boolean): void {
+    this.element.classList.toggle('is-busy', isBusy);
+    if (isBusy) {
+      this.element.setAttribute('aria-busy', 'true');
+    } else {
+      this.element.removeAttribute('aria-busy');
+    }
+  }
+
+  private handleDomClick(event: MouseEvent): void {
+    if (this.listeners.length === 0) {
+      return;
+    }
+
+    if (this.clickLock.isLocked) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    if (this.listeners.some((listener) => listener.usesLock)) {
+      this.clickLock.lock(this.lockDuration);
+    }
+
+    this.listeners.forEach((listener) => {
+      listener.handler.call(this.element, event);
+    });
   }
 }

--- a/src/ui/interaction-lock.ts
+++ b/src/ui/interaction-lock.ts
@@ -1,0 +1,111 @@
+const MIN_DURATION = 200;
+const MAX_DURATION = 400;
+const DEFAULT_DURATION = 300;
+
+export interface InteractionLockOptions {
+  duration?: number;
+  onLock?: () => void;
+  onUnlock?: () => void;
+}
+
+export const clampInteractionLockDuration = (value?: number): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return DEFAULT_DURATION;
+  }
+  const rounded = Math.round(value);
+  if (rounded < MIN_DURATION) {
+    return MIN_DURATION;
+  }
+  if (rounded > MAX_DURATION) {
+    return MAX_DURATION;
+  }
+  return rounded;
+};
+
+export class InteractionLock {
+  private locked = false;
+  private timerId?: number;
+  private defaultDuration: number;
+  private readonly onLock?: () => void;
+  private readonly onUnlock?: () => void;
+
+  constructor(options?: InteractionLockOptions) {
+    this.defaultDuration = clampInteractionLockDuration(options?.duration);
+    this.onLock = options?.onLock;
+    this.onUnlock = options?.onUnlock;
+  }
+
+  get isLocked(): boolean {
+    return this.locked;
+  }
+
+  get duration(): number {
+    return this.defaultDuration;
+  }
+
+  set duration(value: number) {
+    this.defaultDuration = clampInteractionLockDuration(value);
+  }
+
+  lock(duration?: number): void {
+    const actualDuration = clampInteractionLockDuration(duration ?? this.defaultDuration);
+    if (this.timerId !== undefined) {
+      window.clearTimeout(this.timerId);
+    }
+
+    const wasLocked = this.locked;
+    this.locked = true;
+    if (!wasLocked) {
+      this.onLock?.();
+    }
+
+    this.timerId = window.setTimeout(() => this.unlock(), actualDuration);
+  }
+
+  unlock(): void {
+    if (this.timerId !== undefined) {
+      window.clearTimeout(this.timerId);
+      this.timerId = undefined;
+    }
+
+    if (!this.locked) {
+      return;
+    }
+
+    this.locked = false;
+    this.onUnlock?.();
+  }
+
+  run<T>(callback: () => T, duration?: number): T | undefined {
+    if (this.locked) {
+      return undefined;
+    }
+    this.lock(duration);
+    return callback();
+  }
+
+  wrap<E extends Event>(handler: (event: E) => void, duration?: number): (event: E) => void {
+    return (event: E) => {
+      if (this.locked) {
+        if (typeof event.preventDefault === 'function') {
+          event.preventDefault();
+        }
+        if (typeof event.stopImmediatePropagation === 'function') {
+          event.stopImmediatePropagation();
+        }
+        return;
+      }
+
+      this.lock(duration);
+      handler(event);
+    };
+  }
+}
+
+export const withInteractionLock = <E extends Event>(
+  handler: (event: E) => void,
+  options?: InteractionLockOptions,
+): ((event: E) => void) => {
+  const lock = new InteractionLock(options);
+  return lock.wrap(handler);
+};

--- a/src/ui/modal.ts
+++ b/src/ui/modal.ts
@@ -5,6 +5,9 @@ export interface ModalAction {
   label: string;
   variant?: ButtonVariant;
   dismiss?: boolean;
+  disabled?: boolean;
+  preventRapid?: boolean;
+  lockDuration?: number;
   onSelect?: () => void;
 }
 
@@ -59,6 +62,9 @@ class ModalView extends UIComponent<HTMLDivElement> {
       const button = new UIButton({
         label: action.label,
         variant: action.variant,
+        disabled: action.disabled,
+        preventRapid: action.preventRapid,
+        lockDuration: action.lockDuration,
       });
       button.onClick(() => {
         action.onSelect?.();

--- a/src/views/placeholder.ts
+++ b/src/views/placeholder.ts
@@ -4,6 +4,8 @@ export interface PlaceholderAction {
   label: string;
   variant?: ButtonVariant;
   disabled?: boolean;
+  preventRapid?: boolean;
+  lockDuration?: number;
   onSelect: () => void;
 }
 
@@ -40,6 +42,8 @@ export const createPlaceholderView = (options: PlaceholderOptions): HTMLElement 
         label: action.label,
         variant: action.variant,
         disabled: action.disabled,
+        preventRapid: action.preventRapid,
+        lockDuration: action.lockDuration,
       });
       button.onClick(() => action.onSelect());
       actions.append(button.el);

--- a/styles/base.css
+++ b/styles/base.css
@@ -87,6 +87,30 @@ p {
   box-shadow: 0 8px 24px rgba(251, 191, 36, 0.35);
 }
 
+.button.is-busy {
+  cursor: wait;
+  pointer-events: none;
+  opacity: 0.85;
+  transform: none;
+  box-shadow: none;
+}
+
+.button::after {
+  content: '';
+  display: none;
+}
+
+.button.is-busy::after {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  margin-left: 0.5rem;
+  border-radius: 50%;
+  border: 2px solid rgba(15, 23, 42, 0.25);
+  border-top-color: currentColor;
+  animation: button-spinner 600ms linear infinite;
+}
+
 .button--ghost {
   background: transparent;
   color: var(--color-text);
@@ -211,4 +235,13 @@ p {
   flex-wrap: wrap;
   justify-content: center;
   gap: 0.75rem;
+}
+
+@keyframes button-spinner {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
## Summary
- add an interaction lock utility to normalise the shared click cooldown behaviour
- update UIButton to share the lock across handlers, expose busy state, and support configurable cooldowns
- pass the cooldown options through modal and placeholder actions and style the busy state indicator

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3c36a3740832a9d6333fe35b1987f