### PR TITLE
Expand spotlight set picker width

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -2454,7 +2454,7 @@ p {
 }
 
 .spotlight-set-picker__panel {
-  width: min(100%, 720px);
+  width: min(100%, 840px);
   padding: clamp(1.25rem, 3.5vh, 1.75rem) clamp(1.5rem, 4vw, 2.25rem);
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 28px;


### PR DESCRIPTION
## Summary
- セットオープン用のスポットライトカード選択パネルの最大幅を拡張

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d77efabc1c832aabf79e62e979cca2