### PR TITLE
feat: display boo warning in watch view

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -150,8 +150,8 @@ const WATCH_ACTOR_LABEL = '役者（表）';
 const WATCH_KUROKO_LABEL = '黒子（裏）';
 const WATCH_REQUIRED_BOO_COUNT = 3;
 const WATCH_REMAINING_PLACEHOLDER = '—';
-const WATCH_FORCED_BADGE_LABEL = 'ブーイング必須';
-const WATCH_CLAP_DISABLED_MESSAGE = '残り機会的にブーイングが必要です';
+const WATCH_WARNING_BADGE_LABEL = 'ブーイング不足注意';
+const WATCH_CLAP_WARNING_MESSAGE = '残り機会的にブーイングが必要です';
 const WATCH_STAGE_EMPTY_MESSAGE = 'ステージにカードが配置されていません。';
 const WATCH_KUROKO_DEFAULT_DESCRIPTION = '黒子のカードはまだ公開されていません。';
 const WATCH_TO_INTERMISSION_PATH = '#/phase/intermission/gate';
@@ -1235,7 +1235,7 @@ const mapWatchStatus = (state: GameState): WatchStatusViewModel => {
   const booCount = player?.booCount ?? 0;
   const remaining = getRemainingWatchCount(state);
   const needed = Math.max(0, WATCH_REQUIRED_BOO_COUNT - booCount);
-  const forced = remaining !== null && needed >= remaining;
+  const warning = remaining !== null && needed >= remaining;
 
   const turnLabel = `ターン：#${state.turn.count}`;
   const booLabel = `あなたのブーイング：${booCount} / ${WATCH_REQUIRED_BOO_COUNT}`;
@@ -1247,24 +1247,24 @@ const mapWatchStatus = (state: GameState): WatchStatusViewModel => {
     turnLabel,
     booLabel,
     remainingLabel,
-    forced,
-    forcedLabel: WATCH_FORCED_BADGE_LABEL,
-    clapDisabled: forced,
-    clapDisabledReason: forced ? WATCH_CLAP_DISABLED_MESSAGE : undefined,
+    warning,
+    warningLabel: WATCH_WARNING_BADGE_LABEL,
+    warningMessage: warning ? WATCH_CLAP_WARNING_MESSAGE : undefined,
+    clapDisabled: false,
   };
 };
 
-const notifyWatchClapForced = (): void => {
+const notifyWatchClapWarning = (): void => {
   if (typeof window === 'undefined') {
-    console.warn(WATCH_CLAP_DISABLED_MESSAGE);
+    console.warn(WATCH_CLAP_WARNING_MESSAGE);
     return;
   }
 
   const toast = window.curtainCall?.toast;
   if (toast) {
-    toast.show({ message: WATCH_CLAP_DISABLED_MESSAGE, variant: 'warning' });
+    toast.show({ message: WATCH_CLAP_WARNING_MESSAGE, variant: 'warning' });
   } else {
-    console.warn(WATCH_CLAP_DISABLED_MESSAGE);
+    console.warn(WATCH_CLAP_WARNING_MESSAGE);
   }
 };
 
@@ -1478,9 +1478,8 @@ const openWatchConfirmDialog = (decision: WatchDecision): void => {
 
 const requestWatchDeclaration = (decision: WatchDecision): void => {
   const status = mapWatchStatus(gameStore.getState());
-  if (decision === 'clap' && status.forced) {
-    notifyWatchClapForced();
-    return;
+  if (decision === 'clap' && status.warning && status.warningMessage) {
+    notifyWatchClapWarning();
   }
 
   openWatchConfirmDialog(decision);

--- a/src/views/watch.ts
+++ b/src/views/watch.ts
@@ -23,8 +23,9 @@ export interface WatchStatusViewModel {
   turnLabel: string;
   booLabel: string;
   remainingLabel: string;
-  forced: boolean;
-  forcedLabel?: string;
+  warning: boolean;
+  warningLabel?: string;
+  warningMessage?: string;
   clapDisabled: boolean;
   clapDisabledReason?: string;
 }
@@ -52,7 +53,7 @@ export interface WatchViewElement extends HTMLElement {
 }
 
 const DEFAULT_EMPTY_MESSAGE = 'カードが配置されていません。';
-const DEFAULT_FORCED_LABEL = 'ブーイング必須';
+const DEFAULT_WARNING_LABEL = 'ブーイング不足注意';
 const DEFAULT_CLAP_LABEL = 'クラップ（同数）';
 const DEFAULT_BOO_LABEL = 'ブーイング（異なる）';
 
@@ -212,10 +213,15 @@ export const createWatchView = (options: WatchViewOptions): WatchViewElement => 
   remainingItem.className = 'watch-status__item';
   statusBar.append(remainingItem);
 
-  const forcedBadge = document.createElement('span');
-  forcedBadge.className = 'watch-status__badge';
-  forcedBadge.hidden = true;
-  statusBar.append(forcedBadge);
+  const warningBadge = document.createElement('span');
+  warningBadge.className = 'watch-status__badge';
+  warningBadge.hidden = true;
+  statusBar.append(warningBadge);
+
+  const warningMessage = document.createElement('p');
+  warningMessage.className = 'watch-status__warning';
+  warningMessage.hidden = true;
+  statusBar.append(warningMessage);
 
   const stageSection = document.createElement('section');
   stageSection.className = 'watch-stage';
@@ -260,13 +266,23 @@ export const createWatchView = (options: WatchViewOptions): WatchViewElement => 
     booItem.textContent = status.booLabel;
     remainingItem.textContent = status.remainingLabel;
 
-    const forcedLabel = status.forcedLabel ?? DEFAULT_FORCED_LABEL;
-    forcedBadge.textContent = forcedLabel;
-    forcedBadge.hidden = !status.forced;
+    const warningLabel = status.warningLabel ?? DEFAULT_WARNING_LABEL;
+    warningBadge.textContent = warningLabel;
+    warningBadge.hidden = !status.warning;
+
+    if (status.warning && status.warningMessage) {
+      warningMessage.textContent = status.warningMessage;
+      warningMessage.hidden = false;
+    } else {
+      warningMessage.textContent = '';
+      warningMessage.hidden = true;
+    }
 
     clapButton.setDisabled(Boolean(status.clapDisabled));
     if (status.clapDisabled && status.clapDisabledReason) {
       clapButton.el.title = status.clapDisabledReason;
+    } else if (status.warning && status.warningMessage) {
+      clapButton.el.title = status.warningMessage;
     } else {
       clapButton.el.removeAttribute('title');
     }

--- a/styles/base.css
+++ b/styles/base.css
@@ -975,6 +975,14 @@ p {
   display: none;
 }
 
+.watch-status__warning {
+  margin: 0;
+  flex-basis: 100%;
+  font-size: 0.9rem;
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
 .watch-stage {
   padding: clamp(1.75rem, 2.5vw, 2.5rem);
   border-radius: 28px;


### PR DESCRIPTION
## Summary
- add watch status warning badge and message to show boo shortage alerts
- warn players when selecting clap while the boo shortage condition is met

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5082316f0832aa778aed7885ca453