### PR TITLE
feat: add backstage view to board check

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -1908,7 +1908,16 @@ p {
 
 .board-check__card-grid-item {
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.board-check__card-label {
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .board-check__card-details {


### PR DESCRIPTION
## Summary
- add a Backstage tab to the board check modal showing public and hidden items with contextual labels
- display hidden backstage items as face-down cards and show reveal details for published ones
- update board check styling to support the backstage grid layout and descriptive captions

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d683470b90832aa7a5cde5b696ec94