### PR TITLE
Adjust layout spacing to fit within viewport

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -8,6 +8,62 @@
   --color-danger: #f87171;
   --shadow-lg: 0 16px 48px rgba(15, 23, 42, 0.35);
   --font-sans: 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  --viewport-height: 100vh;
+  --view-padding-block: clamp(2rem, 8vh, 3rem);
+  --view-padding-inline: clamp(1.25rem, 4vw, 2.5rem);
+  --panel-gap: clamp(1.75rem, 6vh, 2.75rem);
+  --panel-padding: clamp(2rem, 7vh, 3rem);
+  --button-padding-y: 0.75rem;
+  --button-padding-x: 1.25rem;
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --viewport-height: 100dvh;
+  }
+}
+
+@media (max-height: 760px) {
+  :root {
+    --view-padding-block: clamp(1.5rem, 6vh, 2.5rem);
+    --view-padding-inline: clamp(1.1rem, 4vw, 2rem);
+    --panel-gap: clamp(1.25rem, 4.5vh, 2.15rem);
+    --panel-padding: clamp(1.5rem, 5.5vh, 2.4rem);
+    --button-padding-y: 0.65rem;
+    --button-padding-x: 1.1rem;
+  }
+}
+
+@media (max-height: 640px) {
+  :root {
+    --view-padding-block: clamp(1.25rem, 5.5vh, 2.15rem);
+    --view-padding-inline: clamp(1rem, 4.5vw, 1.75rem);
+    --panel-gap: clamp(1rem, 3.75vh, 1.75rem);
+    --panel-padding: clamp(1.25rem, 4.5vh, 2.1rem);
+    --button-padding-y: 0.6rem;
+    --button-padding-x: 1rem;
+  }
+
+  .home__subtitle,
+  .standby__subtitle,
+  .watch-stage__description {
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+
+  .home,
+  .standby,
+  .scout,
+  .watch,
+  .gate-view__panel {
+    border-radius: 28px;
+  }
+
+  .action-hand__card {
+    min-width: clamp(72px, 15vw, 100px);
+    padding: 0.65rem;
+  }
 }
 
 *,
@@ -18,7 +74,7 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
+  min-height: var(--viewport-height);
   font-family: var(--font-sans);
   color: var(--color-text);
   background:
@@ -40,7 +96,7 @@ p {
 }
 
 .app-shell {
-  min-height: 100vh;
+  min-height: var(--viewport-height);
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -48,22 +104,23 @@ p {
 }
 
 .view {
-  padding: 1.5rem;
+  min-height: var(--viewport-height);
+  padding: var(--view-padding-block) var(--view-padding-inline);
 }
 
 .home-view {
-  min-height: calc(100vh - 3rem);
+  min-height: var(--viewport-height);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
+  padding: var(--view-padding-block) var(--view-padding-inline);
 }
 
-.home { 
+.home {
   width: min(520px, 100%);
   display: grid;
-  gap: clamp(1.75rem, 2.5vw, 2.75rem);
-  padding: clamp(2rem, 2.5vw + 1rem, 3rem);
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
   border-radius: 32px;
   background: var(--color-surface);
   box-shadow: var(--shadow-lg);
@@ -72,24 +129,24 @@ p {
 
 .home__title {
   margin: 0;
-  font-size: clamp(2rem, 3vw + 1rem, 2.75rem);
+  font-size: clamp(1.85rem, 3vw + 0.9rem, 2.5rem);
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .standby-view {
-  min-height: calc(100vh - 3rem);
+  min-height: var(--viewport-height);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
+  padding: var(--view-padding-block) var(--view-padding-inline);
 }
 
 .standby {
   width: min(720px, 100%);
   display: grid;
-  gap: clamp(1.75rem, 2.5vw, 2.5rem);
-  padding: clamp(2rem, 2.5vw + 1rem, 3rem);
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
   border-radius: 32px;
   background: var(--color-surface);
   box-shadow: var(--shadow-lg);
@@ -97,7 +154,7 @@ p {
 
 .standby__title {
   margin: 0;
-  font-size: clamp(1.85rem, 2.5vw + 1rem, 2.35rem);
+  font-size: clamp(1.7rem, 2.2vw + 0.9rem, 2.2rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -111,12 +168,12 @@ p {
 
 .standby__content {
   display: grid;
-  gap: clamp(1.5rem, 2vw, 2rem);
+  gap: clamp(1.25rem, min(2.5vw, 4vh), 2rem);
 }
 
 .standby__fieldset {
   margin: 0;
-  padding: 1.5rem;
+  padding: clamp(1.1rem, 3.5vh, 1.5rem);
   border-radius: 24px;
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: rgba(15, 23, 42, 0.4);
@@ -133,7 +190,7 @@ p {
 
 .standby__players {
   display: grid;
-  gap: 1.25rem;
+  gap: clamp(1rem, 3.5vh, 1.25rem);
 }
 
 .standby-player {
@@ -187,7 +244,7 @@ p {
 
 .standby__first-player-options {
   display: grid;
-  gap: 0.75rem;
+  gap: clamp(0.6rem, 2.5vh, 0.75rem);
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
@@ -251,7 +308,7 @@ p {
   display: none;
   align-items: center;
   justify-content: center;
-  padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
+  padding: var(--view-padding-block) var(--view-padding-inline);
   background: rgba(15, 23, 42, 0.92);
   z-index: 40;
 }
@@ -263,8 +320,8 @@ p {
 .standby-overlay__panel {
   width: min(520px, 100%);
   display: grid;
-  gap: clamp(1.25rem, 2vw, 1.75rem);
-  padding: clamp(2rem, 2.5vw + 1.25rem, 2.75rem);
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
   border-radius: 32px;
   background: rgba(15, 23, 42, 0.95);
   box-shadow: var(--shadow-lg);
@@ -305,18 +362,18 @@ p {
 }
 
 .scout-view {
-  min-height: calc(100vh - 3rem);
+  min-height: var(--viewport-height);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
+  padding: var(--view-padding-block) var(--view-padding-inline);
 }
 
 .scout {
   width: min(960px, 100%);
   display: grid;
-  gap: clamp(1.75rem, 2.5vw, 2.5rem);
-  padding: clamp(2rem, 2.5vw + 1rem, 3rem);
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
   border-radius: 32px;
   background: var(--color-surface);
   box-shadow: var(--shadow-lg);
@@ -350,7 +407,7 @@ p {
 
 .scout__title {
   margin: 0;
-  font-size: clamp(1.85rem, 2.5vw + 1rem, 2.35rem);
+  font-size: clamp(1.7rem, 2.25vw + 0.95rem, 2.25rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -663,14 +720,14 @@ p {
 }
 
 .action-view {
-  --action-padding-x: clamp(1.5rem, 3vw, 2.5rem);
-  --action-hand-height: clamp(9rem, 18vh, 11rem);
+  --action-padding-x: clamp(1.25rem, min(3vw, 4vh), 2.25rem);
+  --action-hand-height: clamp(8.5rem, 18vh, 10.5rem);
   --action-actor-color: var(--color-accent);
   --action-actor-shadow: rgba(251, 191, 36, 0.18);
   --action-kuroko-color: #38bdf8;
   --action-kuroko-shadow: rgba(56, 189, 248, 0.18);
   --action-kuroko-shadow-strong: rgba(56, 189, 248, 0.25);
-  min-height: 100vh;
+  min-height: var(--viewport-height);
   display: flex;
   flex-direction: column;
   padding: var(--action-padding-x);
@@ -681,19 +738,19 @@ p {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: clamp(1.5rem, 2.5vw, 2rem);
+  gap: clamp(1.25rem, min(3vw, 5vh), 1.85rem);
 }
 
 .action__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: clamp(0.75rem, 2vw, 1.5rem);
+  gap: clamp(0.6rem, min(2vw, 4vh), 1.35rem);
 }
 
 .action__title {
   margin: 0;
-  font-size: clamp(1.85rem, 2.5vw + 1rem, 2.35rem);
+  font-size: clamp(1.7rem, 2.25vw + 0.9rem, 2.2rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -701,7 +758,7 @@ p {
 .action__actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: clamp(0.5rem, 2vw, 0.85rem);
 }
 
 .action-confirm__list {
@@ -726,8 +783,9 @@ p {
 .action-hand {
   position: sticky;
   bottom: 0;
-  margin: clamp(2rem, 3vw, 2.5rem) calc(var(--action-padding-x) * -1) 0;
-  padding: 1.25rem var(--action-padding-x) calc(var(--action-padding-x) - 0.25rem);
+  margin: clamp(1.5rem, min(4vw, 5vh), 2.25rem) calc(var(--action-padding-x) * -1) 0;
+  padding: clamp(1rem, 3.5vh, 1.25rem) var(--action-padding-x)
+    clamp(calc(var(--action-padding-x) - 0.5rem), 2vh, calc(var(--action-padding-x) - 0.15rem));
   border-top: 1px solid rgba(148, 163, 184, 0.25);
   background:
     linear-gradient(180deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.98)),
@@ -741,8 +799,8 @@ p {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.75rem;
-  margin-bottom: 0.75rem;
+  gap: clamp(0.5rem, 2vw, 0.85rem);
+  margin-bottom: clamp(0.5rem, 2.5vh, 0.75rem);
 }
 
 .action-hand__title {
@@ -759,7 +817,7 @@ p {
   margin: 0;
   padding: 0;
   display: flex;
-  gap: clamp(0.75rem, 1.5vw, 1.25rem);
+  gap: clamp(0.65rem, min(1.5vw, 2.5vh), 1.1rem);
   overflow-x: auto;
   padding-bottom: 0.25rem;
   scroll-snap-type: x proximity;
@@ -890,18 +948,18 @@ p {
 }
 
 .watch-view {
-  min-height: calc(100vh - 3rem);
+  min-height: var(--viewport-height);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(2rem, 3vw + 1rem, 3rem) 1.5rem;
+  padding: var(--view-padding-block) var(--view-padding-inline);
 }
 
 .watch {
   width: min(840px, 100%);
   display: grid;
-  gap: clamp(1.75rem, 2.5vw, 2.5rem);
-  padding: clamp(2rem, 2.5vw + 1rem, 3rem);
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
   border-radius: 32px;
   background: var(--color-surface);
   box-shadow: var(--shadow-lg);
@@ -917,7 +975,7 @@ p {
 
 .watch__title {
   margin: 0;
-  font-size: clamp(1.85rem, 2.5vw + 1rem, 2.4rem);
+  font-size: clamp(1.7rem, 2.25vw + 0.95rem, 2.3rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -942,9 +1000,9 @@ p {
 .watch-status {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem 1.5rem;
+  gap: clamp(0.5rem, 2vh, 0.75rem) clamp(1rem, 3vw, 1.5rem);
   align-items: center;
-  padding: 1rem 1.25rem;
+  padding: clamp(0.75rem, 2.5vh, 1rem) clamp(0.85rem, 2.5vh + 0.5rem, 1.25rem);
   border-radius: 24px;
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: rgba(15, 23, 42, 0.4);
@@ -1051,15 +1109,15 @@ p {
 
 .watch-actions {
   display: grid;
-  gap: 0.75rem;
+  gap: clamp(0.6rem, 2.5vh, 0.85rem);
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .watch-actions__button {
   width: 100%;
   justify-content: center;
-  font-size: 1.05rem;
-  padding: 0.9rem 1.5rem;
+  font-size: clamp(0.95rem, 2.6vw, 1.05rem);
+  padding: calc(var(--button-padding-y) + 0.05rem) clamp(1.25rem, 4vw, 1.5rem);
 }
 
 .watch-actions__button--clap {
@@ -1084,7 +1142,7 @@ p {
 
 .home__actions {
   display: grid;
-  gap: 1rem;
+  gap: clamp(0.85rem, 3vh, 1.35rem);
 }
 
 .home__action {
@@ -1095,8 +1153,7 @@ p {
 .home__button {
   width: 100%;
   justify-content: center;
-  font-size: 1.05rem;
-  padding-block: 0.85rem;
+  font-size: clamp(0.95rem, 2.8vw, 1.05rem);
 }
 
 .home__resume-details {
@@ -1248,7 +1305,7 @@ p {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.75rem 1.25rem;
+  padding: var(--button-padding-y) var(--button-padding-x);
   border-radius: 9999px;
   border: none;
   font-size: 1rem;
@@ -1419,15 +1476,15 @@ p {
 }
 
 .gate-view {
-  min-height: calc(100vh - 4rem);
+  min-height: var(--viewport-height);
   display: grid;
   place-items: center;
-  padding: 2.5rem 1.5rem;
+  padding: var(--view-padding-block) var(--view-padding-inline);
 }
 
 .gate-view__panel {
   width: min(560px, 100%);
-  padding: clamp(1.75rem, 2.5vw + 1rem, 2.5rem);
+  padding: var(--panel-padding);
   border-radius: 28px;
   background: rgba(15, 23, 42, 0.88);
   box-shadow: var(--shadow-lg);
@@ -1435,7 +1492,7 @@ p {
 }
 
 .gate-view__title {
-  font-size: clamp(1.75rem, 2vw + 1.2rem, 2.3rem);
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.2rem);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   margin-bottom: 1.25rem;


### PR DESCRIPTION
## Summary
- introduce viewport-aware layout variables to ensure primary views stay within the visible area
- tighten gaps, padding, and typography across home, standby, scout, watch, and action screens for compact displays
- refine action hand and watch controls so their elements scale with reduced vertical space

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d513805d2c832ab055e2c44e33948c