### PR TITLE
feat: ブラウザ戻る操作のブロック

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -4,6 +4,11 @@ export const DEFAULT_GATE_MESSAGE =
   '端末を次のプレイヤーに渡したら「準備完了」を押して、秘匿情報の閲覧を開始してください。';
 export const DEFAULT_CLOSE_LABEL = '閉じる';
 
+export const NAVIGATION_BLOCK_TITLE = '戻る操作はできません';
+export const NAVIGATION_BLOCK_MESSAGE =
+  'ゲーム進行中はブラウザの戻る操作を利用できません。画面内のボタンから操作してください。';
+export const NAVIGATION_BLOCK_CONFIRM_LABEL = 'OK';
+
 export const HANDOFF_GATE_HINTS = Object.freeze([
   '端末を次のプレイヤーに渡したら「準備完了」を押してください。',
   'ゲートを通過した後に秘匿情報が画面へ描画されます。',


### PR DESCRIPTION
## Summary
- ルーターにナビゲーションガードを追加してブラウザ戻る操作を検出・制御できるようにしました
- ゲーム進行中の戻る操作を阻止し、モーダルまたはトーストでガイドを表示する処理を実装しました
- 戻る操作ブロック用の案内文言を追加しました

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6eee91d18832aa28a8c215b6133b1