### PR TITLE
feat: add action to watch transition with confirmation

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -608,6 +608,34 @@ p {
   box-shadow: 0 18px 36px rgba(251, 191, 36, 0.22);
 }
 
+.action-complete {
+  display: grid;
+  gap: 1.25rem;
+  padding: 0.5rem 0;
+  text-align: center;
+}
+
+.action-complete__message {
+  margin: 0;
+  font-weight: 600;
+  line-height: 1.6;
+}
+
+.action-complete__summary {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 500;
+  line-height: 1.6;
+}
+
+.action-complete__caption {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .action-view {
   --action-padding-x: clamp(1.5rem, 3vw, 2.5rem);
   --action-hand-height: clamp(9rem, 18vh, 11rem);


### PR DESCRIPTION
## Summary
- アクション確定処理で配置カード情報を保持し、完了後に結果ポップアップを表示
- ポップアップからウォッチゲートへの遷移とセーブ処理を追加
- アクション完了ポップアップ用のスタイルを追加

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4ca20dd18832abdae4d82292f1c31