### PR TITLE
feat: カーテンコール集計ロジックを実装

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -1,3 +1,5 @@
+import type { RankValueRuleId } from './rank.js';
+
 export type PhaseKey =
   | 'home'
   | 'standby'
@@ -131,6 +133,27 @@ export interface SetState {
   opened: SetReveal[];
 }
 
+export type CurtainCallReason = 'jokerBonus' | 'setRemaining1';
+
+export interface CurtainCallPlayerSummary {
+  kamiCards: CardSnapshot[];
+  handCards: CardSnapshot[];
+  sumKami: number;
+  sumHand: number;
+  penalty: number;
+  final: number;
+}
+
+export interface CurtainCallSummary {
+  reason: CurtainCallReason;
+  preparedAt: number;
+  rankValueRule: RankValueRuleId;
+  booCount: Record<PlayerId, number>;
+  winner: PlayerId | 'draw';
+  margin: number;
+  players: Record<PlayerId, CurtainCallPlayerSummary>;
+}
+
 export type HistoryEntryType =
   | 'setup'
   | 'standby'
@@ -203,6 +226,7 @@ export interface GameState extends Record<string, unknown> {
   action: ActionState;
   watch: WatchState;
   remainingWatchIncludingCurrent?: Record<PlayerId, number>;
+  curtainCall?: CurtainCallSummary;
 }
 
 export type StateListener<TState> = (state: TState) => void;


### PR DESCRIPTION
## Summary
- カーテンコール計算用のサマリー型を状態に追加
- ステージと手札からカミ合計やペナルティを算出し勝者を決定するロジックを実装
- JOKERボーナスとセット残り1枚の分岐で集計を呼び出すよう接続

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d5feaedbe4832ab0fc18bbd9aaf290