### PR TITLE
feat: ポップアップ文言の共通化

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -111,6 +111,7 @@ declare global {
 
 const {
   DEFAULT_GATE_CONFIRM_LABEL,
+  DEFAULT_CLOSE_LABEL,
   HANDOFF_GATE_HINTS,
   HANDOFF_GATE_MODAL_NOTES,
   INTERMISSION_GATE_TITLE,
@@ -269,11 +270,19 @@ const {
   CURTAINCALL_SUMMARY_PREPARING_SUBTITLE,
   SCOUT_PICK_RESULT_TITLE,
   SCOUT_PICK_RESULT_OK_LABEL,
+  SCOUT_PICK_RESULT_DRAWN_MESSAGE,
+  SCOUT_PICK_RESULT_PREVIEW_CAPTION,
+  SCOUT_PICK_RESULT_ACTION_NOTICE,
   HOME_SETTINGS_TITLE,
   HOME_SETTINGS_MESSAGE,
+  HELP_POPUP_BLOCKED_TOAST_MESSAGE,
+  HELP_POPUP_BLOCKED_CONSOLE_MESSAGE,
   HISTORY_DIALOG_TITLE,
   HISTORY_DIALOG_DESCRIPTION,
   HISTORY_EMPTY_MESSAGE,
+  HISTORY_UNKNOWN_TIMESTAMP,
+  HISTORY_COPY_BUTTON_LABEL,
+  HISTORY_DELETE_BUTTON_LABEL,
   HISTORY_COPY_SUCCESS,
   HISTORY_COPY_FAILURE,
   HISTORY_DELETE_SUCCESS,
@@ -1089,7 +1098,7 @@ const openSettingsDialog = (): void => {
     body: HOME_SETTINGS_MESSAGE,
     actions: [
       {
-        label: '閉じる',
+        label: DEFAULT_CLOSE_LABEL,
         variant: 'primary',
         preventRapid: true,
       },
@@ -1109,11 +1118,11 @@ const openRulebookHelp = (): void => {
     const toast = window.curtainCall?.toast;
     if (toast) {
       toast.show({
-        message: 'ヘルプを開けませんでした。ブラウザのポップアップ設定をご確認ください。',
+        message: HELP_POPUP_BLOCKED_TOAST_MESSAGE,
         variant: 'warning',
       });
     } else {
-      console.warn('ヘルプ画面を開けませんでした。ポップアップブロックを解除してください。');
+      console.warn(HELP_POPUP_BLOCKED_CONSOLE_MESSAGE);
     }
   }
 };
@@ -1247,7 +1256,7 @@ const openMyHandDialog = (): void => {
     body: container,
     actions: [
       {
-        label: '閉じる',
+        label: DEFAULT_CLOSE_LABEL,
         variant: 'ghost',
         preventRapid: false,
       },
@@ -1349,7 +1358,7 @@ const openHistoryDialog = (): void => {
         }
         timestamp.textContent = formatted;
       } else {
-        timestamp.textContent = '日時不明';
+        timestamp.textContent = HISTORY_UNKNOWN_TIMESTAMP;
       }
       header.append(timestamp);
 
@@ -1368,7 +1377,7 @@ const openHistoryDialog = (): void => {
       const copyButton = document.createElement('button');
       copyButton.type = 'button';
       copyButton.className = 'home-history__action';
-      copyButton.textContent = 'コピー';
+      copyButton.textContent = HISTORY_COPY_BUTTON_LABEL;
       copyButton.addEventListener('click', async () => {
         const text = [entry.summary, entry.detail].filter(Boolean).join('\n\n');
         const success = await copyToClipboard(text);
@@ -1382,7 +1391,7 @@ const openHistoryDialog = (): void => {
       const deleteButton = document.createElement('button');
       deleteButton.type = 'button';
       deleteButton.className = 'home-history__action home-history__action--danger';
-      deleteButton.textContent = '削除';
+      deleteButton.textContent = HISTORY_DELETE_BUTTON_LABEL;
       deleteButton.addEventListener('click', () => {
         const removed = deleteResult(entry.id);
         if (!removed) {
@@ -1414,7 +1423,7 @@ const openHistoryDialog = (): void => {
     body: container,
     actions: [
       {
-        label: '閉じる',
+        label: DEFAULT_CLOSE_LABEL,
         variant: 'primary',
         preventRapid: true,
       },
@@ -1464,7 +1473,8 @@ const createScoutPickResultContent = (
 
   const message = document.createElement('p');
   message.className = 'scout-complete__message';
-  message.textContent = `${formatCardLabel(card)}を引きました！`;
+  const cardLabel = formatCardLabel(card);
+  message.textContent = SCOUT_PICK_RESULT_DRAWN_MESSAGE(cardLabel);
   container.append(message);
 
   const preview = document.createElement('div');
@@ -1481,14 +1491,14 @@ const createScoutPickResultContent = (
 
   const previewCaption = document.createElement('p');
   previewCaption.className = 'scout-complete__caption';
-  previewCaption.textContent = '引いたカードは以下の通りです。';
+  previewCaption.textContent = SCOUT_PICK_RESULT_PREVIEW_CAPTION;
   preview.append(previewCaption);
 
   container.append(preview);
 
   const actionNotice = document.createElement('p');
   actionNotice.className = 'scout-complete__caption';
-  actionNotice.textContent = `${playerName}は${opponentName}に画面が見えないことを確認し、「${SCOUT_PICK_RESULT_OK_LABEL}」を押してアクションフェーズへ進みましょう。`;
+  actionNotice.textContent = SCOUT_PICK_RESULT_ACTION_NOTICE(playerName, opponentName);
   container.append(actionNotice);
 
   return container;
@@ -2148,7 +2158,7 @@ const openIntermissionSummaryDialog = (): void => {
     body,
     actions: [
       {
-        label: '閉じる',
+        label: DEFAULT_CLOSE_LABEL,
         variant: 'ghost',
       },
     ],

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -2,6 +2,7 @@ export const DEFAULT_GATE_TITLE = 'ハンドオフゲート';
 export const DEFAULT_GATE_CONFIRM_LABEL = '準備完了';
 export const DEFAULT_GATE_MESSAGE =
   '端末を次のプレイヤーに渡したら「準備完了」を押して、秘匿情報の閲覧を開始してください。';
+export const DEFAULT_CLOSE_LABEL = '閉じる';
 
 export const HANDOFF_GATE_HINTS = Object.freeze([
   '端末を次のプレイヤーに渡したら「準備完了」を押してください。',
@@ -41,6 +42,8 @@ export const INTERMISSION_BACKSTAGE_COMPLETE_MESSAGE = 'バックステージア
 export const STANDBY_DEAL_ERROR_MESSAGE =
   'スタンバイの初期化に失敗しました。もう一度お試しください。';
 export const STANDBY_FIRST_PLAYER_ERROR_MESSAGE = '先手が未決定です。スタンバイに戻ります。';
+
+export const BOARD_CHECK_MODAL_TITLE = 'ボードチェック';
 
 export const SCOUT_PICK_CONFIRM_TITLE = 'カードを引く';
 export const SCOUT_PICK_CONFIRM_MESSAGE = 'このカードを引いて手札に加えます。元に戻せません。';
@@ -229,14 +232,28 @@ export const CURTAINCALL_SUMMARY_PREPARING_SUBTITLE = '結果データを準備�
 
 export const SCOUT_PICK_RESULT_TITLE = 'カードを取得しました';
 export const SCOUT_PICK_RESULT_OK_LABEL = 'OK';
+export const SCOUT_PICK_RESULT_DRAWN_MESSAGE = (cardLabel: string): string => `${cardLabel}を引きました！`;
+export const SCOUT_PICK_RESULT_PREVIEW_CAPTION = '引いたカードは以下の通りです。';
+export const SCOUT_PICK_RESULT_ACTION_NOTICE = (
+  playerName: string,
+  opponentName: string,
+): string =>
+  `${playerName}は${opponentName}に画面が見えないことを確認し、「${SCOUT_PICK_RESULT_OK_LABEL}」を押してアクションフェーズへ進みましょう。`;
 
 export const HOME_SETTINGS_TITLE = '設定';
 export const HOME_SETTINGS_MESSAGE = '設定メニューは現在準備中です。';
+export const HELP_POPUP_BLOCKED_TOAST_MESSAGE =
+  'ヘルプを開けませんでした。ブラウザのポップアップ設定をご確認ください。';
+export const HELP_POPUP_BLOCKED_CONSOLE_MESSAGE =
+  'ヘルプ画面を開けませんでした。ポップアップブロックを解除してください。';
 
 export const HISTORY_DIALOG_TITLE = 'リザルト履歴';
 export const HISTORY_DIALOG_DESCRIPTION =
   '保存済みのリザルトを確認できます。コピーや削除が可能です（最大50件まで保持されます）。';
 export const HISTORY_EMPTY_MESSAGE = '保存されたリザルト履歴はまだありません。';
+export const HISTORY_UNKNOWN_TIMESTAMP = '日時不明';
+export const HISTORY_COPY_BUTTON_LABEL = 'コピー';
+export const HISTORY_DELETE_BUTTON_LABEL = '削除';
 export const HISTORY_COPY_SUCCESS = '履歴をコピーしました。';
 export const HISTORY_COPY_FAILURE = '履歴をコピーできませんでした。';
 export const HISTORY_DELETE_SUCCESS = '履歴を削除しました。';

--- a/src/ui/board-check.ts
+++ b/src/ui/board-check.ts
@@ -12,6 +12,7 @@ import {
   StagePair,
   gameStore,
 } from '../state.js';
+import { BOARD_CHECK_MODAL_TITLE, DEFAULT_CLOSE_LABEL } from '../messages.js';
 import { CardComponent } from './card.js';
 import { UIComponent } from './component.js';
 import type { ModalController } from './modal.js';
@@ -679,11 +680,11 @@ export const showBoardCheck = (options: BoardCheckOptions = {}): void => {
   const view = new BoardCheckView(state, initialTab);
 
   modal.open({
-    title: 'ボードチェック',
+    title: BOARD_CHECK_MODAL_TITLE,
     body: view.el,
     actions: [
       {
-        label: '閉じる',
+        label: DEFAULT_CLOSE_LABEL,
         variant: 'ghost',
       },
     ],


### PR DESCRIPTION
## Summary
- ポップアップ/モーダルで使用する共通文言を messages.ts に集約
- 既存ダイアログやトーストで共通文言を利用するよう更新し重複定義を削減

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d68dd15e44832ab8b7d0fcff16f96a