### PR TITLE
Fix scout result dialog after card pick

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -646,17 +646,20 @@ const createScoutPickResultContent = (card: CardSnapshot): HTMLElement => {
   cardPreview.el.classList.add('scout-complete__card');
   preview.append(cardPreview.el);
 
-  const caption = document.createElement('p');
-  caption.className = 'scout-complete__caption';
-  caption.textContent = 'アクションフェーズへ移行します。';
-  preview.append(caption);
+  const previewCaption = document.createElement('p');
+  previewCaption.className = 'scout-complete__caption';
+  previewCaption.textContent = '引いたカードは以下の通りです。';
+  preview.append(previewCaption);
 
   container.append(preview);
 
-  const caption = document.createElement('p');
-  caption.className = 'scout-complete__caption';
-  caption.textContent = 'アクションフェーズへ移行します。';
-  preview.append(caption);
+  const actionNotice = document.createElement('p');
+  actionNotice.className = 'scout-complete__caption';
+  actionNotice.textContent = 'OKを押してアクションフェーズへ進みましょう。';
+  container.append(actionNotice);
+
+  return container;
+};
 
 
 let isScoutResultDialogOpen = false;


### PR DESCRIPTION
## Summary
- ensure the scout result dialog builds its body correctly and informs the player about the drawn card
- add guidance that pressing OK will advance to the action phase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b094d424832a95d7bff5a4b19040