### PR TITLE
feat: enforce watch boo requirement

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1173,7 +1173,7 @@ const mapWatchStatus = (state: GameState): WatchStatusViewModel => {
   const booCount = player?.booCount ?? 0;
   const remaining = getRemainingWatchCount(state);
   const needed = Math.max(0, WATCH_REQUIRED_BOO_COUNT - booCount);
-  const forced = remaining !== null && remaining > 0 && needed >= remaining;
+  const forced = remaining !== null && needed >= remaining;
 
   const turnLabel = `ターン：#${state.turn.count}`;
   const booLabel = `あなたのブーイング：${booCount} / ${WATCH_REQUIRED_BOO_COUNT}`;


### PR DESCRIPTION
## Summary
- ウォッチフェーズの強制ブーイング判定から不要な残回数チェックを削除し、仕様通り needed >= remaining で強制状態になるように調整

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4dc0d7ccc832ab1fab97892d5e3d5