### PR TITLE
feat: support actor selection in action phase

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -170,6 +170,12 @@ export interface ScoutState {
   selectedOpponentCardIndex: number | null;
 }
 
+export interface ActionState {
+  selectedCardId: string | null;
+  actorCardId: string | null;
+  kurokoCardId: string | null;
+}
+
 export interface GameState extends Record<string, unknown> {
   matchId: string;
   phase: PhaseKey;
@@ -186,6 +192,7 @@ export interface GameState extends Record<string, unknown> {
   resume?: ResumeSnapshot;
   recentScoutedCard: CardSnapshot | null;
   scout: ScoutState;
+  action: ActionState;
 }
 
 export type StateListener<TState> = (state: TState) => void;
@@ -282,6 +289,12 @@ const createMatchId = (): string => {
   return `match-${Date.now()}-${random}`;
 };
 
+export const createInitialActionState = (): ActionState => ({
+  selectedCardId: null,
+  actorCardId: null,
+  kurokoCardId: null,
+});
+
 export const createInitialState = (): GameState => {
   const timestamp = Date.now();
   return {
@@ -314,6 +327,7 @@ export const createInitialState = (): GameState => {
     scout: {
       selectedOpponentCardIndex: null,
     },
+    action: createInitialActionState(),
   };
 };
 


### PR DESCRIPTION
## Summary
- add action phase selection state to the game store for actor/kuroko placeholders
- wire the action hand view to toggle the actor card and reflect the current selection

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4c17fda40832a9132da811391780b