### PR TITLE
feat: implement gate modal for handoff routes

### DIFF
--- a/src/views/gate.ts
+++ b/src/views/gate.ts
@@ -1,0 +1,80 @@
+import { showGate, GateOptions } from '../ui/gate.js';
+
+export interface GateViewOptions {
+  title: string;
+  subtitle?: string;
+  message?: string | HTMLElement;
+  confirmLabel?: string;
+  hints?: string[];
+  modalNotes?: string[];
+  modalTitle?: string;
+  preventRapid?: boolean;
+  lockDuration?: number;
+  onGatePass?: () => void;
+}
+
+const DEFAULT_GATE_MESSAGE =
+  '端末を次のプレイヤーに渡したら「準備完了」を押して、秘匿情報の閲覧を開始してください。';
+
+const createTextParagraph = (content: string): HTMLParagraphElement => {
+  const paragraph = document.createElement('p');
+  paragraph.textContent = content;
+  return paragraph;
+};
+
+const renderHintList = (hints: string[] | undefined): HTMLUListElement | null => {
+  if (!hints || hints.length === 0) {
+    return null;
+  }
+  const list = document.createElement('ul');
+  list.className = 'gate-view__hints';
+  hints.forEach((hint) => {
+    const item = document.createElement('li');
+    item.textContent = hint;
+    list.append(item);
+  });
+  return list;
+};
+
+export const createGateView = (options: GateViewOptions): HTMLElement => {
+  const section = document.createElement('section');
+  section.className = 'view gate-view';
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'gate-view__panel';
+
+  const heading = document.createElement('h1');
+  heading.className = 'gate-view__title';
+  heading.textContent = options.title;
+  wrapper.append(heading);
+
+  if (options.subtitle) {
+    const subtitle = createTextParagraph(options.subtitle);
+    subtitle.className = 'gate-view__subtitle';
+    wrapper.append(subtitle);
+  }
+
+  const hints = renderHintList(options.hints);
+  if (hints) {
+    wrapper.append(hints);
+  }
+
+  section.append(wrapper);
+
+  if (typeof window !== 'undefined') {
+    queueMicrotask(() => {
+      const gateOptions: GateOptions = {
+        title: options.modalTitle ?? options.title,
+        text: options.message ?? DEFAULT_GATE_MESSAGE,
+        notes: options.modalNotes,
+        confirmLabel: options.confirmLabel,
+        preventRapid: options.preventRapid,
+        lockDuration: options.lockDuration,
+        onOk: options.onGatePass,
+      };
+      showGate(gateOptions);
+    });
+  }
+
+  return section;
+};

--- a/styles/base.css
+++ b/styles/base.css
@@ -160,6 +160,41 @@ p {
   gap: 0.75rem;
 }
 
+.gate-modal {
+  display: grid;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.gate-modal__message {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--color-text);
+}
+
+.gate-modal__notes {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.gate-modal__notes li {
+  position: relative;
+  padding-left: 1.25rem;
+  text-align: left;
+}
+
+.gate-modal__notes li::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  color: var(--color-accent);
+}
+
 .toast-root {
   position: fixed;
   inset-inline: 0;
@@ -195,6 +230,64 @@ p {
 
 .toast--danger {
   border-left: 4px solid var(--color-danger);
+}
+
+.gate-view {
+  min-height: calc(100vh - 4rem);
+  display: grid;
+  place-items: center;
+  padding: 2.5rem 1.5rem;
+}
+
+.gate-view__panel {
+  width: min(560px, 100%);
+  padding: clamp(1.75rem, 2.5vw + 1rem, 2.5rem);
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.88);
+  box-shadow: var(--shadow-lg);
+  text-align: center;
+}
+
+.gate-view__title {
+  font-size: clamp(1.75rem, 2vw + 1.2rem, 2.3rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 1.25rem;
+}
+
+.gate-view__subtitle {
+  margin: 0 auto 1.5rem;
+  max-width: 38ch;
+  color: var(--color-muted);
+  line-height: 1.7;
+}
+
+.gate-view__hints {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.gate-view__hints li {
+  position: relative;
+  padding: 0.75rem 0.75rem 0.75rem 2.25rem;
+  border-radius: 16px;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text);
+  font-weight: 500;
+  line-height: 1.6;
+}
+
+.gate-view__hints li::before {
+  content: '\27A4';
+  position: absolute;
+  left: 0.9rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-accent);
 }
 
 .card {


### PR DESCRIPTION
## Summary
- add a reusable gate modal controller to centralize handoff confirmation overlays
- render dedicated gate views for /gate routes and navigate to phase routes after confirmation
- style gate screens and modal content to emphasize full-screen blocking handoff flow

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3dc9e5b5c832aa56cda275121ecf7