### PR TITLE
feat: switch active player during intermission handoff

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2759,9 +2759,11 @@ const handleIntermissionGatePass = (router: Router): void => {
     const timestamp = Date.now();
     const currentTurn = current.turn ?? { count: 0, startedAt: timestamp };
     const previousWatchState = current.watch ?? createInitialWatchState();
+    const nextActivePlayerId = getOpponentId(current.activePlayer);
 
     return {
       ...current,
+      activePlayer: nextActivePlayerId,
       turn: {
         count: currentTurn.count + 1,
         startedAt: timestamp,


### PR DESCRIPTION
## Summary
- 更新されたインターミッションゲート通過処理で手番を相手プレイヤーへ交代
- 手番交代後もターン情報とウォッチ状態のリセットを従来通り維持

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5619e0b74832aaf82a0cb64466c8d