### PR TITLE
feat: implement spotlight kuroko reveal

### DIFF
--- a/src/views/spotlight.ts
+++ b/src/views/spotlight.ts
@@ -1,0 +1,246 @@
+import { UIButton } from '../ui/button.js';
+import { CardComponent } from '../ui/card.js';
+import type { CardSuit } from '../ui/card.js';
+
+export interface SpotlightStageCardViewModel {
+  rank: string;
+  suit: CardSuit;
+  faceDown?: boolean;
+  annotation?: string;
+  description?: string;
+}
+
+export interface SpotlightStageViewModel {
+  actorLabel: string;
+  actorCard?: SpotlightStageCardViewModel | null;
+  actorEmptyMessage?: string;
+  kurokoLabel: string;
+  kurokoCard?: SpotlightStageCardViewModel | null;
+  kurokoEmptyMessage?: string;
+}
+
+export interface SpotlightViewOptions {
+  title: string;
+  stage: SpotlightStageViewModel;
+  revealLabel?: string;
+  revealDisabled?: boolean;
+  revealCaption?: string;
+  boardCheckLabel?: string;
+  helpLabel?: string;
+  helpAriaLabel?: string;
+  onReveal?: () => void;
+  onOpenBoardCheck?: () => void;
+  onOpenHelp?: () => void;
+}
+
+export interface SpotlightViewElement extends HTMLElement {
+  updateStage: (stage: SpotlightStageViewModel) => void;
+  setRevealDisabled: (disabled: boolean) => void;
+  updateRevealCaption: (caption?: string | null) => void;
+}
+
+const DEFAULT_EMPTY_MESSAGE = 'カードが配置されていません。';
+const DEFAULT_REVEAL_LABEL = '黒子を公開する';
+
+interface SpotlightCardSlotElements {
+  slot: HTMLDivElement;
+  heading: HTMLHeadingElement;
+  card: CardComponent;
+  placeholder: HTMLDivElement;
+  description: HTMLParagraphElement;
+}
+
+const createCardSlot = (
+  label: string,
+  options: { emptyMessage?: string } = {},
+): SpotlightCardSlotElements => {
+  const slot = document.createElement('div');
+  slot.className = 'spotlight-stage__slot';
+
+  const heading = document.createElement('h2');
+  heading.className = 'spotlight-stage__heading';
+  heading.textContent = label;
+  slot.append(heading);
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'spotlight-stage__card-wrapper';
+  slot.append(wrapper);
+
+  const card = new CardComponent({ rank: '?', suit: 'spades', faceDown: true });
+  card.el.classList.add('spotlight-stage__card');
+  wrapper.append(card.el);
+
+  const placeholder = document.createElement('div');
+  placeholder.className = 'spotlight-stage__placeholder';
+  placeholder.textContent = options.emptyMessage ?? DEFAULT_EMPTY_MESSAGE;
+  placeholder.hidden = true;
+  wrapper.append(placeholder);
+
+  const description = document.createElement('p');
+  description.className = 'spotlight-stage__description';
+  description.hidden = true;
+  slot.append(description);
+
+  return { slot, heading, card, placeholder, description };
+};
+
+const updateCardSlot = (
+  elements: SpotlightCardSlotElements,
+  viewModel: SpotlightStageCardViewModel | null | undefined,
+  emptyMessage?: string,
+): void => {
+  if (!viewModel) {
+    elements.slot.classList.add('is-empty');
+    elements.card.el.hidden = true;
+    elements.card.el.setAttribute('aria-hidden', 'true');
+    elements.placeholder.textContent = emptyMessage ?? DEFAULT_EMPTY_MESSAGE;
+    elements.placeholder.hidden = false;
+    elements.description.hidden = true;
+    elements.description.textContent = '';
+    elements.card.el.removeAttribute('title');
+    return;
+  }
+
+  elements.slot.classList.remove('is-empty');
+  elements.card.el.hidden = false;
+  elements.card.el.removeAttribute('aria-hidden');
+  elements.placeholder.hidden = true;
+
+  elements.card.setCard(viewModel.rank, viewModel.suit);
+  elements.card.setFaceDown(Boolean(viewModel.faceDown));
+
+  if (viewModel.annotation) {
+    elements.card.el.title = viewModel.annotation;
+  } else {
+    elements.card.el.removeAttribute('title');
+  }
+
+  if (viewModel.description) {
+    elements.description.hidden = false;
+    elements.description.textContent = viewModel.description;
+  } else {
+    elements.description.hidden = true;
+    elements.description.textContent = '';
+  }
+};
+
+export const createSpotlightView = (options: SpotlightViewOptions): SpotlightViewElement => {
+  const section = document.createElement('section');
+  section.className = 'view spotlight-view';
+
+  const main = document.createElement('main');
+  main.className = 'spotlight';
+  section.append(main);
+
+  const header = document.createElement('div');
+  header.className = 'spotlight__header';
+  main.append(header);
+
+  const heading = document.createElement('h1');
+  heading.className = 'spotlight__title';
+  heading.textContent = options.title;
+  header.append(heading);
+
+  const headerActions = document.createElement('div');
+  headerActions.className = 'spotlight__header-actions';
+
+  if (options.onOpenBoardCheck) {
+    const boardCheckButton = new UIButton({
+      label: options.boardCheckLabel ?? 'ボードチェック',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    boardCheckButton.el.classList.add('spotlight__header-button');
+    boardCheckButton.onClick(() => options.onOpenBoardCheck?.());
+    headerActions.append(boardCheckButton.el);
+  }
+
+  if (options.onOpenHelp) {
+    const helpButton = new UIButton({
+      label: options.helpLabel ?? '？',
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    helpButton.el.classList.add('spotlight__header-button', 'spotlight__header-button--help');
+    const ariaLabel = options.helpAriaLabel ?? 'ヘルプ';
+    helpButton.el.setAttribute('aria-label', ariaLabel);
+    helpButton.el.title = ariaLabel;
+    helpButton.onClick(() => options.onOpenHelp?.());
+    headerActions.append(helpButton.el);
+  }
+
+  if (headerActions.childElementCount > 0) {
+    header.append(headerActions);
+  }
+
+  const stageSection = document.createElement('section');
+  stageSection.className = 'spotlight-stage';
+  main.append(stageSection);
+
+  const stageGrid = document.createElement('div');
+  stageGrid.className = 'spotlight-stage__slots';
+  stageSection.append(stageGrid);
+
+  const actorSlot = createCardSlot(options.stage.actorLabel, {
+    emptyMessage: options.stage.actorEmptyMessage,
+  });
+  stageGrid.append(actorSlot.slot);
+
+  const kurokoSlot = createCardSlot(options.stage.kurokoLabel, {
+    emptyMessage: options.stage.kurokoEmptyMessage,
+  });
+  stageGrid.append(kurokoSlot.slot);
+
+  const actions = document.createElement('div');
+  actions.className = 'spotlight-actions';
+  main.append(actions);
+
+  const revealButton = new UIButton({
+    label: options.revealLabel ?? DEFAULT_REVEAL_LABEL,
+    variant: 'primary',
+    disabled: Boolean(options.revealDisabled),
+  });
+  revealButton.el.classList.add('spotlight-actions__button');
+  revealButton.onClick(() => options.onReveal?.());
+  actions.append(revealButton.el);
+
+  const revealCaption = document.createElement('p');
+  revealCaption.className = 'spotlight-actions__caption';
+  if (options.revealCaption) {
+    revealCaption.textContent = options.revealCaption;
+  } else {
+    revealCaption.hidden = true;
+  }
+  actions.append(revealCaption);
+
+  const applyStage = (stage: SpotlightStageViewModel) => {
+    actorSlot.heading.textContent = stage.actorLabel;
+    updateCardSlot(actorSlot, stage.actorCard ?? null, stage.actorEmptyMessage);
+
+    kurokoSlot.heading.textContent = stage.kurokoLabel;
+    if (stage.kurokoCard) {
+      updateCardSlot(kurokoSlot, stage.kurokoCard, stage.kurokoEmptyMessage);
+    } else {
+      updateCardSlot(kurokoSlot, null, stage.kurokoEmptyMessage);
+    }
+  };
+
+  applyStage(options.stage);
+
+  const view = section as SpotlightViewElement;
+  view.updateStage = (stage) => applyStage(stage);
+  view.setRevealDisabled = (disabled) => {
+    revealButton.setDisabled(disabled);
+  };
+  view.updateRevealCaption = (caption) => {
+    if (caption) {
+      revealCaption.hidden = false;
+      revealCaption.textContent = caption;
+      return;
+    }
+    revealCaption.hidden = true;
+    revealCaption.textContent = '';
+  };
+
+  return view;
+};

--- a/styles/base.css
+++ b/styles/base.css
@@ -1785,3 +1785,139 @@ p {
     transform: rotate(360deg);
   }
 }
+
+.spotlight-view {
+  min-height: var(--viewport-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--view-padding-block) var(--view-padding-inline);
+}
+
+.spotlight {
+  width: min(840px, 100%);
+  display: grid;
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
+  border-radius: 32px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.spotlight__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.spotlight__title {
+  margin: 0;
+  font-size: clamp(1.7rem, 2.25vw + 0.95rem, 2.3rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.spotlight__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.spotlight__header-button {
+  min-width: 0;
+}
+
+.spotlight__header-button--help {
+  width: 3rem;
+  aspect-ratio: 1;
+  padding: 0;
+  justify-content: center;
+}
+
+.spotlight-stage {
+  padding: clamp(1.75rem, 2.5vw, 2.5rem);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.35);
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+}
+
+.spotlight-stage__slots {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.spotlight-stage__slot {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.spotlight-stage__heading {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.spotlight-stage__card-wrapper {
+  min-height: clamp(180px, 30vh, 220px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem;
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.spotlight-stage__card {
+  width: clamp(120px, 18vw, 160px);
+  height: clamp(168px, 26vw, 220px);
+  font-size: clamp(1.6rem, 2.5vw, 2.25rem);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+}
+
+.spotlight-stage__placeholder {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.spotlight-stage__slot.is-empty .spotlight-stage__card {
+  display: none;
+}
+
+.spotlight-stage__slot.is-empty .spotlight-stage__placeholder {
+  display: block;
+}
+
+.spotlight-stage__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.spotlight-actions {
+  display: grid;
+  gap: clamp(0.6rem, 2.5vh, 0.85rem);
+  justify-items: center;
+}
+
+.spotlight-actions__button {
+  width: min(320px, 100%);
+  justify-content: center;
+  font-size: clamp(0.98rem, 2.4vw, 1.08rem);
+  font-weight: 700;
+}
+
+.spotlight-actions__caption {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- スポットライトフェーズで黒子を公開するためのロジックと確認ダイアログを追加しました
- 新しいスポットライト用ビューとスタイルを実装し、ルーティングと状態更新を連携させました

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d525e7b08c832aa03f9a22fc34b768