### PR TITLE
バックステージ公開フローを段階化してUIを整理

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -39,15 +39,34 @@ export const INTERMISSION_BACKSTAGE_PENDING_MESSAGE =
   'バックステージアクションを実行するか、スキップしてください。';
 export const INTERMISSION_BACKSTAGE_RESULT_MATCH = '一致！セットのカードとペアが成立しました。ステージに配置しました。';
 export const INTERMISSION_BACKSTAGE_RESULT_MISMATCH =
-  '一致しませんでした。さらに1枚を手札に加えてください。';
+  '一致しませんでした。バックステージからカードを引いてください。';
 export const INTERMISSION_BACKSTAGE_RESULT_TITLE = 'バックステージ判定';
 export const INTERMISSION_BACKSTAGE_RESULT_MATCH_OK_LABEL = 'インターミッションへ';
-export const INTERMISSION_BACKSTAGE_RESULT_MISMATCH_OK_LABEL = 'バックステージから取得へ';
+export const INTERMISSION_BACKSTAGE_RESULT_MISMATCH_OK_LABEL = 'OK';
 export const INTERMISSION_BACKSTAGE_DRAW_TITLE = 'バックステージから取得';
 export const INTERMISSION_BACKSTAGE_DRAW_MESSAGE = '手札に加えるカードを選んでください（非公開）';
 export const INTERMISSION_BACKSTAGE_DRAW_EMPTY_MESSAGE =
   'これ以上取得できるカードはありません。';
 export const INTERMISSION_BACKSTAGE_COMPLETE_MESSAGE = 'バックステージアクションを完了しました。';
+
+export const INTERMISSION_BACKSTAGE_DECIDE_LABEL = '決定';
+export const INTERMISSION_BACKSTAGE_CONFIRM_MESSAGE = 'このカードにしますか？';
+export const INTERMISSION_BACKSTAGE_CONFIRM_OK_LABEL = 'OK';
+export const INTERMISSION_BACKSTAGE_CONFIRM_CANCEL_LABEL = '戻る';
+export const INTERMISSION_BACKSTAGE_PREVIEW_TITLE = 'カードの最終確認';
+export const INTERMISSION_BACKSTAGE_PREVIEW_MESSAGE =
+  '直前に公開されたカードと選択したカードを確認してください。';
+export const INTERMISSION_BACKSTAGE_PREVIEW_CONFIRM_LABEL = 'カードを確認';
+export const INTERMISSION_BACKSTAGE_REVEAL_READY_TITLE = 'カードをオープン';
+export const INTERMISSION_BACKSTAGE_REVEAL_READY_MESSAGE = 'カードをオープンします。';
+export const INTERMISSION_BACKSTAGE_REVEAL_READY_OK_LABEL = 'OK';
+export const INTERMISSION_BACKSTAGE_RESULT_MISMATCH_INSTRUCTION = 'バックステージからカードを引いてください。';
+export const INTERMISSION_BACKSTAGE_STAGE_MOVE_MESSAGE = (playerName: string): string =>
+  `${playerName}のステージに移動します。`;
+export const INTERMISSION_BACKSTAGE_DRAW_DECIDE_LABEL = '決定';
+export const INTERMISSION_BACKSTAGE_DRAW_CONFIRM_TITLE = 'カードを取得しました';
+export const INTERMISSION_BACKSTAGE_DRAW_CONFIRM_MESSAGE = (cardLabel: string): string =>
+  `${cardLabel}を手札に加えました。`;
 
 export const BACKSTAGE_GATE_TITLE = 'バックステージ';
 export const BACKSTAGE_GATE_CONFIRM_LABEL = 'インターミッションへ';

--- a/styles/base.css
+++ b/styles/base.css
@@ -2418,6 +2418,17 @@ p {
   opacity: 0.65;
 }
 
+.intermission-backstage__button--selected {
+  border-color: rgba(251, 191, 36, 0.55);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: 0 16px 36px rgba(251, 191, 36, 0.22);
+}
+
+.intermission-backstage__button--selected .intermission-backstage__card {
+  border-color: rgba(251, 191, 36, 0.55);
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.35);
+}
+
 .intermission-backstage__card {
   width: clamp(72px, 15vw, 100px);
   height: clamp(104px, 21vw, 140px);
@@ -2437,10 +2448,24 @@ p {
   font-weight: 600;
 }
 
+.intermission-backstage__card-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  text-align: center;
+}
+
 .intermission-backstage__actions {
   display: flex;
   gap: clamp(0.75rem, 1.5vw, 1rem);
   justify-content: center;
+}
+
+.intermission-backstage__note {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  text-align: center;
 }
 
 .intermission-backstage__actions .button {


### PR DESCRIPTION
## Summary
- バックステージ公開処理を選択→確認→公開→判定の段階に分割し、各モーダルの文言を整理しました
- 不一致時の取得フローをカード選択＋決定ボタン方式に変更し、取得カードの確認モーダルを追加しました
- 新しいフローに合わせたメッセージ定数とハイライト用スタイルを追加しました

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d78141e38c832a842f274c9de56bc6