### PR TITLE
fix: ensure joker stays in the set

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -131,6 +131,20 @@ export type DealOptions = ShuffleOptions;
 export const dealInitialSetup = (options: DealOptions = {}): InitialDealResult => {
   const deck = shuffleCards(createStandardDeck(), options);
 
+  const setSize = CARD_COMPOSITION.set;
+  if (setSize <= 0) {
+    throw new Error('セットの枚数が不正です。');
+  }
+
+  const jokerIndex = deck.findIndex((card) => card.rank === 'JOKER');
+  if (jokerIndex === -1) {
+    throw new Error('初期デッキにJOKERが含まれていません。');
+  }
+
+  if (jokerIndex >= setSize) {
+    swap(deck, jokerIndex, setSize - 1);
+  }
+
   const setCards = deck.slice(0, CARD_COMPOSITION.set).map<SetCardState>((card, index) => ({
     id: `set-${String(index + 1).padStart(2, '0')}`,
     card,


### PR DESCRIPTION
## Summary
- ensure the Joker card is always part of the initial set during standby dealing
- add validation around set size and Joker presence when preparing the deck

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4b3a63048832aba8c4b15c50c4b32