### PR TITLE
スタンバイ画面のプレイヤー入力欄を横並びに配置

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -427,6 +427,8 @@ p {
 .standby__players {
   display: grid;
   gap: clamp(1rem, 3.5vh, 1.25rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: start;
 }
 
 .standby-player {


### PR DESCRIPTION
## 概要
- スタンバイ画面のプレイヤー名入力欄にグリッドの列指定を追加し、横並びで表示されるように調整しました
- 自動折り返しが効く最小幅を設定し、画面幅に応じてレイアウトが崩れないようにしています

## テスト
- 未実施

------
https://chatgpt.com/codex/tasks/task_e_68d7703ae6c4832aa1e3ceb65030b7c5