### PR TITLE
feat: show recent taken cards in scout view

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,10 @@ import { createGateView } from './views/gate.js';
 import { createHomeView } from './views/home.js';
 import { createPlaceholderView } from './views/placeholder.js';
 import { createScoutView } from './views/scout.js';
-import type { ScoutOpponentHandCardViewModel } from './views/scout.js';
+import type {
+  ScoutOpponentHandCardViewModel,
+  ScoutRecentTakenCardViewModel,
+} from './views/scout.js';
 import { createStandbyView } from './views/standby.js';
 
 interface GateDescriptor {
@@ -468,6 +471,19 @@ const mapOpponentHandCards = (state: GameState): ScoutOpponentHandCardViewModel[
   return opponent.hand.cards.map((card) => ({ id: card.id }));
 };
 
+const mapRecentTakenCards = (state: GameState): ScoutRecentTakenCardViewModel[] => {
+  const player = state.players[state.activePlayer];
+  if (!player) {
+    return [];
+  }
+  return player.takenByOpponent.map((card) => ({
+    id: card.id,
+    rank: card.rank,
+    suit: card.suit,
+    annotation: card.annotation,
+  }));
+};
+
 let activeScoutCleanup: (() => void) | null = null;
 
 const cleanupActiveScoutView = (): void => {
@@ -796,6 +812,7 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
             title: route.heading,
             cards: mapOpponentHandCards(state),
             selectedIndex: state.scout.selectedOpponentCardIndex,
+            recentTakenCards: mapRecentTakenCards(state),
             onSelectCard: (index) => {
               gameStore.setState((current) => {
                 const opponentId = getOpponentId(current.activePlayer);
@@ -830,6 +847,7 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
               mapOpponentHandCards(nextState),
               nextState.scout.selectedOpponentCardIndex,
             );
+            view.updateRecentTaken(mapRecentTakenCards(nextState));
           });
 
           activeScoutCleanup = () => {

--- a/styles/base.css
+++ b/styles/base.css
@@ -424,6 +424,45 @@ p {
   font-size: 0.95rem;
 }
 
+.scout-recent {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.scout-recent__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scout-recent__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.scout-recent__item {
+  display: flex;
+}
+
+.scout-recent__card {
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+}
+
+.scout-recent__empty {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
 .home__subtitle {
   margin: 0;
   color: var(--color-muted);


### PR DESCRIPTION
## Summary
- add recent taken card view model handling to the scout view
- render a styled list of the player's recently taken cards with fallback messaging
- map store state to the new view data and keep it updated on state changes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4102bf120832a98a0154a2ccc1ac9