### PR TITLE
Fix board check hidden panels display

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -1092,6 +1092,10 @@ p {
   display: block;
 }
 
+.board-check__panel[hidden] {
+  display: none;
+}
+
 .board-check__content {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- ensure board check tab panels respect the hidden attribute so only the active tab is shown

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b18355d8832a851b56bf8e78467c