### PR TITLE
feat: allow selecting kuroko card

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -976,6 +976,48 @@ const toggleActionActorCard = (cardId: string): void => {
   });
 };
 
+const toggleActionKurokoCard = (cardId: string): void => {
+  gameStore.setState((current) => {
+    const player = current.players[current.activePlayer];
+    if (!player) {
+      return current;
+    }
+
+    const hasCard = player.hand.cards.some((card) => card.id === cardId);
+    if (!hasCard) {
+      return current;
+    }
+
+    const nextKurokoCardId = current.action.kurokoCardId === cardId ? null : cardId;
+    const nextActorCardId =
+      nextKurokoCardId !== null && current.action.actorCardId === nextKurokoCardId
+        ? null
+        : current.action.actorCardId;
+
+    if (
+      nextActorCardId === current.action.actorCardId &&
+      nextKurokoCardId === current.action.kurokoCardId &&
+      current.action.selectedCardId === null
+    ) {
+      return current;
+    }
+
+    const timestamp = Date.now();
+
+    return {
+      ...current,
+      action: {
+        ...current.action,
+        selectedCardId: null,
+        actorCardId: nextActorCardId,
+        kurokoCardId: nextKurokoCardId,
+      },
+      updatedAt: timestamp,
+      revision: current.revision + 1,
+    };
+  });
+};
+
 let isScoutPickInProgress = false;
 
 const clearScoutSecretState = (): void => {
@@ -1441,7 +1483,20 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
             actorCardId: state.action.actorCardId,
             kurokoCardId: state.action.kurokoCardId,
             onSelectHandCard: (cardId) => {
-              toggleActionActorCard(cardId);
+              const current = gameStore.getState();
+              if (current.action.actorCardId === cardId) {
+                toggleActionActorCard(cardId);
+                return;
+              }
+              if (current.action.kurokoCardId === cardId) {
+                toggleActionKurokoCard(cardId);
+                return;
+              }
+              if (current.action.actorCardId === null) {
+                toggleActionActorCard(cardId);
+                return;
+              }
+              toggleActionKurokoCard(cardId);
             },
           });
 


### PR DESCRIPTION
## Summary
- add state update helper to toggle the currently selected kuroko card while keeping actor and kuroko distinct
- extend action hand click handling to toggle actor and kuroko slots appropriately based on current selection

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4c337dcc4832a978cf90c268d3622