### PR TITLE
Fix spotlight set confirm back navigation

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3336,6 +3336,17 @@ const openSpotlightSetConfirmDialog = (setCardId: string): void => {
       {
         label: SPOTLIGHT_SET_CONFIRM_CANCEL_LABEL,
         variant: 'ghost',
+        dismiss: false,
+        onSelect: () => {
+          const activePlayer = gameStore.getState().activePlayer;
+          modal.close();
+          if (!activePlayer) {
+            return;
+          }
+          window.setTimeout(() => {
+            openSpotlightSetPickerDialog(activePlayer);
+          }, 0);
+        },
       },
       {
         label: SPOTLIGHT_SET_CONFIRM_OK_LABEL,


### PR DESCRIPTION
## Summary
- スポットライトのセット確認ダイアログで「戻る」を選ぶとカード一覧へ戻るように修正しました

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d774e37af4832aadb517f7572a3b68