### PR TITLE
feat: implement curtain call result view

### DIFF
--- a/src/views/curtaincall.ts
+++ b/src/views/curtaincall.ts
@@ -1,0 +1,297 @@
+import { UIButton } from '../ui/button.js';
+import { CardComponent } from '../ui/card.js';
+import type { CardSuit } from '../ui/card.js';
+
+export interface CurtainCallCardViewModel {
+  id: string;
+  rank: string;
+  suit: CardSuit;
+  annotation?: string;
+  label?: string;
+}
+
+export interface CurtainCallCardListViewModel {
+  label: string;
+  cards: CurtainCallCardViewModel[];
+  emptyMessage?: string;
+}
+
+export interface CurtainCallBreakdownRow {
+  label: string;
+  value: string;
+}
+
+export type CurtainCallFinalTrend = 'positive' | 'negative' | 'zero';
+
+export interface CurtainCallFinalViewModel {
+  label: string;
+  value: string;
+  trend: CurtainCallFinalTrend;
+}
+
+export interface CurtainCallBooProgressViewModel {
+  label: string;
+  value: string;
+}
+
+export interface CurtainCallPlayerSummaryViewModel {
+  id: string;
+  name: string;
+  breakdown: CurtainCallBreakdownRow[];
+  final: CurtainCallFinalViewModel;
+  booProgress: CurtainCallBooProgressViewModel;
+  kami: CurtainCallCardListViewModel;
+  hand: CurtainCallCardListViewModel;
+}
+
+export interface CurtainCallResultViewModel {
+  label: string;
+  description?: string;
+}
+
+export interface CurtainCallViewOptions {
+  title: string;
+  result: CurtainCallResultViewModel;
+  players: CurtainCallPlayerSummaryViewModel[];
+  boardCheckLabel?: string;
+  homeLabel?: string;
+  newGameLabel?: string;
+  saveLabel?: string;
+  onOpenBoardCheck?: () => void;
+  onGoHome?: () => void;
+  onStartNewGame?: () => void;
+  onSaveResult?: () => void;
+}
+
+export interface CurtainCallViewElement extends HTMLElement {
+  updateResult: (result: CurtainCallResultViewModel) => void;
+  updatePlayers: (players: CurtainCallPlayerSummaryViewModel[]) => void;
+}
+
+const DEFAULT_BOARD_CHECK_LABEL = 'ボードチェック';
+const DEFAULT_HOME_LABEL = 'HOME';
+const DEFAULT_NEW_GAME_LABEL = '新しいゲーム';
+const DEFAULT_SAVE_LABEL = '結果の保存';
+const DEFAULT_EMPTY_MESSAGE = 'カードはありません。';
+
+const renderCardList = (viewModel: CurtainCallCardListViewModel): HTMLElement => {
+  const section = document.createElement('section');
+  section.className = 'curtaincall-cards';
+
+  const heading = document.createElement('h3');
+  heading.className = 'curtaincall-cards__heading';
+  heading.textContent = viewModel.label;
+  section.append(heading);
+
+  if (viewModel.cards.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'curtaincall-cards__empty';
+    empty.textContent = viewModel.emptyMessage ?? DEFAULT_EMPTY_MESSAGE;
+    section.append(empty);
+    return section;
+  }
+
+  const list = document.createElement('div');
+  list.className = 'curtaincall-cards__list';
+
+  viewModel.cards.forEach((card) => {
+    const cardComponent = new CardComponent({
+      rank: card.rank,
+      suit: card.suit,
+      faceDown: false,
+      annotation: card.annotation ?? card.label,
+    });
+    cardComponent.el.classList.add('curtaincall-cards__card');
+    cardComponent.el.dataset.cardId = card.id;
+
+    if (card.label) {
+      cardComponent.el.setAttribute('aria-label', card.label);
+      if (!card.annotation) {
+        cardComponent.el.title = card.label;
+      }
+    }
+
+    list.append(cardComponent.el);
+  });
+
+  section.append(list);
+  return section;
+};
+
+const renderBreakdown = (rows: CurtainCallBreakdownRow[]): HTMLElement => {
+  const list = document.createElement('dl');
+  list.className = 'curtaincall-player__breakdown';
+
+  rows.forEach((row) => {
+    const item = document.createElement('div');
+    item.className = 'curtaincall-player__row';
+
+    const label = document.createElement('dt');
+    label.className = 'curtaincall-player__label';
+    label.textContent = row.label;
+
+    const value = document.createElement('dd');
+    value.className = 'curtaincall-player__value';
+    value.textContent = row.value;
+
+    item.append(label, value);
+    list.append(item);
+  });
+
+  return list;
+};
+
+const renderFinal = (final: CurtainCallFinalViewModel): HTMLElement => {
+  const container = document.createElement('div');
+  container.className = 'curtaincall-player__final';
+
+  const label = document.createElement('span');
+  label.className = 'curtaincall-player__final-label';
+  label.textContent = final.label;
+
+  const value = document.createElement('span');
+  value.className = 'curtaincall-player__final-value';
+  value.textContent = final.value;
+  value.dataset.trend = final.trend;
+
+  container.append(label, value);
+  return container;
+};
+
+const renderBooProgress = (booProgress: CurtainCallBooProgressViewModel): HTMLElement => {
+  const paragraph = document.createElement('p');
+  paragraph.className = 'curtaincall-player__boo';
+
+  const label = document.createElement('span');
+  label.className = 'curtaincall-player__boo-label';
+  label.textContent = `${booProgress.label}：`;
+
+  const value = document.createElement('span');
+  value.className = 'curtaincall-player__boo-value';
+  value.textContent = booProgress.value;
+
+  paragraph.append(label, value);
+  return paragraph;
+};
+
+const renderPlayerCard = (viewModel: CurtainCallPlayerSummaryViewModel): HTMLElement => {
+  const card = document.createElement('article');
+  card.className = 'curtaincall-player';
+  card.dataset.playerId = viewModel.id;
+
+  const name = document.createElement('h2');
+  name.className = 'curtaincall-player__name';
+  name.textContent = viewModel.name;
+  card.append(name);
+
+  card.append(renderBreakdown(viewModel.breakdown));
+  card.append(renderFinal(viewModel.final));
+  card.append(renderBooProgress(viewModel.booProgress));
+  card.append(renderCardList(viewModel.kami));
+  card.append(renderCardList(viewModel.hand));
+
+  return card;
+};
+
+export const createCurtainCallView = (options: CurtainCallViewOptions): CurtainCallViewElement => {
+  const section = document.createElement('section') as CurtainCallViewElement;
+  section.className = 'view curtaincall-view';
+
+  const main = document.createElement('main');
+  main.className = 'curtaincall';
+  section.append(main);
+
+  const header = document.createElement('div');
+  header.className = 'curtaincall__header';
+  main.append(header);
+
+  const heading = document.createElement('h1');
+  heading.className = 'curtaincall__title';
+  heading.textContent = options.title;
+  header.append(heading);
+
+  if (options.onOpenBoardCheck) {
+    const boardCheckButton = new UIButton({
+      label: options.boardCheckLabel ?? DEFAULT_BOARD_CHECK_LABEL,
+      variant: 'ghost',
+      preventRapid: false,
+    });
+    boardCheckButton.el.classList.add('curtaincall__boardcheck-button');
+    boardCheckButton.onClick(() => options.onOpenBoardCheck?.());
+    header.append(boardCheckButton.el);
+  }
+
+  const result = document.createElement('div');
+  result.className = 'curtaincall__result';
+  main.append(result);
+
+  const resultLabel = document.createElement('p');
+  resultLabel.className = 'curtaincall__result-label';
+  resultLabel.textContent = options.result.label;
+  result.append(resultLabel);
+
+  const resultDescription = document.createElement('p');
+  resultDescription.className = 'curtaincall__result-description';
+  if (options.result.description) {
+    resultDescription.textContent = options.result.description;
+  } else {
+    resultDescription.hidden = true;
+  }
+  result.append(resultDescription);
+
+  const summary = document.createElement('div');
+  summary.className = 'curtaincall-summary';
+  main.append(summary);
+
+  const renderPlayers = (players: CurtainCallPlayerSummaryViewModel[]): void => {
+    const items = players.map((player) => renderPlayerCard(player));
+    summary.replaceChildren(...items);
+  };
+
+  renderPlayers(options.players);
+
+  const actions = document.createElement('div');
+  actions.className = 'curtaincall__actions';
+  main.append(actions);
+
+  const homeButton = new UIButton({
+    label: options.homeLabel ?? DEFAULT_HOME_LABEL,
+    variant: 'ghost',
+  });
+  homeButton.el.classList.add('curtaincall__action-button');
+  homeButton.onClick(() => options.onGoHome?.());
+  actions.append(homeButton.el);
+
+  const newGameButton = new UIButton({
+    label: options.newGameLabel ?? DEFAULT_NEW_GAME_LABEL,
+    variant: 'primary',
+  });
+  newGameButton.el.classList.add('curtaincall__action-button', 'curtaincall__action-button--primary');
+  newGameButton.onClick(() => options.onStartNewGame?.());
+  actions.append(newGameButton.el);
+
+  const saveButton = new UIButton({
+    label: options.saveLabel ?? DEFAULT_SAVE_LABEL,
+    variant: 'ghost',
+  });
+  saveButton.el.classList.add('curtaincall__action-button');
+  saveButton.onClick(() => options.onSaveResult?.());
+  actions.append(saveButton.el);
+
+  section.updateResult = (resultViewModel) => {
+    resultLabel.textContent = resultViewModel.label;
+    if (resultViewModel.description) {
+      resultDescription.textContent = resultViewModel.description;
+      resultDescription.hidden = false;
+    } else {
+      resultDescription.textContent = '';
+      resultDescription.hidden = true;
+    }
+  };
+
+  section.updatePlayers = (players) => {
+    renderPlayers(players);
+  };
+
+  return section;
+};

--- a/styles/base.css
+++ b/styles/base.css
@@ -2142,3 +2142,210 @@ p {
   font-size: clamp(1.4rem, 2.1vw, 2rem);
   box-shadow: 0 14px 28px rgba(15, 23, 42, 0.3);
 }
+
+.curtaincall-view {
+  min-height: var(--viewport-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--view-padding-block) var(--view-padding-inline);
+}
+
+.curtaincall {
+  width: min(960px, 100%);
+  display: grid;
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
+  border-radius: 32px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.curtaincall__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.curtaincall__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 2.4vw + 0.9rem, 2.45rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.curtaincall__boardcheck-button {
+  min-width: 0;
+}
+
+.curtaincall__result {
+  padding: clamp(1.25rem, 3vh, 1.75rem);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.4);
+  display: grid;
+  gap: 0.6rem;
+  text-align: center;
+}
+
+.curtaincall__result-label {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.2vw + 0.8rem, 2.05rem);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.curtaincall__result-description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.curtaincall-summary {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.curtaincall-player {
+  display: grid;
+  gap: clamp(0.85rem, 2vh, 1.25rem);
+  padding: clamp(1.25rem, 3.5vh, 1.75rem);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.curtaincall-player__name {
+  margin: 0;
+  font-size: clamp(1.15rem, 1.6vw + 0.8rem, 1.45rem);
+  font-weight: 600;
+}
+
+.curtaincall-player__breakdown {
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.curtaincall-player__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.curtaincall-player__label {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.curtaincall-player__value {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.curtaincall-player__final {
+  margin: 0;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.curtaincall-player__final-label {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.curtaincall-player__final-value {
+  font-size: clamp(1.45rem, 2vw + 0.8rem, 1.85rem);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.curtaincall-player__final-value[data-trend='positive'] {
+  color: var(--color-accent-strong);
+}
+
+.curtaincall-player__final-value[data-trend='negative'] {
+  color: var(--color-danger);
+}
+
+.curtaincall-player__boo {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.curtaincall-player__boo-value {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.curtaincall-cards {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.curtaincall-cards__heading {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.curtaincall-cards__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.curtaincall-cards__card {
+  width: clamp(68px, 13vw, 88px);
+  height: clamp(98px, 18vw, 126px);
+  font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.28);
+}
+
+.curtaincall-cards__empty {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.curtaincall__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.curtaincall__action-button {
+  flex: 1 1 220px;
+  max-width: 260px;
+}
+
+@media (max-width: 640px) {
+  .curtaincall {
+    border-radius: 28px;
+  }
+
+  .curtaincall-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .curtaincall__action-button {
+    flex-basis: 100%;
+    max-width: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Curtain Call result view with victory banner, player breakdowns, and action buttons
- map Curtain Call summaries from state to the new view and wire the route to render it
- style the Curtain Call screen with responsive layouts and card lists for kami and hand cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d602b44a04832a9cd2887ddc3403c4