### PR TITLE
feat: implement watch presentation view

### DIFF
--- a/src/views/watch.ts
+++ b/src/views/watch.ts
@@ -1,0 +1,294 @@
+import { UIButton } from '../ui/button.js';
+import { CardComponent } from '../ui/card.js';
+import type { CardSuit } from '../ui/card.js';
+
+export interface WatchStageCardViewModel {
+  rank: string;
+  suit: CardSuit;
+  faceDown?: boolean;
+  annotation?: string;
+  description?: string;
+}
+
+export interface WatchStageViewModel {
+  actorLabel: string;
+  actorCard?: WatchStageCardViewModel | null;
+  actorEmptyMessage?: string;
+  kurokoLabel: string;
+  kurokoCard?: WatchStageCardViewModel | null;
+  kurokoEmptyMessage?: string;
+}
+
+export interface WatchStatusViewModel {
+  turnLabel: string;
+  booLabel: string;
+  remainingLabel: string;
+  forced: boolean;
+  forcedLabel?: string;
+  clapDisabled: boolean;
+  clapDisabledReason?: string;
+}
+
+export interface WatchViewOptions {
+  title: string;
+  status: WatchStatusViewModel;
+  stage: WatchStageViewModel;
+  boardCheckLabel?: string;
+  myHandLabel?: string;
+  helpLabel?: string;
+  helpAriaLabel?: string;
+  clapLabel?: string;
+  booLabel?: string;
+  onClap?: () => void;
+  onBoo?: () => void;
+  onOpenBoardCheck?: () => void;
+  onOpenMyHand?: () => void;
+  onOpenHelp?: () => void;
+}
+
+export interface WatchViewElement extends HTMLElement {
+  updateStatus: (status: WatchStatusViewModel) => void;
+  updateStage: (stage: WatchStageViewModel) => void;
+}
+
+const DEFAULT_EMPTY_MESSAGE = 'カードが配置されていません。';
+const DEFAULT_FORCED_LABEL = 'ブーイング必須';
+const DEFAULT_CLAP_LABEL = 'クラップ（同数）';
+const DEFAULT_BOO_LABEL = 'ブーイング（異なる）';
+
+interface WatchCardSlotElements {
+  slot: HTMLDivElement;
+  card: CardComponent;
+  placeholder: HTMLDivElement;
+  description: HTMLParagraphElement;
+}
+
+const createCardSlot = (
+  label: string,
+  options: { emptyMessage?: string },
+): WatchCardSlotElements => {
+  const slot = document.createElement('div');
+  slot.className = 'watch-stage__slot';
+
+  const heading = document.createElement('h2');
+  heading.className = 'watch-stage__heading';
+  heading.textContent = label;
+  slot.append(heading);
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'watch-stage__card-wrapper';
+  slot.append(wrapper);
+
+  const card = new CardComponent({ rank: '?', suit: 'spades', faceDown: true });
+  card.el.classList.add('watch-stage__card');
+  wrapper.append(card.el);
+
+  const placeholder = document.createElement('div');
+  placeholder.className = 'watch-stage__placeholder';
+  placeholder.textContent = options.emptyMessage ?? DEFAULT_EMPTY_MESSAGE;
+  placeholder.hidden = true;
+  wrapper.append(placeholder);
+
+  const description = document.createElement('p');
+  description.className = 'watch-stage__description';
+  description.hidden = true;
+  slot.append(description);
+
+  return { slot, card, placeholder, description };
+};
+
+const updateCardSlot = (
+  elements: WatchCardSlotElements,
+  viewModel: WatchStageCardViewModel | null | undefined,
+  emptyMessage?: string,
+): void => {
+  if (!viewModel) {
+    elements.slot.classList.add('is-empty');
+    elements.card.el.hidden = true;
+    elements.card.el.setAttribute('aria-hidden', 'true');
+    elements.placeholder.textContent = emptyMessage ?? DEFAULT_EMPTY_MESSAGE;
+    elements.placeholder.hidden = false;
+    elements.description.hidden = true;
+    elements.description.textContent = '';
+    return;
+  }
+
+  elements.slot.classList.remove('is-empty');
+  elements.card.el.hidden = false;
+  elements.card.el.removeAttribute('aria-hidden');
+  elements.placeholder.hidden = true;
+
+  elements.card.setCard(viewModel.rank, viewModel.suit);
+  elements.card.setFaceDown(Boolean(viewModel.faceDown));
+
+  if (viewModel.annotation) {
+    elements.card.el.title = viewModel.annotation;
+  } else {
+    elements.card.el.removeAttribute('title');
+  }
+
+  if (viewModel.description) {
+    elements.description.hidden = false;
+    elements.description.textContent = viewModel.description;
+  } else {
+    elements.description.hidden = true;
+    elements.description.textContent = '';
+  }
+};
+
+export const createWatchView = (options: WatchViewOptions): WatchViewElement => {
+  const section = document.createElement('section');
+  section.className = 'view watch-view';
+
+  const main = document.createElement('main');
+  main.className = 'watch';
+  section.append(main);
+
+  const header = document.createElement('div');
+  header.className = 'watch__header';
+  main.append(header);
+
+  const heading = document.createElement('h1');
+  heading.className = 'watch__title';
+  heading.textContent = options.title;
+  header.append(heading);
+
+  const headerActions = document.createElement('div');
+  headerActions.className = 'watch__header-actions';
+
+  if (options.onOpenBoardCheck) {
+    const boardCheckButton = new UIButton({
+      label: options.boardCheckLabel ?? 'ボードチェック',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    boardCheckButton.el.classList.add('watch__header-button');
+    boardCheckButton.onClick(() => options.onOpenBoardCheck?.());
+    headerActions.append(boardCheckButton.el);
+  }
+
+  if (options.onOpenMyHand) {
+    const myHandButton = new UIButton({
+      label: options.myHandLabel ?? '自分の手札',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    myHandButton.el.classList.add('watch__header-button');
+    myHandButton.onClick(() => options.onOpenMyHand?.());
+    headerActions.append(myHandButton.el);
+  }
+
+  if (options.onOpenHelp) {
+    const helpButton = new UIButton({
+      label: options.helpLabel ?? '？',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    helpButton.el.classList.add('watch__header-button', 'watch__header-button--help');
+    const helpAriaLabel = options.helpAriaLabel ?? 'ヘルプ';
+    helpButton.el.setAttribute('aria-label', helpAriaLabel);
+    helpButton.el.title = helpAriaLabel;
+    helpButton.onClick(() => options.onOpenHelp?.());
+    headerActions.append(helpButton.el);
+  }
+
+  if (headerActions.childElementCount > 0) {
+    header.append(headerActions);
+  }
+
+  const statusBar = document.createElement('div');
+  statusBar.className = 'watch-status';
+  main.append(statusBar);
+
+  const turnItem = document.createElement('p');
+  turnItem.className = 'watch-status__item';
+  statusBar.append(turnItem);
+
+  const booItem = document.createElement('p');
+  booItem.className = 'watch-status__item';
+  statusBar.append(booItem);
+
+  const remainingItem = document.createElement('p');
+  remainingItem.className = 'watch-status__item';
+  statusBar.append(remainingItem);
+
+  const forcedBadge = document.createElement('span');
+  forcedBadge.className = 'watch-status__badge';
+  forcedBadge.hidden = true;
+  statusBar.append(forcedBadge);
+
+  const stageSection = document.createElement('section');
+  stageSection.className = 'watch-stage';
+  main.append(stageSection);
+
+  const stageGrid = document.createElement('div');
+  stageGrid.className = 'watch-stage__slots';
+  stageSection.append(stageGrid);
+
+  const actorSlot = createCardSlot(options.stage.actorLabel, {
+    emptyMessage: options.stage.actorEmptyMessage,
+  });
+  stageGrid.append(actorSlot.slot);
+
+  const kurokoSlot = createCardSlot(options.stage.kurokoLabel, {
+    emptyMessage: options.stage.kurokoEmptyMessage,
+  });
+  stageGrid.append(kurokoSlot.slot);
+
+  const actions = document.createElement('div');
+  actions.className = 'watch-actions';
+  main.append(actions);
+
+  const clapButton = new UIButton({
+    label: options.clapLabel ?? DEFAULT_CLAP_LABEL,
+    variant: 'ghost',
+  });
+  clapButton.el.classList.add('watch-actions__button', 'watch-actions__button--clap');
+  clapButton.onClick(() => options.onClap?.());
+  actions.append(clapButton.el);
+
+  const booButton = new UIButton({
+    label: options.booLabel ?? DEFAULT_BOO_LABEL,
+    variant: 'primary',
+  });
+  booButton.el.classList.add('watch-actions__button', 'watch-actions__button--boo');
+  booButton.onClick(() => options.onBoo?.());
+  actions.append(booButton.el);
+
+  const applyStatus = (status: WatchStatusViewModel) => {
+    turnItem.textContent = status.turnLabel;
+    booItem.textContent = status.booLabel;
+    remainingItem.textContent = status.remainingLabel;
+
+    const forcedLabel = status.forcedLabel ?? DEFAULT_FORCED_LABEL;
+    forcedBadge.textContent = forcedLabel;
+    forcedBadge.hidden = !status.forced;
+
+    clapButton.setDisabled(Boolean(status.clapDisabled));
+    if (status.clapDisabled && status.clapDisabledReason) {
+      clapButton.el.title = status.clapDisabledReason;
+    } else {
+      clapButton.el.removeAttribute('title');
+    }
+  };
+
+  const applyStage = (stage: WatchStageViewModel) => {
+    updateCardSlot(actorSlot, stage.actorCard ?? null, stage.actorEmptyMessage);
+
+    if (stage.kurokoCard) {
+      updateCardSlot(kurokoSlot, stage.kurokoCard, stage.kurokoEmptyMessage);
+      return;
+    }
+
+    updateCardSlot(kurokoSlot, null, stage.kurokoEmptyMessage);
+  };
+
+  applyStatus(options.status);
+  applyStage(options.stage);
+
+  const view = section as WatchViewElement;
+  view.updateStatus = (status) => applyStatus(status);
+  view.updateStage = (stage) => applyStage(stage);
+
+  return view;
+};

--- a/styles/base.css
+++ b/styles/base.css
@@ -889,6 +889,184 @@ p {
   font-size: 0.95rem;
 }
 
+.watch-view {
+  min-height: calc(100vh - 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
+}
+
+.watch {
+  width: min(840px, 100%);
+  display: grid;
+  gap: clamp(1.75rem, 2.5vw, 2.5rem);
+  padding: clamp(2rem, 2.5vw + 1rem, 3rem);
+  border-radius: 32px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.watch__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.watch__title {
+  margin: 0;
+  font-size: clamp(1.85rem, 2.5vw + 1rem, 2.4rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.watch__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.watch__header-button {
+  min-width: 0;
+}
+
+.watch__header-button--help {
+  width: 3rem;
+  aspect-ratio: 1;
+  padding: 0;
+  justify-content: center;
+}
+
+.watch-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  align-items: center;
+  padding: 1rem 1.25rem;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.watch-status__item {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  font-weight: 600;
+}
+
+.watch-status__badge {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--color-danger);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.watch-status__badge[hidden] {
+  display: none;
+}
+
+.watch-stage {
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.35);
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+}
+
+.watch-stage__slots {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.watch-stage__slot {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.watch-stage__heading {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.watch-stage__card-wrapper {
+  min-height: clamp(180px, 30vh, 220px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.watch-stage__card {
+  width: clamp(120px, 18vw, 160px);
+  height: clamp(168px, 26vw, 220px);
+  font-size: clamp(1.6rem, 2.5vw, 2.25rem);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+}
+
+.watch-stage__placeholder {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.watch-stage__slot.is-empty .watch-stage__card {
+  display: none;
+}
+
+.watch-stage__slot.is-empty .watch-stage__placeholder {
+  display: block;
+}
+
+.watch-stage__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.watch-actions {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.watch-actions__button {
+  width: 100%;
+  justify-content: center;
+  font-size: 1.05rem;
+  padding: 0.9rem 1.5rem;
+}
+
+.watch-actions__button--clap {
+  box-shadow: 0 12px 28px rgba(148, 163, 184, 0.2);
+}
+
+.watch-actions__button--clap:disabled {
+  box-shadow: none;
+  opacity: 0.65;
+}
+
+.watch-actions__button--boo {
+  box-shadow: 0 14px 32px rgba(248, 113, 113, 0.25);
+}
+
 .home__subtitle {
   margin: 0;
   color: var(--color-muted);


### PR DESCRIPTION
## Summary
- add watch-phase constants, status mapping, and route wiring in the app shell
- introduce a dedicated watch view with stage presentation and status controls
- style the watch phase layout, status bar, and action buttons for the new UI

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4d9518854832a8ea99651e5e610cc