### PR TITLE
feat: カーテンコール結果の保存機能を実装

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -2335,6 +2335,63 @@ p {
   max-width: 260px;
 }
 
+.curtaincall-save {
+  display: grid;
+  gap: clamp(0.9rem, 2.5vh, 1.1rem);
+  color: var(--color-text);
+}
+
+.curtaincall-save__field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.curtaincall-save__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.curtaincall-save__input,
+.curtaincall-save__textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--color-text);
+  font-size: 1rem;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    background 120ms ease;
+}
+
+.curtaincall-save__input::placeholder,
+.curtaincall-save__textarea::placeholder {
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.curtaincall-save__input:focus,
+.curtaincall-save__textarea:focus {
+  outline: none;
+  border-color: rgba(251, 191, 36, 0.85);
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.curtaincall-save__textarea {
+  min-height: 120px;
+  resize: vertical;
+  line-height: 1.55;
+}
+
+.curtaincall-save__error {
+  margin: 0;
+  color: #fca5a5;
+  font-size: 0.9rem;
+}
+
 @media (max-width: 640px) {
   .curtaincall {
     border-radius: 28px;


### PR DESCRIPTION
## Summary
- カーテンコール結果の保存モーダルと履歴用テキスト生成ロジックを実装しました
- セーブ履歴を追記する storage API を追加しました
- 保存モーダル向けのフォームスタイルを追加しました

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d608f0862c832aa2a5a513cbe9ce43