### PR TITLE
feat: guard spotlight secrets on back navigation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -371,6 +371,12 @@ const revokeSpotlightSecretAccess = (): void => {
 
 const hasSpotlightSecretAccess = (): boolean => spotlightSecretAccessGranted;
 
+const resetPendingSpotlightSecrets = (): void => {
+  pendingSpotlightSecretPair = null;
+  pendingSpotlightSetOpen = null;
+  revokeSpotlightSecretAccess();
+};
+
 let lastActionGuardMessage: string | null = null;
 
 const formatCardLabel = (card: CardSnapshot): string => {
@@ -6071,11 +6077,20 @@ const initializeApp = (): void => {
   router.subscribe((path) => {
     const current = gameStore.getState();
 
-    if (path !== WATCH_TO_SPOTLIGHT_PATH && path !== SPOTLIGHT_GATE_PATH) {
+    const isSpotlightRoute = path === WATCH_TO_SPOTLIGHT_PATH;
+    const isSpotlightGateRoute = path === SPOTLIGHT_GATE_PATH;
+
+    if (!isSpotlightRoute && !isSpotlightGateRoute) {
+      if (pendingSpotlightSecretPair || pendingSpotlightSetOpen || hasSpotlightSecretAccess()) {
+        resetPendingSpotlightSecrets();
+      }
+    } else if (
+      isSpotlightRoute &&
+      current.route === SPOTLIGHT_GATE_PATH &&
+      !hasSpotlightSecretAccess()
+    ) {
       if (pendingSpotlightSecretPair || pendingSpotlightSetOpen) {
-        pendingSpotlightSecretPair = null;
-        pendingSpotlightSetOpen = null;
-        revokeSpotlightSecretAccess();
+        resetPendingSpotlightSecrets();
       }
     }
 


### PR DESCRIPTION
## Summary
- add a helper to reset pending spotlight secret requests together with secret access flags
- clear pending spotlight secret flows when leaving the phase or backing out before passing the gate so hidden data is not redrawn prematurely

## Testing
- npm test *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d68bde9b6c832a87dcc28ced475226