### PR TITLE
バックステージ判定ポップアップの追加とゲート操作の整理

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -37,9 +37,12 @@ export const INTERMISSION_BACKSTAGE_REVEAL_GUARD_MESSAGE =
   'バックステージアクションを実行できる状態ではありません。';
 export const INTERMISSION_BACKSTAGE_PENDING_MESSAGE =
   'バックステージアクションを実行するか、スキップしてください。';
-export const INTERMISSION_BACKSTAGE_RESULT_MATCH = '一致！セットのカードとペアが成立しました。';
+export const INTERMISSION_BACKSTAGE_RESULT_MATCH = '一致！セットのカードとペアが成立しました。ステージに配置しました。';
 export const INTERMISSION_BACKSTAGE_RESULT_MISMATCH =
   '一致しませんでした。さらに1枚を手札に加えてください。';
+export const INTERMISSION_BACKSTAGE_RESULT_TITLE = 'バックステージ判定';
+export const INTERMISSION_BACKSTAGE_RESULT_MATCH_OK_LABEL = 'インターミッションへ';
+export const INTERMISSION_BACKSTAGE_RESULT_MISMATCH_OK_LABEL = 'バックステージから取得へ';
 export const INTERMISSION_BACKSTAGE_DRAW_TITLE = 'バックステージから取得';
 export const INTERMISSION_BACKSTAGE_DRAW_MESSAGE = '手札に加えるカードを選んでください（非公開）';
 export const INTERMISSION_BACKSTAGE_DRAW_EMPTY_MESSAGE =


### PR DESCRIPTION
## Summary
- バックステージゲートからインターミッション向けの補助操作を排除して処理の混同を防止
- バックステージ公開後の結果をモーダルで通知し、ペア成立時は配置完了、未成立時は取得処理へ誘導
- 判定モーダル用の文言を整備し、ペア成立メッセージにステージ配置を明記

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d773ac5d28832abb9862a89a6eb4f2