### PR TITLE
feat: expand spotlight set picker width

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -2479,7 +2479,7 @@ p {
 }
 
 .spotlight-set-picker__panel {
-  width: min(100%, 840px);
+  width: min(100%, 1680px);
   padding: clamp(1.25rem, 3.5vh, 1.75rem) clamp(1.5rem, 4vw, 2.25rem);
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 28px;


### PR DESCRIPTION
## Summary
- double the maximum width of the spotlight set picker panel so more cards fit without scrolling as quickly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d789ec1fa0832a9460fca26d355399