### PR TITLE
バックステージゲートにカード選択UIを直接表示

### DIFF
--- a/src/views/gate.ts
+++ b/src/views/gate.ts
@@ -22,6 +22,7 @@ export interface GateViewOptions {
   lockDuration?: number;
   onGatePass?: () => void;
   actions?: GateViewAction[];
+  content?: HTMLElement | null;
 }
 
 const createTextParagraph = (content: string): HTMLParagraphElement => {
@@ -94,6 +95,10 @@ export const createGateView = (options: GateViewOptions): HTMLElement => {
   const hints = renderHintList(options.hints);
   if (hints) {
     main.append(hints);
+  }
+
+  if (options.content) {
+    main.append(options.content);
   }
 
   const actions = renderActions(options.actions);

--- a/styles/base.css
+++ b/styles/base.css
@@ -2345,6 +2345,13 @@ p {
   justify-items: center;
 }
 
+.intermission-backstage__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-align: center;
+}
+
 .intermission-backstage__message,
 .intermission-backstage__instruction {
   margin: 0;
@@ -2426,6 +2433,16 @@ p {
 .intermission-backstage__label {
   font-size: 0.9rem;
   font-weight: 600;
+}
+
+.intermission-backstage__actions {
+  display: flex;
+  gap: clamp(0.75rem, 1.5vw, 1rem);
+  justify-content: center;
+}
+
+.intermission-backstage__actions .button {
+  min-width: clamp(8rem, 18vw, 10rem);
 }
 
 .spotlight-set-picker {


### PR DESCRIPTION
## Summary
- バックステージゲートにカード一覧とスキップ操作を直接配置し、モーダルを経由せずにアクションを完了できるようにしました
- ゲートビューがカスタムコンテンツを受け取れるようにし、バックステージ用パネルを描画します
- 新しいインラインパネル向けのスタイルを追加し、見出しと操作行を整えました

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d7791b3c00832a8d03dc1145797cee