### PR TITLE
feat: スカウトのピック確認フローを実装

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -461,6 +461,27 @@ p {
 .scout-recent__empty {
   font-size: 0.95rem;
   color: var(--color-muted);
+  letter-spacing: 0.06em;
+}
+
+.scout-actions {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.scout-actions__button {
+  min-width: min(100%, 160px);
+}
+
+.scout-actions__button--secondary {
+  order: 0;
+}
+
+.scout-actions__button--primary {
+  order: 1;
 }
 
 .home__subtitle {


### PR DESCRIPTION
## Summary
- スカウト画面に選択クリア・ピック確定ボタンを追加し、状態に応じた活性制御を実装
- ピック確定時に確認モーダルを表示し、カード移動とトースト通知を行うロジックを追加
- アクションバー用のスタイルを整備し、操作ボタンの配置を調整

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d412f493b4832a87e48b850b223319