### PR TITLE
chore: introduce shared animation framework

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ import {
 import { getActiveRankValueRule, rankValue } from './rank.js';
 import { ModalController } from './ui/modal.js';
 import { ToastManager } from './ui/toast.js';
+import { animationManager } from './ui/animation.js';
 import { CardComponent } from './ui/card.js';
 import { showBoardCheck } from './ui/board-check.js';
 import { createGateView } from './views/gate.js';
@@ -100,6 +101,7 @@ declare global {
       router: Router;
       modal: ModalController;
       toast: ToastManager;
+      animation: typeof animationManager;
     };
   }
 }
@@ -5394,7 +5396,7 @@ const initializeApp = (): void => {
   const modal = new ModalController(modalRoot);
   const toast = new ToastManager(toastRoot);
 
-  window.curtainCall = { router, modal, toast };
+  window.curtainCall = { router, modal, toast, animation: animationManager };
 
   buildRouteDefinitions(router).forEach((definition) => router.register(definition));
 

--- a/src/ui/animation.ts
+++ b/src/ui/animation.ts
@@ -1,0 +1,118 @@
+/**
+ * アニメーションの有効・無効を一元管理するための型とコントローラです。
+ * ブラウザの「簡易モーション（prefers-reduced-motion）」設定も読み取り、
+ * 手動指定との整合を取りながら `<html>` 要素にフラグ属性を反映します。
+ */
+export type AnimationPreference = 'auto' | 'on' | 'off';
+
+export interface AnimationState {
+  /** 現時点で演出が有効かどうか（`true` = アニメーション適用） */
+  enabled: boolean;
+  /** ユーザーが選択した優先度（自動／常に有効／常に無効） */
+  preference: AnimationPreference;
+}
+
+export type AnimationChangeListener = (state: AnimationState) => void;
+
+const DATA_ATTRIBUTE = 'data-cc-animations';
+
+class AnimationManager {
+  private preference: AnimationPreference = 'auto';
+  private readonly mediaQuery: MediaQueryList;
+  private readonly listeners = new Set<AnimationChangeListener>();
+  private enabled: boolean;
+
+  constructor() {
+    this.mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    this.enabled = this.computeEnabled();
+    this.applyPreference();
+    if (typeof this.mediaQuery.addEventListener === 'function') {
+      this.mediaQuery.addEventListener('change', this.handleSystemPreferenceChange);
+    } else {
+      // 古いブラウザ向けのフォールバック。addListener は非推奨だが互換のために残す。
+      this.mediaQuery.addListener(this.handleSystemPreferenceChange);
+    }
+  }
+
+  getState(): AnimationState {
+    return { enabled: this.enabled, preference: this.preference };
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  setPreference(preference: AnimationPreference): void {
+    if (this.preference === preference) {
+      return;
+    }
+
+    this.preference = preference;
+    const nextEnabled = this.computeEnabled();
+    if (nextEnabled === this.enabled) {
+      this.applyPreference();
+      this.emit();
+      return;
+    }
+
+    this.enabled = nextEnabled;
+    this.applyPreference();
+    this.emit();
+  }
+
+  useSystemPreference(): void {
+    this.setPreference('auto');
+  }
+
+  enable(): void {
+    this.setPreference('on');
+  }
+
+  disable(): void {
+    this.setPreference('off');
+  }
+
+  subscribe(listener: AnimationChangeListener): () => void {
+    this.listeners.add(listener);
+    listener(this.getState());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private computeEnabled(): boolean {
+    if (this.preference === 'on') {
+      return true;
+    }
+    if (this.preference === 'off') {
+      return false;
+    }
+    return !this.mediaQuery.matches;
+  }
+
+  private applyPreference(): void {
+    const root = document.documentElement;
+    const flag = this.enabled ? 'on' : 'off';
+    root.setAttribute(DATA_ATTRIBUTE, flag);
+  }
+
+  private emit(): void {
+    const snapshot = this.getState();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+
+  private handleSystemPreferenceChange = (): void => {
+    if (this.preference !== 'auto') {
+      return;
+    }
+    const nextEnabled = this.computeEnabled();
+    if (nextEnabled === this.enabled) {
+      return;
+    }
+    this.enabled = nextEnabled;
+    this.applyPreference();
+    this.emit();
+  };
+}
+
+export const animationManager = new AnimationManager();

--- a/src/ui/toast.ts
+++ b/src/ui/toast.ts
@@ -1,4 +1,5 @@
 import { UIComponent } from './component.js';
+import { animationManager } from './animation.js';
 
 export type ToastVariant = 'info' | 'success' | 'warning' | 'danger';
 
@@ -45,7 +46,19 @@ export class ToastManager {
   dismiss(id: number): void {
     const toast = this.host.querySelector<HTMLElement>(`.toast[data-toast-id="${id}"]`);
     if (toast) {
-      toast.remove();
+      // アニメーションが有効ならフェードアウトを待ってから DOM を取り除く。
+      if (animationManager.isEnabled()) {
+        if (!toast.classList.contains('is-leaving')) {
+          const handleRemoval = () => {
+            toast.remove();
+          };
+          toast.classList.add('is-leaving');
+          toast.addEventListener('animationend', handleRemoval, { once: true });
+          toast.addEventListener('animationcancel', handleRemoval, { once: true });
+        }
+      } else {
+        toast.remove();
+      }
     }
     const timer = this.timers.get(id);
     if (typeof timer === 'number') {

--- a/styles/base.css
+++ b/styles/base.css
@@ -16,6 +16,94 @@
   --panel-padding: clamp(2rem, 7vh, 3rem);
   --button-padding-y: 0.75rem;
   --button-padding-x: 1.25rem;
+
+  --motion-duration-short: 180ms;
+  --motion-duration-medium: 260ms;
+  --motion-duration-long: 380ms;
+  --motion-ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --motion-ease-in: cubic-bezier(0.7, 0, 0.84, 0);
+  --motion-ease-in-out: cubic-bezier(0.83, 0, 0.17, 1);
+  --motion-translate-distance: 1.5rem;
+}
+
+@keyframes view-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(var(--motion-translate-distance));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes modal-overlay-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes modal-overlay-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes modal-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.75rem) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes modal-content-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(0.75rem) scale(0.98);
+  }
+}
+
+@keyframes toast-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes toast-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
 }
 
 @supports (height: 100dvh) {
@@ -106,6 +194,7 @@ p {
 .view {
   min-height: var(--viewport-height);
   padding: var(--view-padding-block) var(--view-padding-inline);
+  animation: view-fade-in var(--motion-duration-medium) var(--motion-ease-out) both;
 }
 
 .home-view {
@@ -1364,17 +1453,31 @@ p {
 .modal-root {
   position: fixed;
   inset: 0;
-  display: none;
+  display: flex;
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
   background: rgba(15, 23, 42, 0.75);
   backdrop-filter: blur(6px);
   z-index: 40;
+  visibility: hidden;
+  pointer-events: none;
+  opacity: 0;
 }
 
 .modal-root.is-active {
-  display: flex;
+  visibility: visible;
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.modal-root.is-active:not(.is-closing) {
+  animation: modal-overlay-in var(--motion-duration-short) var(--motion-ease-out) both;
+}
+
+.modal-root.is-active.is-closing {
+  pointer-events: none;
+  animation: modal-overlay-out var(--motion-duration-short) var(--motion-ease-in) both;
 }
 
 .modal {
@@ -1383,6 +1486,12 @@ p {
   border-radius: 20px;
   padding: 1.75rem;
   box-shadow: var(--shadow-lg);
+  animation: modal-content-in var(--motion-duration-medium) var(--motion-ease-out) both;
+  transform-origin: center top;
+}
+
+.modal-root.is-active.is-closing .modal {
+  animation: modal-content-out var(--motion-duration-short) var(--motion-ease-in) both;
 }
 
 .modal--board-check {
@@ -1480,6 +1589,11 @@ p {
   box-shadow: var(--shadow-lg);
   color: var(--color-text);
   pointer-events: auto;
+  animation: toast-enter var(--motion-duration-medium) var(--motion-ease-out) both;
+}
+
+.toast.is-leaving {
+  animation: toast-exit var(--motion-duration-short) var(--motion-ease-in) both;
 }
 
 .toast--info {
@@ -1587,6 +1701,32 @@ p {
   margin-top: 25vh;
   text-align: center;
   color: var(--color-muted);
+}
+
+:root[data-cc-animations='off'] .view,
+:root[data-cc-animations='off'] .modal-root,
+:root[data-cc-animations='off'] .modal,
+:root[data-cc-animations='off'] .modal-root.is-active.is-closing .modal,
+:root[data-cc-animations='off'] .toast,
+:root[data-cc-animations='off'] .toast.is-leaving {
+  animation: none !important;
+}
+
+:root[data-cc-animations='off'] .button.is-busy::after {
+  animation: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .view,
+  .modal-root,
+  .modal,
+  .toast {
+    animation: none !important;
+  }
+
+  .button.is-busy::after {
+    animation: none !important;
+  }
 }
 
 .intermission-summary {


### PR DESCRIPTION
## Summary
- add an animation manager that synchronizes with reduced-motion settings and exposes manual controls
- apply fade/slide motion to views, modals, and toasts while keeping an opt-out path
- expose the animation controller on the global runtime for future settings hooks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d65bb9142c832a95a4023d8b3570ad