### PR TITLE
fix: リロード時にセーブデータを復元する

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import {
   deleteResult,
   getSavedGameMetadata,
   listResultHistory,
+  loadGame,
   ResultHistoryEntry,
   saveGame,
   saveResult,
@@ -6411,7 +6412,22 @@ const initializeApp = (): void => {
 
   buildRouteDefinitions(router).forEach((definition) => router.register(definition));
 
-  gameStore.setState(createInitialState());
+  const initialState: GameState = (() => {
+    try {
+      const payload = loadGame({
+        allowUnsafe: true,
+        currentPath: typeof window !== 'undefined' ? window.location.hash ?? null : null,
+      });
+      if (payload?.state) {
+        return payload.state;
+      }
+    } catch (error) {
+      console.warn('セーブデータの復元に失敗したため、新しいゲームを開始します。', error);
+    }
+    return createInitialState();
+  })();
+
+  gameStore.setState(initialState);
 
   router.subscribe((path) => {
     const current = gameStore.getState();


### PR DESCRIPTION
## Summary
- アプリ初期化時に localStorage からセーブデータを読み込み、復元できた場合はその状態でゲームを再開するように変更しました。
- セーブデータの解析に失敗したときは警告を記録したうえで新しいゲームを開始するフォールバックを追加しました。

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d775ac2c58832aabd64a4130d79e7f