### PR TITLE
Fix backstage action availability after unpaired set reveal

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2003,7 +2003,7 @@ const canPerformBackstageAction = (state: GameState): boolean => {
   }
 
   const reveal = getLatestSpotlightSetReveal(state);
-  if (!reveal || reveal.assignedTo) {
+  if (!reveal) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- loosen the backstage action guard so it only requires a recent set reveal
- ensure the intermission backstage option appears when a set reveal failed to pair

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c6ea6a60832a84494bf8c75d1289