### PR TITLE
Show scout result dialog before advancing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -88,9 +88,6 @@ const SCOUT_PICK_CONFIRM_MESSAGE = 'このカードを引いて手札に加え�
 const SCOUT_PICK_CONFIRM_OK_LABEL = 'OK';
 const SCOUT_PICK_CONFIRM_CANCEL_LABEL = 'キャンセル';
 
-const SCOUT_COMPLETE_TITLE = 'スカウト完了';
-const SCOUT_COMPLETE_ACTION_LABEL = 'アクションへ';
-const SCOUT_COMPLETE_CARD_CAPTION = '引いたカード';
 const SCOUT_TO_ACTION_PATH = '#/phase/action';
 const SCOUT_BOARD_CHECK_LABEL = 'ボードチェック';
 const SCOUT_MY_HAND_LABEL = '自分の手札';
@@ -111,10 +108,7 @@ const formatCardLabel = (card: CardSnapshot): string => {
 };
 
 const createScoutPickSuccessMessage = (card: CardSnapshot): string =>
-  `${formatCardLabel(card)}のカードを引きました！`;
-
-const createScoutCompletionDescription = (card: CardSnapshot): string =>
-  `「${formatCardLabel(card)}のカードを引きました！」`;
+  `${formatCardLabel(card)}のカードを引きました！アクションフェーズへ移行します`;
 
 const cloneCardSnapshot = (card: CardSnapshot): CardSnapshot => ({
   id: card.id,
@@ -629,48 +623,44 @@ const openHistoryDialog = (): void => {
 
 const getOpponentId = (player: PlayerId): PlayerId => (player === 'lumina' ? 'nox' : 'lumina');
 
-const showScoutPickToast = (card: CardSnapshot): void => {
+const SCOUT_PICK_RESULT_TITLE = 'カードを取得しました';
+const SCOUT_PICK_RESULT_OK_LABEL = 'OK';
+
+const showScoutPickResultDialog = (card: CardSnapshot): void => {
   const message = createScoutPickSuccessMessage(card);
+
   if (typeof window === 'undefined') {
     console.info(message);
+    navigateToActionPhase();
+    isScoutPickInProgress = false;
     return;
   }
-  const toast = window.curtainCall?.toast;
-  if (toast) {
-    toast.show({ message, variant: 'info' });
-  } else {
+
+  const modal = window.curtainCall?.modal;
+  if (!modal) {
     console.info(message);
+    navigateToActionPhase();
+    isScoutPickInProgress = false;
+    return;
   }
-};
 
-const createScoutCompletionBody = (card: CardSnapshot): HTMLElement => {
-  const container = document.createElement('div');
-  container.className = 'scout-complete';
-
-  const message = document.createElement('p');
-  message.className = 'scout-complete__message';
-  message.textContent = createScoutCompletionDescription(card);
-  container.append(message);
-
-  const preview = document.createElement('div');
-  preview.className = 'scout-complete__preview';
-  container.append(preview);
-
-  const caption = document.createElement('p');
-  caption.className = 'scout-complete__caption';
-  caption.textContent = SCOUT_COMPLETE_CARD_CAPTION;
-  preview.append(caption);
-
-  const cardComponent = new CardComponent({
-    rank: card.rank,
-    suit: card.suit,
-    faceDown: false,
-    annotation: card.annotation,
+  modal.open({
+    title: SCOUT_PICK_RESULT_TITLE,
+    body: message,
+    dismissible: false,
+    actions: [
+      {
+        label: SCOUT_PICK_RESULT_OK_LABEL,
+        variant: 'primary',
+        preventRapid: true,
+        onSelect: () => {
+          modal.close();
+          navigateToActionPhase();
+          isScoutPickInProgress = false;
+        },
+      },
+    ],
   });
-  cardComponent.el.classList.add('scout-complete__card');
-  preview.append(cardComponent.el);
-
-  return container;
 };
 
 const navigateToActionPhase = (): void => {
@@ -684,39 +674,6 @@ const navigateToActionPhase = (): void => {
     router.go(SCOUT_TO_ACTION_PATH);
   } else {
     window.location.hash = SCOUT_TO_ACTION_PATH;
-  }
-};
-
-const openScoutCompletionDialog = (card: CardSnapshot): void => {
-  if (typeof window === 'undefined') {
-    navigateToActionPhase();
-    return;
-  }
-
-  const modal = window.curtainCall?.modal;
-  if (!modal) {
-    console.warn('スカウト完了ダイアログを表示するモーダルが初期化されていません。');
-    navigateToActionPhase();
-    return;
-  }
-
-  try {
-    modal.open({
-      title: SCOUT_COMPLETE_TITLE,
-      body: createScoutCompletionBody(card),
-      dismissible: false,
-      actions: [
-        {
-          label: SCOUT_COMPLETE_ACTION_LABEL,
-          variant: 'primary',
-          preventRapid: true,
-          onSelect: () => navigateToActionPhase(),
-        },
-      ],
-    });
-  } catch (error) {
-    console.warn('スカウト完了ダイアログの表示に失敗しました。代わりに次フェーズへ遷移します。', error);
-    navigateToActionPhase();
   }
 };
 
@@ -812,8 +769,10 @@ const finalizeScoutPick = (): void => {
 
   const card = completeScoutPick();
   if (card) {
-    showScoutPickToast(card);
-    openScoutCompletionDialog(card);
+    if (typeof window !== 'undefined') {
+      window.curtainCall?.modal?.close();
+    }
+    showScoutPickResultDialog(card);
   } else {
     isScoutPickInProgress = false;
     console.warn('カードの取得に失敗しました。選択状態を再確認してください。');
@@ -870,6 +829,15 @@ const mapOpponentHandCards = (state: GameState): ScoutOpponentHandCardViewModel[
   }
   return opponent.hand.cards.map((card) => ({ id: card.id }));
 };
+
+const getOpponentHandCount = (state: GameState): number => {
+  const opponentId = getOpponentId(state.activePlayer);
+  const opponent = state.players[opponentId];
+  return opponent?.hand.cards.length ?? 0;
+};
+
+const shouldAutoAdvanceFromScout = (state: GameState): boolean =>
+  getOpponentHandCount(state) === 0;
 
 const mapRecentTakenCards = (state: GameState): ScoutRecentTakenCardViewModel[] => {
   const player = state.players[state.activePlayer];
@@ -1236,6 +1204,25 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
         title: route.title,
         render: () => {
           const state = gameStore.getState();
+          let hasTriggeredAutoAdvance = false;
+
+          const triggerAutoAdvance = (): void => {
+            if (hasTriggeredAutoAdvance || isScoutPickInProgress) {
+              return;
+            }
+            hasTriggeredAutoAdvance = true;
+            if (typeof window !== 'undefined') {
+              window.curtainCall?.modal?.close();
+            }
+            navigateToActionPhase();
+          };
+
+          if (shouldAutoAdvanceFromScout(state)) {
+            triggerAutoAdvance();
+            const placeholder = document.createElement('section');
+            placeholder.className = 'view scout-view';
+            return placeholder;
+          }
 
           const updateSelectedOpponentCard = (index: number | null): void => {
             gameStore.setState((current) => {
@@ -1283,6 +1270,10 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
           });
 
           const unsubscribe = gameStore.subscribe((nextState) => {
+            if (shouldAutoAdvanceFromScout(nextState)) {
+              triggerAutoAdvance();
+              return;
+            }
             view.updateOpponentHand(
               mapOpponentHandCards(nextState),
               nextState.scout.selectedOpponentCardIndex,


### PR DESCRIPTION
## Summary
- add a dedicated scout result dialog that reports the taken card and announces the move to the action phase
- block automatic scout-to-action transitions while the result dialog is displayed to prevent premature navigation

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4892b45ec832a83adf0e8c659a48d