### PR TITLE
スポットライト判定ポップアップのカードレイアウトを横並びに変更

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -2306,14 +2306,19 @@ p {
   margin: 0;
   padding: 0;
   list-style: none;
-  display: grid;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: stretch;
+  flex-wrap: wrap;
   gap: 1rem;
 }
 
 .spotlight-reveal-result__card {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: 0.5rem;
-  justify-items: center;
 }
 
 .spotlight-reveal-result__card .card {


### PR DESCRIPTION
## Summary
- スポットライトの判定結果ポップアップでカードリストを横並び表示に切り替えました
- 各カード項目をフレックスレイアウトに変更し、中央揃えの表示バランスを維持しました

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d76f823c10832a88e011bbc6e0ab1e