### PR TITLE
タスク15〜19: スタンバイUIと初期化フローの整備

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -81,6 +81,28 @@ const swap = <T>(items: T[], a: number, b: number): void => {
 
 const defaultRandom = (): number => Math.random();
 
+const hashSeed = (seed: string): number => {
+  let h = 1779033703 ^ seed.length;
+  for (let i = 0; i < seed.length; i += 1) {
+    h = Math.imul(h ^ seed.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return (h ^ (h >>> 16)) >>> 0;
+};
+
+export const createSeededRandom = (seed: string): (() => number) => {
+  let state = hashSeed(seed);
+  if (state === 0) {
+    state = 0x1a2b3c4d;
+  }
+  return () => {
+    state += 0x6d2b79f5;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
 export interface ShuffleOptions {
   random?: () => number;
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -188,37 +188,49 @@ p {
 .standby__first-player-options {
   display: grid;
   gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
-.standby-radio {
+.standby__first-player-options .button {
+  width: 100%;
+  justify-content: center;
+}
+
+.standby__first-player-button.is-selected {
+  box-shadow: 0 8px 24px rgba(251, 191, 36, 0.25);
+}
+
+.standby__initial-status {
+  margin: 0 0 0.75rem;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.standby-seed-toggle {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 1.1rem;
-  border-radius: 9999px;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(15, 23, 42, 0.35);
-  transition:
-    border-color 120ms ease,
-    background 120ms ease,
-    color 120ms ease;
-  cursor: pointer;
 }
 
-.standby-radio.is-selected {
-  border-color: rgba(251, 191, 36, 0.8);
-  background: rgba(251, 191, 36, 0.15);
-}
-
-.standby-radio__input {
-  width: 1.05rem;
-  height: 1.05rem;
+.standby-seed-toggle__input {
+  width: 1.1rem;
+  height: 1.1rem;
   accent-color: var(--color-accent);
 }
 
-.standby-radio__caption {
+.standby-seed-toggle__label {
   font-weight: 600;
   color: var(--color-text);
+}
+
+.standby-seed-toggle__status {
+  margin-left: auto;
+  font-size: 0.9rem;
+  color: var(--color-muted);
 }
 
 .standby__actions {


### PR DESCRIPTION
## Summary
- スタンバイ画面でプレイヤー名入力と先手選択ボタン（ランダム含む）を実装し、進行状況オーバーレイと連携させました。
- 初期化セクションに「セットのシャッフル準備OK」表示とシード固定トグルを追加し、ゲーム状態・スタイルを更新しました。
- シード固定時に決定的なデッキ配布が行われるようシャッフル処理とゲート通過後の配布処理を拡張しました。
- スタンバイ完了後に冗長なゲート画面を挟まず直接フェーズ遷移するよう修正しました。

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d401257204832a944a4e3613b0a53d