### PR TITLE
feat: add scout completion transition dialog

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -484,6 +484,41 @@ p {
   order: 1;
 }
 
+.scout-complete {
+  display: grid;
+  gap: 1.25rem;
+  padding: 0.5rem 0;
+  text-align: center;
+}
+
+.scout-complete__message {
+  margin: 0;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+.scout-complete__preview {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.scout-complete__caption {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.scout-complete__card {
+  width: 96px;
+  height: 138px;
+  font-size: 1.5rem;
+  border-color: rgba(251, 191, 36, 0.65);
+  box-shadow: 0 18px 36px rgba(251, 191, 36, 0.22);
+}
+
 .home__subtitle {
   margin: 0;
   color: var(--color-muted);


### PR DESCRIPTION
## Summary
- show a completion modal after a scout pick with the drawn card preview
- add navigation helper to move to the action phase from the completion dialog and toast feedback
- style the scout completion modal content for the drawn card emphasis

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d416f3f254832a963746237f68adef