### PR TITLE
feat: インターミッションゲートの実装

### DIFF
--- a/src/views/gate.ts
+++ b/src/views/gate.ts
@@ -1,4 +1,13 @@
+import { UIButton, ButtonVariant } from '../ui/button.js';
 import { showGate, GateOptions } from '../ui/gate.js';
+
+export interface GateViewAction {
+  label: string;
+  variant?: ButtonVariant;
+  preventRapid?: boolean;
+  lockDuration?: number;
+  onSelect?: () => void;
+}
 
 export interface GateViewOptions {
   title: string;
@@ -11,6 +20,7 @@ export interface GateViewOptions {
   preventRapid?: boolean;
   lockDuration?: number;
   onGatePass?: () => void;
+  actions?: GateViewAction[];
 }
 
 const DEFAULT_GATE_MESSAGE =
@@ -36,6 +46,32 @@ const renderHintList = (hints: string[] | undefined): HTMLUListElement | null =>
   return list;
 };
 
+const renderActions = (actions: GateViewAction[] | undefined): HTMLDivElement | null => {
+  if (!actions || actions.length === 0) {
+    return null;
+  }
+
+  const container = document.createElement('div');
+  container.className = 'gate-view__actions';
+
+  actions.forEach((action) => {
+    const button = new UIButton({
+      label: action.label,
+      variant: action.variant ?? 'ghost',
+      preventRapid: action.preventRapid,
+      lockDuration: action.lockDuration,
+    });
+
+    if (action.onSelect) {
+      button.onClick(() => action.onSelect?.());
+    }
+
+    container.append(button.el);
+  });
+
+  return container;
+};
+
 export const createGateView = (options: GateViewOptions): HTMLElement => {
   const section = document.createElement('section');
   section.className = 'view gate-view';
@@ -57,6 +93,11 @@ export const createGateView = (options: GateViewOptions): HTMLElement => {
   const hints = renderHintList(options.hints);
   if (hints) {
     wrapper.append(hints);
+  }
+
+  const actions = renderActions(options.actions);
+  if (actions) {
+    wrapper.append(actions);
   }
 
   section.append(wrapper);

--- a/styles/base.css
+++ b/styles/base.css
@@ -1556,6 +1556,16 @@ p {
   color: var(--color-accent);
 }
 
+.gate-view__actions {
+  margin-top: 2rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.gate-view__actions .button {
+  width: 100%;
+}
+
 .card {
   width: 64px;
   height: 92px;
@@ -1577,6 +1587,43 @@ p {
   margin-top: 25vh;
   text-align: center;
   color: var(--color-muted);
+}
+
+.intermission-summary {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.intermission-summary__caption {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.6;
+}
+
+.intermission-summary__list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.intermission-summary__item {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.intermission-summary__term {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.intermission-summary__description {
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+  line-height: 1.6;
 }
 
 .placeholder__title {


### PR DESCRIPTION
## Summary
- インターミッションゲートで動的なサブタイトル・ボタンを提供し、ボードチェックや要約表示に対応
- 公開情報のみで構成した前ラウンド要約モーダルを実装し、ターンやスコアなどを表示
- ゲート通過時にターン開始処理を更新し、UIスタイルを追加してゲートアクションを整備

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d55e91f8e4832a837c3b75c4bc0786