### PR TITLE
裏向きカードのランダム表示と手札ソートの改善

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -228,7 +228,7 @@ export interface ResumeSnapshot {
 }
 
 export interface ScoutState {
-  selectedOpponentCardIndex: number | null;
+  selectedOpponentCardId: string | null;
 }
 
 export interface ActionState {
@@ -411,7 +411,7 @@ export const createInitialState = (): GameState => {
     resume: undefined,
     recentScoutedCard: null,
     scout: {
-      selectedOpponentCardIndex: null,
+      selectedOpponentCardId: null,
     },
     action: createInitialActionState(),
     watch: createInitialWatchState(),

--- a/tests/scout.test.ts
+++ b/tests/scout.test.ts
@@ -31,7 +31,7 @@ describe('createScoutView', () => {
     firstButton?.click();
 
     expect(onSelect).toHaveBeenCalledTimes(1);
-    expect(onSelect).toHaveBeenCalledWith(0);
+    expect(onSelect).toHaveBeenCalledWith('opponent-0');
   });
 
   it('選択更新で「これを引く」ボタンが有効化され、押下で確定ハンドラが動作する', () => {
@@ -51,7 +51,7 @@ describe('createScoutView', () => {
     expect(confirmButton?.disabled).toBe(true);
 
     const cards = createOpponentCards(2);
-    view.updateOpponentHand(cards, 1);
+    view.updateOpponentHand(cards, 'opponent-1');
 
     expect(confirmButton?.disabled).toBe(false);
 


### PR DESCRIPTION
## Summary
- 自分の手札モーダルとアクション選択でカードを降順ソートして表示し直近に引いたカードの表示を維持
- スカウト時の相手手札並びをカードIDで管理してランダム化し、セット／バックステージなど裏向きカードの選択肢もシャッフル
- スカウト画面の選択処理とテストをカードIDベースへ更新して新しい並び方に追従

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d768fed2c4832aa94be4bb05851474