### PR TITLE
fix: expand spotlight set picker modal

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3674,6 +3674,7 @@ const openSpotlightSetPickerDialog = (playerId: PlayerId): void => {
   modal.open({
     title: SPOTLIGHT_SET_PICKER_TITLE,
     body: container,
+    className: 'modal--spotlight-set-picker',
     dismissible: false,
     actions: [
       {
@@ -3804,6 +3805,7 @@ const openSpotlightJokerBonusDialog = (jokerReveal: SetReveal, playerName: strin
     modal.open({
       title: SPOTLIGHT_JOKER_BONUS_TITLE,
       body: container,
+      className: 'modal--spotlight-set-picker',
       dismissible: false,
       actions: [
         {
@@ -3871,6 +3873,7 @@ const openSpotlightJokerBonusDialog = (jokerReveal: SetReveal, playerName: strin
   modal.open({
     title: SPOTLIGHT_JOKER_BONUS_TITLE,
     body: container,
+    className: 'modal--spotlight-set-picker',
     dismissible: false,
     actions: [],
   });
@@ -4265,6 +4268,7 @@ const openSpotlightSecretPairDialog = (request: SpotlightSecretPairRequest): voi
   modal.open({
     title: SPOTLIGHT_SECRET_PAIR_TITLE,
     body: container,
+    className: 'modal--spotlight-set-picker',
     dismissible: false,
     actions: [
       {

--- a/styles/base.css
+++ b/styles/base.css
@@ -1670,6 +1670,26 @@ p {
   max-height: none;
 }
 
+.modal--spotlight-set-picker {
+  width: min(calc(1680px + 3rem), calc(100vw - 3rem));
+  max-height: calc(100vh - 3rem);
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+}
+
+.modal--spotlight-set-picker .modal__body {
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  overflow: auto;
+}
+
+.modal--spotlight-set-picker .modal__body > .spotlight-set-picker {
+  width: 100%;
+}
+
 .modal__title {
   font-size: clamp(1.25rem, 1.6vw + 1rem, 1.75rem);
   margin-bottom: 1rem;
@@ -2479,7 +2499,7 @@ p {
 }
 
 .spotlight-set-picker__panel {
-  width: min(100%, 840px);
+  width: min(100%, 1680px);
   padding: clamp(1.25rem, 3.5vh, 1.75rem) clamp(1.5rem, 4vw, 2.25rem);
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 28px;
@@ -3078,6 +3098,12 @@ p {
   .modal--board-check {
     width: min(960px, calc(100vw - 1.5rem));
     max-height: calc(100vh - 1.5rem);
+  }
+
+  .modal--spotlight-set-picker {
+    width: calc(100vw - 1.5rem);
+    max-height: calc(100vh - 1.5rem);
+    padding: 1.25rem;
   }
 
   .toast {


### PR DESCRIPTION
## Summary
- add a dedicated wide modal layout so the spotlight set picker panel can grow to its intended width
- apply the wide modal layout to all spotlight set, joker bonus, and secret pair dialogs
- tweak responsive behaviour to keep the dialog usable on smaller screens

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d789ec1fa0832a9460fca26d355399