### PR TITLE
Adjust card sizing and expand board check modal

### DIFF
--- a/src/ui/board-check.ts
+++ b/src/ui/board-check.ts
@@ -539,5 +539,6 @@ export const showBoardCheck = (options: BoardCheckOptions = {}): void => {
         variant: 'ghost',
       },
     ],
+    className: 'modal--board-check',
   });
 };

--- a/src/ui/modal.ts
+++ b/src/ui/modal.ts
@@ -16,12 +16,17 @@ export interface ModalOptions {
   body?: string | HTMLElement;
   actions?: ModalAction[];
   dismissible?: boolean;
+  className?: string;
 }
 
 class ModalView extends UIComponent<HTMLDivElement> {
   constructor() {
     super(document.createElement('div'));
     this.element.className = 'modal';
+  }
+
+  setClassName(className: string | undefined): void {
+    this.element.className = ['modal', className].filter(Boolean).join(' ');
   }
 
   setTitle(title: string | undefined): void {
@@ -122,6 +127,7 @@ export class ModalController {
 
   open(options: ModalOptions): void {
     this.dismissible = options.dismissible ?? true;
+    this.modalView.setClassName(options.className);
     this.modalView.setTitle(options.title);
     this.modalView.setBody(options.body);
     this.modalView.setActions(options.actions, () => this.close());

--- a/styles/base.css
+++ b/styles/base.css
@@ -1385,6 +1385,28 @@ p {
   box-shadow: var(--shadow-lg);
 }
 
+.modal--board-check {
+  width: min(960px, calc(100vw - 3rem));
+  max-height: calc(100vh - 3rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.modal--board-check .modal__body {
+  flex: 1 1 auto;
+  display: flex;
+  overflow: hidden;
+}
+
+.modal--board-check .modal__footer {
+  margin-top: 1.5rem;
+}
+
+.modal--board-check .board-check {
+  flex: 1 1 auto;
+  max-height: none;
+}
+
 .modal__title {
   font-size: clamp(1.25rem, 1.6vw + 1rem, 1.75rem);
   margin-bottom: 1rem;
@@ -1535,14 +1557,14 @@ p {
 }
 
 .card {
-  width: 72px;
-  height: 104px;
-  border-radius: 12px;
+  width: 64px;
+  height: 92px;
+  border-radius: 10px;
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.35);
   display: grid;
   place-items: center;
-  font-size: 1.25rem;
+  font-size: 1.15rem;
   font-weight: 600;
 }
 
@@ -1578,7 +1600,7 @@ p {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  max-height: min(65vh, 520px);
+  max-height: min(80vh, 640px);
 }
 
 .board-check__tabs {
@@ -1685,7 +1707,7 @@ p {
 }
 
 .board-check__card-list--grid {
-  grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
   gap: 0.75rem;
   justify-items: center;
 }
@@ -1735,7 +1757,7 @@ p {
 
 .board-check__stage-card {
   display: grid;
-  grid-template-columns: 96px 1fr;
+  grid-template-columns: 88px 1fr;
   gap: 1rem;
   align-items: start;
 }


### PR DESCRIPTION
## Summary
- shrink the base card component dimensions for a more compact layout
- allow modals to receive custom class names and tag the board check modal with a dedicated style
- expand the board check modal layout to use more viewport space and tune related grid spacing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d53d6d2dd4832aaf3b870bc4095327