### PR TITLE
Adjust backstage popup layout

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -2342,9 +2342,10 @@ p {
 }
 
 .intermission-backstage {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: clamp(1rem, 2.5vh, 1.5rem);
-  justify-items: center;
+  align-items: stretch;
 }
 
 .intermission-backstage__title {


### PR DESCRIPTION
## Summary
- バックステージアクションのポップアップレイアウトを縦並びに切り替え、テキストの下にカード一覧が表示されるようにしました。

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d789cf8ba0832a8bcc3aaac0218742