### PR TITLE
feat: implement standby setup interface

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -173,7 +173,7 @@ export interface GameState extends Record<string, unknown> {
   revision: number;
   updatedAt: number;
   players: Record<PlayerId, PlayerState>;
-  firstPlayer: PlayerId;
+  firstPlayer: PlayerId | null;
   activePlayer: PlayerId;
   turn: TurnState;
   set: SetState;
@@ -237,8 +237,8 @@ export const CARD_COMPOSITION = Object.freeze({
 });
 
 const DEFAULT_PLAYER_NAMES: Record<PlayerId, string> = {
-  lumina: 'ルミナ',
-  nox: 'ノクス',
+  lumina: 'プレイヤーA',
+  nox: 'プレイヤーB',
 };
 
 const createInitialScore = (): PlayerScore => ({
@@ -289,7 +289,7 @@ export const createInitialState = (): GameState => {
       lumina: createPlayerState('lumina'),
       nox: createPlayerState('nox'),
     },
-    firstPlayer: 'lumina',
+    firstPlayer: null,
     activePlayer: 'lumina',
     turn: {
       count: 1,

--- a/src/views/standby.ts
+++ b/src/views/standby.ts
@@ -1,0 +1,219 @@
+import { PlayerId } from '../state.js';
+import { UIButton } from '../ui/button.js';
+
+export interface StandbyPlayerConfig {
+  id: PlayerId;
+  label: string;
+  role?: string;
+  name: string;
+  placeholder?: string;
+}
+
+export interface StandbyViewOptions {
+  title: string;
+  subtitle?: string;
+  players: StandbyPlayerConfig[];
+  firstPlayer?: PlayerId | null;
+  onPlayerNameChange?: (player: PlayerId, name: string) => void;
+  onFirstPlayerChange?: (player: PlayerId) => void;
+  onStart?: () => void;
+  onReturnHome?: () => void;
+}
+
+export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
+  const section = document.createElement('section');
+  section.className = 'view standby-view';
+
+  const main = document.createElement('main');
+  main.className = 'standby';
+
+  const titleId = `standby-title-${Math.random().toString(36).slice(2, 8)}`;
+
+  const heading = document.createElement('h1');
+  heading.className = 'standby__title';
+  heading.id = titleId;
+  heading.textContent = options.title;
+  main.append(heading);
+
+  if (options.subtitle) {
+    const subtitle = document.createElement('p');
+    subtitle.className = 'standby__subtitle';
+    subtitle.textContent = options.subtitle;
+    main.append(subtitle);
+  }
+
+  main.setAttribute('aria-labelledby', titleId);
+
+  const content = document.createElement('div');
+  content.className = 'standby__content';
+
+  const playerFieldset = document.createElement('fieldset');
+  playerFieldset.className = 'standby__fieldset standby__fieldset--players';
+
+  const playerLegend = document.createElement('legend');
+  playerLegend.className = 'standby__legend';
+  playerLegend.textContent = 'プレイヤー';
+  playerFieldset.append(playerLegend);
+
+  const nameGroup = document.createElement('div');
+  nameGroup.className = 'standby__players';
+
+  const uniqueSuffix = Math.random().toString(36).slice(2, 8);
+
+  const playerLabelMap = new Map<PlayerId, string>();
+
+  options.players.forEach((player) => {
+    playerLabelMap.set(player.id, player.label);
+    const wrapper = document.createElement('div');
+    wrapper.className = 'standby-player';
+
+    const label = document.createElement('label');
+    label.className = 'standby-player__label';
+    const inputId = `standby-player-name-${player.id}-${uniqueSuffix}`;
+    label.htmlFor = inputId;
+
+    const labelName = document.createElement('span');
+    labelName.className = 'standby-player__name';
+    labelName.textContent = player.label;
+    label.append(labelName);
+
+    if (player.role) {
+      const role = document.createElement('span');
+      role.className = 'standby-player__role';
+      role.textContent = player.role;
+      label.append(role);
+    }
+
+    const input = document.createElement('input');
+    input.className = 'standby-player__input';
+    input.type = 'text';
+    input.id = inputId;
+    input.name = inputId;
+    input.autocomplete = 'off';
+    input.value = player.name;
+    if (player.placeholder) {
+      input.placeholder = player.placeholder;
+    }
+
+    input.addEventListener('input', () => {
+      options.onPlayerNameChange?.(player.id, input.value);
+    });
+
+    wrapper.append(label, input);
+    nameGroup.append(wrapper);
+  });
+
+  playerFieldset.append(nameGroup);
+  content.append(playerFieldset);
+
+  const firstPlayerFieldset = document.createElement('fieldset');
+  firstPlayerFieldset.className = 'standby__fieldset standby__fieldset--first-player';
+
+  const firstLegend = document.createElement('legend');
+  firstLegend.className = 'standby__legend';
+  firstLegend.textContent = '先手';
+  firstPlayerFieldset.append(firstLegend);
+
+  const status = document.createElement('p');
+  status.className = 'standby__first-player-status';
+  firstPlayerFieldset.append(status);
+
+  const firstPlayerName = `standby-first-player-${uniqueSuffix}`;
+  let currentFirstPlayer: PlayerId | null = options.firstPlayer ?? null;
+
+  const updateStatus = () => {
+    if (currentFirstPlayer && playerLabelMap.has(currentFirstPlayer)) {
+      status.textContent = `先手：${playerLabelMap.get(currentFirstPlayer)}`;
+    } else {
+      status.textContent = '先手：未決定';
+    }
+  };
+
+  const radioGroup = document.createElement('div');
+  radioGroup.className = 'standby__first-player-options';
+
+  const radioOptions: HTMLLabelElement[] = [];
+
+  const updateRadioSelection = () => {
+    radioOptions.forEach((option) => {
+      const input = option.querySelector<HTMLInputElement>('input[type="radio"]');
+      option.classList.toggle('is-selected', Boolean(input?.checked));
+    });
+  };
+
+  options.players.forEach((player) => {
+    const optionId = `standby-first-player-${player.id}-${uniqueSuffix}`;
+    const label = document.createElement('label');
+    label.className = 'standby-radio';
+
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = firstPlayerName;
+    input.id = optionId;
+    input.value = player.id;
+    input.className = 'standby-radio__input';
+    input.checked = currentFirstPlayer === player.id;
+
+    input.addEventListener('change', () => {
+      if (!input.checked) {
+        return;
+      }
+      currentFirstPlayer = player.id;
+      updateStatus();
+      updateRadioSelection();
+      updateStartButtonState();
+      options.onFirstPlayerChange?.(player.id);
+    });
+
+    const caption = document.createElement('span');
+    caption.className = 'standby-radio__caption';
+    caption.textContent = `先手：${player.label}`;
+
+    label.append(input, caption);
+    radioGroup.append(label);
+    radioOptions.push(label);
+  });
+
+  firstPlayerFieldset.append(radioGroup);
+  content.append(firstPlayerFieldset);
+
+  main.append(content);
+
+  const actions = document.createElement('div');
+  actions.className = 'standby__actions';
+
+  const homeButton = new UIButton({ label: 'HOMEに戻る', variant: 'ghost' });
+  if (options.onReturnHome) {
+    homeButton.onClick(() => {
+      options.onReturnHome?.();
+    });
+  }
+
+  const startButton = new UIButton({
+    label: 'はじめる',
+    variant: 'primary',
+    disabled: !currentFirstPlayer,
+  });
+
+  const updateStartButtonState = () => {
+    startButton.setDisabled(!currentFirstPlayer);
+  };
+
+  startButton.onClick(() => {
+    if (!currentFirstPlayer) {
+      startButton.setDisabled(true);
+      return;
+    }
+    options.onStart?.();
+  });
+
+  updateStatus();
+  updateRadioSelection();
+  updateStartButtonState();
+
+  actions.append(homeButton.el, startButton.el);
+  main.append(actions);
+
+  section.append(main);
+  return section;
+};

--- a/styles/base.css
+++ b/styles/base.css
@@ -59,7 +59,7 @@ p {
   padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
 }
 
-.home {
+.home { 
   width: min(520px, 100%);
   display: grid;
   gap: clamp(1.75rem, 2.5vw, 2.75rem);
@@ -75,6 +75,162 @@ p {
   font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
   letter-spacing: 0.12em;
   text-transform: uppercase;
+}
+
+.standby-view {
+  min-height: calc(100vh - 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
+}
+
+.standby {
+  width: min(720px, 100%);
+  display: grid;
+  gap: clamp(1.75rem, 2.5vw, 2.5rem);
+  padding: clamp(2rem, 2.5vw + 1rem, 3rem);
+  border-radius: 32px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.standby__title {
+  margin: 0;
+  font-size: clamp(1.85rem, 2.5vw + 1rem, 2.35rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.standby__subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.7;
+  font-size: 1rem;
+}
+
+.standby__content {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+}
+
+.standby__fieldset {
+  margin: 0;
+  padding: 1.5rem;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.standby__legend {
+  padding: 0 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.standby__players {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.standby-player {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.standby-player__label {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.standby-player__role {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.standby-player__input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--color-text);
+  font-size: 1rem;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    background 120ms ease;
+}
+
+.standby-player__input::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.standby-player__input:focus {
+  outline: none;
+  border-color: rgba(251, 191, 36, 0.85);
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.standby__first-player-status {
+  margin: 0 0 0.75rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.standby__first-player-options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.standby-radio {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.1rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+  cursor: pointer;
+}
+
+.standby-radio.is-selected {
+  border-color: rgba(251, 191, 36, 0.8);
+  background: rgba(251, 191, 36, 0.15);
+}
+
+.standby-radio__input {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--color-accent);
+}
+
+.standby-radio__caption {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.standby__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.standby__actions .button {
+  min-width: 140px;
+  justify-content: center;
 }
 
 .home__subtitle {


### PR DESCRIPTION
## 概要
- `/standby` ルート向けにスタンバイ設定ビューを実装し、プレイヤー名入力・先手選択・HOMEボタンを配置しました
- 先手が決まるまで「はじめる」ボタンを無効化する UI 制御と、ゲームストアへの同期処理を追加しました
- ゲーム状態の初期値を調整し、プレイヤー名のデフォルトを「プレイヤーA/B」に変更しつつスタイルを整備しました

## テスト
- npm run check


------
https://chatgpt.com/codex/tasks/task_e_68d3f8656724832aa66226e8c4c39671