### PR TITLE
Fix board check stolen cards visibility

### DIFF
--- a/src/ui/board-check.ts
+++ b/src/ui/board-check.ts
@@ -147,13 +147,21 @@ const renderOverviewTab = (state: GameState): HTMLElement => {
       player.takenByOpponent.forEach((card) => {
         const item = document.createElement('li');
         item.className = 'board-check__card-item';
+
         const cardComponent = new CardComponent({
           rank: card.rank,
           suit: card.suit,
-          faceDown: card.face !== 'up',
+          faceDown: false,
           annotation: card.annotation,
         });
-        item.append(cardComponent.el);
+        const cardLabel = formatCardLabel(card);
+        cardComponent.el.setAttribute('aria-label', cardLabel);
+
+        const label = document.createElement('span');
+        label.className = 'board-check__card-label';
+        label.textContent = cardLabel;
+
+        item.append(cardComponent.el, label);
         list.append(item);
       });
       playerBlock.append(list);

--- a/styles/base.css
+++ b/styles/base.css
@@ -1694,6 +1694,11 @@ p {
   align-items: center;
 }
 
+.board-check__card-label {
+  color: var(--color-text);
+  font-weight: 500;
+}
+
 .board-check__card-grid-item {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- always render taken cards in the board check overview as face-up with readable labels
- add styling for the new board check card labels to match the layout

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d51761fab0832abee42356e2c2b7da