### PR TITLE
Add board check button to action phase

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -113,6 +113,7 @@ const SCOUT_HELP_BUTTON_LABEL = '？';
 const SCOUT_HELP_ARIA_LABEL = 'ヘルプ';
 
 const ACTION_CONFIRM_BUTTON_LABEL = '配置を確定';
+const ACTION_BOARD_CHECK_LABEL = 'ボードチェック';
 const ACTION_CONFIRM_MODAL_TITLE = '配置を確定';
 const ACTION_CONFIRM_MODAL_MESSAGE =
   '以下のカードをステージに配置します。確定すると元に戻せません。';
@@ -1911,6 +1912,7 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
             selectedCardId: state.action.selectedCardId,
             actorCardId: state.action.actorCardId,
             kurokoCardId: state.action.kurokoCardId,
+            boardCheckLabel: ACTION_BOARD_CHECK_LABEL,
             confirmLabel: ACTION_CONFIRM_BUTTON_LABEL,
             confirmDisabled: !canConfirmActionPlacement(state),
             onSelectHandCard: (cardId) => {
@@ -1929,6 +1931,7 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
               }
               toggleActionKurokoCard(cardId);
             },
+            onOpenBoardCheck: () => showBoardCheck(),
             onConfirm: () => openActionConfirmDialog(),
           });
 

--- a/src/views/action.ts
+++ b/src/views/action.ts
@@ -23,9 +23,11 @@ export interface ActionViewOptions {
   selectedCardId?: string | null;
   actorCardId?: string | null;
   kurokoCardId?: string | null;
+  boardCheckLabel?: string;
   confirmLabel?: string;
   confirmDisabled?: boolean;
   onSelectHandCard?: (cardId: string) => void;
+  onOpenBoardCheck?: () => void;
   onConfirm?: () => void;
 }
 
@@ -64,6 +66,18 @@ export const createActionView = (options: ActionViewOptions): ActionViewElement 
 
   const actions = document.createElement('div');
   actions.className = 'action__actions';
+
+  if (options.onOpenBoardCheck) {
+    const boardCheckButton = new UIButton({
+      label: options.boardCheckLabel ?? 'ボードチェック',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    boardCheckButton.onClick(() => {
+      options.onOpenBoardCheck?.();
+    });
+    actions.append(boardCheckButton.el);
+  }
 
   const confirmButton = new UIButton({
     label: options.confirmLabel ?? '配置を確定',


### PR DESCRIPTION
## Summary
- アクションフェーズのヘッダーにボードチェックボタンを追加し、ステート更新に合わせて利用できるようにしました

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4ceb98310832a9abe09687b858d90