### PR TITLE
feat: スカウトヘッダーに補助操作を追加

### DIFF
--- a/src/views/scout.ts
+++ b/src/views/scout.ts
@@ -26,6 +26,13 @@ export interface ScoutViewOptions {
   onClearSelection?: () => void;
   confirmLabel?: string;
   clearLabel?: string;
+  boardCheckLabel?: string;
+  myHandLabel?: string;
+  helpLabel?: string;
+  helpAriaLabel?: string;
+  onOpenBoardCheck?: () => void;
+  onOpenMyHand?: () => void;
+  onOpenHelp?: () => void;
 }
 
 export interface ScoutViewElement extends HTMLElement {
@@ -47,10 +54,64 @@ export const createScoutView = (options: ScoutViewOptions): ScoutViewElement => 
   main.className = 'scout';
   section.append(main);
 
+  const header = document.createElement('div');
+  header.className = 'scout__header';
+
   const heading = document.createElement('h1');
   heading.className = 'scout__title';
   heading.textContent = options.title;
-  main.append(heading);
+  header.append(heading);
+
+  const headerActions = document.createElement('div');
+  headerActions.className = 'scout__header-actions';
+
+  if (options.onOpenBoardCheck) {
+    const boardCheckButton = new UIButton({
+      label: options.boardCheckLabel ?? 'ボードチェック',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    boardCheckButton.el.classList.add('scout__header-button');
+    boardCheckButton.onClick(() => {
+      options.onOpenBoardCheck?.();
+    });
+    headerActions.append(boardCheckButton.el);
+  }
+
+  if (options.onOpenMyHand) {
+    const myHandButton = new UIButton({
+      label: options.myHandLabel ?? '自分の手札',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    myHandButton.el.classList.add('scout__header-button');
+    myHandButton.onClick(() => {
+      options.onOpenMyHand?.();
+    });
+    headerActions.append(myHandButton.el);
+  }
+
+  if (options.onOpenHelp) {
+    const helpButton = new UIButton({
+      label: options.helpLabel ?? '？',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    helpButton.el.classList.add('scout__header-button', 'scout__header-button--help');
+    const helpAriaLabel = options.helpAriaLabel ?? 'ヘルプ';
+    helpButton.el.setAttribute('aria-label', helpAriaLabel);
+    helpButton.el.title = helpAriaLabel;
+    helpButton.onClick(() => {
+      options.onOpenHelp?.();
+    });
+    headerActions.append(helpButton.el);
+  }
+
+  if (headerActions.childElementCount > 0) {
+    header.append(headerActions);
+  }
+
+  main.append(header);
 
   const opponentTitle = options.opponentLabel
     ? `${options.opponentLabel}の手札`

--- a/styles/base.css
+++ b/styles/base.css
@@ -322,6 +322,32 @@ p {
   box-shadow: var(--shadow-lg);
 }
 
+.scout__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.scout__header-actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.5rem, 1vw, 0.75rem);
+}
+
+.scout__header-button {
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.scout__header-button--help {
+  width: clamp(2.25rem, 4vw, 2.75rem);
+  aspect-ratio: 1;
+  padding: 0;
+  font-weight: 600;
+  border-radius: 999px;
+}
+
 .scout__title {
   margin: 0;
   font-size: clamp(1.85rem, 2.5vw + 1rem, 2.35rem);
@@ -462,6 +488,69 @@ p {
   font-size: 0.95rem;
   color: var(--color-muted);
   letter-spacing: 0.06em;
+}
+
+.scout-myhand {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.scout-myhand__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.scout-myhand__heading {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.scout-myhand__count {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.scout-myhand__empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.scout-myhand__hand-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: clamp(0.75rem, 1.5vw, 1.25rem);
+}
+
+.scout-myhand__hand-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.scout-myhand__card {
+  width: clamp(80px, 12vw, 112px);
+  font-size: clamp(1.1rem, 2vw, 1.35rem);
+}
+
+.scout-myhand__card-label {
+  font-size: 0.95rem;
+  color: var(--color-foreground);
+}
+
+.scout-myhand__recent-list {
+  margin: 0;
+  padding: 0;
 }
 
 .scout-actions {


### PR DESCRIPTION
## Summary
- スカウト画面のヘッダーにボードチェック・自分の手札・ヘルプの操作を追加
- 自分の手札モーダルを実装してヘッダーから起動
- 新しいヘッダーとモーダル向けのスタイルを整備

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d45ef028d4832a911a1d63413db3bf