### PR TITLE
Adjust action hand list padding to prevent clipping

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -1052,7 +1052,7 @@ p {
 .action-hand__list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 clamp(0.65rem, min(1.5vw, 2.5vh), 1.1rem) 0.25rem;
   display: grid;
   grid-template-rows: repeat(2, auto);
   grid-auto-flow: column;
@@ -1063,8 +1063,8 @@ p {
   align-items: start;
   align-content: start;
   overflow-x: auto;
-  padding-bottom: 0.25rem;
   scroll-snap-type: x proximity;
+  scroll-padding-inline: clamp(0.65rem, min(1.5vw, 2.5vh), 1.1rem);
 }
 
 .action-hand__list::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- add horizontal padding to the action phase hand list so the first card remains visible
- configure scroll padding to keep snapped items fully in view

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d78bf538e8832a89a9b9a7399fe4ba