### PR TITLE
Align spotlight set selection layout with action view

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3197,6 +3197,32 @@ const requestSpotlightSecretPair = (
   }
 };
 
+interface SpotlightPickerLayout {
+  container: HTMLDivElement;
+  panel: HTMLDivElement;
+}
+
+const createSpotlightPickerLayout = (title: string): SpotlightPickerLayout => {
+  const container = document.createElement('div');
+  container.className = 'spotlight-set-picker';
+
+  const panel = document.createElement('div');
+  panel.className = 'spotlight-set-picker__panel';
+
+  const header = document.createElement('div');
+  header.className = 'spotlight-set-picker__header';
+
+  const heading = document.createElement('h2');
+  heading.className = 'spotlight-set-picker__title';
+  heading.textContent = title;
+
+  header.append(heading);
+  panel.append(header);
+  container.append(panel);
+
+  return { container, panel };
+};
+
 const openSpotlightSetPickerDialog = (playerId: PlayerId): void => {
   if (typeof window === 'undefined') {
     return;
@@ -3216,19 +3242,18 @@ const openSpotlightSetPickerDialog = (playerId: PlayerId): void => {
   const playerName = getPlayerDisplayName(state, playerId);
   const availableCards = shuffleCards(getAvailableSpotlightSetCards(state));
 
-  const container = document.createElement('div');
-  container.className = 'spotlight-set-picker';
+  const { container, panel } = createSpotlightPickerLayout(SPOTLIGHT_SET_PICKER_TITLE);
 
   const message = document.createElement('p');
   message.className = 'spotlight-set-picker__message';
   message.textContent = `${playerName}のターンです。${SPOTLIGHT_SET_PICKER_MESSAGE}`;
-  container.append(message);
+  panel.append(message);
 
   if (availableCards.length === 0) {
     const empty = document.createElement('p');
     empty.className = 'spotlight-set-picker__empty';
     empty.textContent = SPOTLIGHT_SET_PICKER_EMPTY_MESSAGE;
-    container.append(empty);
+    panel.append(empty);
   } else {
     const list = document.createElement('ul');
     list.className = 'spotlight-set-picker__list';
@@ -3265,7 +3290,7 @@ const openSpotlightSetPickerDialog = (playerId: PlayerId): void => {
       list.append(item);
     });
 
-    container.append(list);
+    panel.append(list);
   }
 
   modal.open({
@@ -3374,19 +3399,18 @@ const openSpotlightJokerBonusDialog = (jokerReveal: SetReveal, playerName: strin
   const state = gameStore.getState();
   const availableCards = shuffleCards(getAvailableSpotlightSetCards(state));
 
-  const container = document.createElement('div');
-  container.className = 'spotlight-set-picker';
+  const { container, panel } = createSpotlightPickerLayout(SPOTLIGHT_JOKER_BONUS_TITLE);
 
   const message = document.createElement('p');
   message.className = 'spotlight-set-picker__message';
   message.textContent = SPOTLIGHT_JOKER_BONUS_MESSAGE(playerName);
-  container.append(message);
+  panel.append(message);
 
   if (availableCards.length === 0) {
     const empty = document.createElement('p');
     empty.className = 'spotlight-set-picker__empty';
     empty.textContent = SPOTLIGHT_JOKER_BONUS_EMPTY_MESSAGE;
-    container.append(empty);
+    panel.append(empty);
 
     modal.open({
       title: SPOTLIGHT_JOKER_BONUS_TITLE,
@@ -3416,7 +3440,7 @@ const openSpotlightJokerBonusDialog = (jokerReveal: SetReveal, playerName: strin
   const prompt = document.createElement('p');
   prompt.className = 'spotlight-set-picker__empty';
   prompt.textContent = SPOTLIGHT_JOKER_BONUS_MULTI_PROMPT;
-  container.append(prompt);
+  panel.append(prompt);
 
   const list = document.createElement('ul');
   list.className = 'spotlight-set-picker__list';
@@ -3453,7 +3477,7 @@ const openSpotlightJokerBonusDialog = (jokerReveal: SetReveal, playerName: strin
     list.append(item);
   });
 
-  container.append(list);
+  panel.append(list);
 
   modal.open({
     title: SPOTLIGHT_JOKER_BONUS_TITLE,
@@ -3798,19 +3822,18 @@ const openSpotlightSecretPairDialog = (request: SpotlightSecretPairRequest): voi
     return;
   }
 
-  const container = document.createElement('div');
-  container.className = 'spotlight-set-picker';
+  const { container, panel } = createSpotlightPickerLayout(SPOTLIGHT_SECRET_PAIR_TITLE);
 
   const message = document.createElement('p');
   message.className = 'spotlight-set-picker__message';
   message.textContent = SPOTLIGHT_SECRET_PAIR_MESSAGE(playerName, openCardLabel);
-  container.append(message);
+  panel.append(message);
 
   if (candidates.length === 0) {
     const empty = document.createElement('p');
     empty.className = 'spotlight-set-picker__empty';
     empty.textContent = SPOTLIGHT_SECRET_PAIR_EMPTY_MESSAGE;
-    container.append(empty);
+    panel.append(empty);
   } else {
     const list = document.createElement('ul');
     list.className = 'spotlight-set-picker__list';
@@ -3847,7 +3870,7 @@ const openSpotlightSecretPairDialog = (request: SpotlightSecretPairRequest): voi
       list.append(item);
     });
 
-    container.append(list);
+    panel.append(list);
   }
 
   modal.open({

--- a/src/views/action.ts
+++ b/src/views/action.ts
@@ -111,7 +111,7 @@ export const createActionView = (options: ActionViewOptions): ActionViewElement 
   handList.setAttribute('aria-label', handTitle.textContent);
   hand.append(handList);
 
-  section.append(hand);
+  main.append(hand);
 
   let currentCards = options.handCards.slice();
   let currentSelection = createInitialSelection(options);

--- a/styles/base.css
+++ b/styles/base.css
@@ -256,11 +256,6 @@
 
   .action-view {
     --action-padding-x: clamp(1rem, 5vw, 1.5rem);
-    --action-hand-height: clamp(7rem, 20vh, 9rem);
-  }
-
-  .action-hand {
-    margin: clamp(1.25rem, min(4vw, 5vh), 2rem) calc(var(--action-padding-x) * -1) 0;
   }
 
   .action-hand__header {
@@ -270,6 +265,7 @@
   }
 
   .action-hand__list {
+    grid-auto-columns: minmax(96px, 1fr);
     gap: clamp(0.5rem, 4vw, 0.85rem);
   }
 
@@ -961,7 +957,6 @@ p {
 
 .action-view {
   --action-padding-x: clamp(1.25rem, min(3vw, 4vh), 2.25rem);
-  --action-hand-height: clamp(8.5rem, 18vh, 10.5rem);
   --action-actor-color: var(--color-accent);
   --action-actor-shadow: rgba(251, 191, 36, 0.18);
   --action-kuroko-color: #38bdf8;
@@ -970,15 +965,18 @@ p {
   min-height: var(--viewport-height);
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: center;
   padding: var(--action-padding-x);
-  padding-bottom: calc(var(--action-padding-x) + var(--action-hand-height));
 }
 
 .action {
   flex: 1 1 auto;
-  display: flex;
-  flex-direction: column;
+  width: min(960px, 100%);
+  display: grid;
   gap: clamp(1.25rem, min(3vw, 5vh), 1.85rem);
+  align-content: center;
+  justify-items: stretch;
 }
 
 .action__header {
@@ -1021,17 +1019,17 @@ p {
 }
 
 .action-hand {
-  position: sticky;
-  bottom: 0;
-  margin: clamp(1.5rem, min(4vw, 5vh), 2.25rem) calc(var(--action-padding-x) * -1) 0;
-  padding: clamp(1rem, 3.5vh, 1.25rem) var(--action-padding-x)
-    clamp(calc(var(--action-padding-x) - 0.5rem), 2vh, calc(var(--action-padding-x) - 0.15rem));
-  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  width: 100%;
+  margin: 0;
+  padding: clamp(1.25rem, 3.5vh, 1.75rem) clamp(1.5rem, 4vw, 2.25rem);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 28px;
   background:
-    linear-gradient(180deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.98)), rgba(15, 23, 42, 0.92);
-  box-shadow: 0 -18px 48px rgba(15, 23, 42, 0.6);
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.98)), rgba(15, 23, 42, 0.92);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.5);
   backdrop-filter: blur(14px);
-  z-index: 5;
+  display: grid;
+  gap: clamp(0.75rem, min(3vw, 4vh), 1.1rem);
 }
 
 .action-hand__header {
@@ -1039,7 +1037,7 @@ p {
   align-items: baseline;
   justify-content: space-between;
   gap: clamp(0.5rem, 2vw, 0.85rem);
-  margin-bottom: clamp(0.5rem, 2.5vh, 0.75rem);
+  margin: 0;
 }
 
 .action-hand__title {
@@ -1055,8 +1053,13 @@ p {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
+  display: grid;
+  grid-template-rows: repeat(2, auto);
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(clamp(104px, 15vw, 140px), 1fr);
   gap: clamp(0.65rem, min(1.5vw, 2.5vh), 1.1rem);
+  justify-items: center;
+  align-items: start;
   overflow-x: auto;
   padding-bottom: 0.25rem;
   scroll-snap-type: x proximity;
@@ -2426,8 +2429,40 @@ p {
 }
 
 .spotlight-set-picker {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.spotlight-set-picker__panel {
+  width: min(100%, 720px);
+  padding: clamp(1.25rem, 3.5vh, 1.75rem) clamp(1.5rem, 4vw, 2.25rem);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.98)),
+    rgba(15, 23, 42, 0.92);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(14px);
   display: grid;
-  gap: 1.25rem;
+  gap: clamp(0.75rem, min(3vw, 4vh), 1.1rem);
+}
+
+.spotlight-set-picker__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: clamp(0.5rem, 2vw, 0.85rem);
+}
+
+.spotlight-set-picker__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  text-align: center;
 }
 
 .spotlight-set-picker__message,
@@ -2442,14 +2477,39 @@ p {
   margin: 0;
   padding: 0;
   list-style: none;
+  width: 100%;
   display: grid;
-  gap: clamp(0.75rem, 1.5vw, 1.25rem);
-  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  grid-template-rows: repeat(2, auto);
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(clamp(96px, 16vw, 140px), 1fr);
+  gap: clamp(0.65rem, min(1.5vw, 2.5vh), 1.1rem);
+  justify-items: center;
+  align-items: start;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
+  scroll-snap-type: x proximity;
+}
+
+.spotlight-set-picker__list::-webkit-scrollbar {
+  height: 6px;
+}
+
+.spotlight-set-picker__list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.spotlight-set-picker__list::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
 }
 
 .spotlight-set-picker__item {
+  position: relative;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  scroll-snap-align: start;
 }
 
 .spotlight-set-picker__button {


### PR DESCRIPTION
## Summary
- refactor spotlight set and secret pair dialogs to share a centered picker layout helper
- restyle the spotlight set picker panel to mirror the action hand presentation with a two-row card grid

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d772c47940832a90c1869ec80f19eb