### PR TITLE
バックステージフェーズのビューを実装

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6122,7 +6122,20 @@ const ROUTES: RouteDescriptor[] = [
       confirmLabel: BACKSTAGE_GATE_CONFIRM_LABEL,
       resolveMessage: () => BACKSTAGE_GATE_MESSAGE,
       resolveSubtitle: (state) => createBackstageGateSubtitle(state),
-      resolveActions: () => [
+      resolveActions: ({ router }) => [
+        {
+          label: INTERMISSION_BACKSTAGE_ACTION_LABEL,
+          preventRapid: true,
+          onSelect: () => {
+            const latestState = gameStore.getState();
+            if (!shouldEnterBackstagePhase(latestState)) {
+              showIntermissionBackstageGuard(INTERMISSION_BACKSTAGE_REVEAL_GUARD_MESSAGE);
+              return;
+            }
+
+            router.go(BACKSTAGE_PHASE_PATH);
+          },
+        },
         {
           label: INTERMISSION_BOARD_CHECK_LABEL,
           variant: 'ghost',

--- a/src/views/backstage.ts
+++ b/src/views/backstage.ts
@@ -1,0 +1,275 @@
+import { UIButton } from '../ui/button.js';
+import { CardComponent, type CardSuit } from '../ui/card.js';
+
+export interface BackstageRevealItemViewModel {
+  id: string;
+  order: number;
+  rank: string;
+  suit: CardSuit;
+  annotation?: string | null;
+}
+
+export interface BackstageViewContent {
+  hasAction: boolean;
+  message: string;
+  instruction?: string | null;
+  items: BackstageRevealItemViewModel[];
+}
+
+export interface BackstageViewOptions {
+  title: string;
+  subtitle: string;
+  content: BackstageViewContent;
+  notes?: string[];
+  confirmLabel: string;
+  skipLabel: string;
+  revealLabel: string;
+  boardCheckLabel?: string;
+  summaryLabel?: string;
+  onConfirmSelection?: (itemId: string) => void;
+  onSkip?: () => void;
+  onOpenBoardCheck?: () => void;
+  onOpenSummary?: () => void;
+}
+
+export interface BackstageViewElement extends HTMLElement {
+  updateSubtitle: (subtitle: string) => void;
+  updateContent: (content: BackstageViewContent) => void;
+  updateNotes: (notes: string[]) => void;
+}
+
+const CARD_ORDER_LABEL = (order: number): string => `カード ${String(order).padStart(2, '0')}`;
+
+const createBackstageRevealListItem = (
+  item: BackstageRevealItemViewModel,
+  revealLabel: string,
+  onSelect: (itemId: string) => void,
+): HTMLLIElement => {
+  const listItem = document.createElement('li');
+  listItem.className = 'intermission-backstage__item';
+  listItem.dataset.itemId = item.id;
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'intermission-backstage__button';
+  button.dataset.itemId = item.id;
+  button.addEventListener('click', () => onSelect(item.id));
+  button.setAttribute('aria-label', `${revealLabel}：${CARD_ORDER_LABEL(item.order)}`);
+
+  const cardComponent = new CardComponent({
+    rank: item.rank,
+    suit: item.suit,
+    faceDown: true,
+    annotation: item.annotation ?? undefined,
+  });
+  cardComponent.el.classList.add('intermission-backstage__card');
+  button.append(cardComponent.el);
+
+  const label = document.createElement('span');
+  label.className = 'intermission-backstage__label';
+  label.textContent = CARD_ORDER_LABEL(item.order);
+  button.append(label);
+
+  listItem.append(button);
+  return listItem;
+};
+
+export const createBackstageView = (options: BackstageViewOptions): BackstageViewElement => {
+  const section = document.createElement('section');
+  section.className = 'view backstage-view';
+
+  const main = document.createElement('main');
+  main.className = 'backstage';
+  section.append(main);
+
+  const header = document.createElement('header');
+  header.className = 'backstage__header';
+  main.append(header);
+
+  const heading = document.createElement('h1');
+  heading.className = 'backstage__title';
+  heading.id = 'backstage-view-title';
+  heading.textContent = options.title;
+  header.append(heading);
+  main.setAttribute('aria-labelledby', heading.id);
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'backstage__subtitle';
+  subtitle.textContent = options.subtitle;
+  header.append(subtitle);
+
+  const headerActions = document.createElement('div');
+  headerActions.className = 'backstage__header-actions';
+
+  if (options.onOpenBoardCheck) {
+    const boardCheckButton = new UIButton({
+      label: options.boardCheckLabel ?? 'ボードチェック',
+      variant: 'ghost',
+      preventRapid: true,
+    });
+    boardCheckButton.el.classList.add('backstage__header-button');
+    boardCheckButton.onClick(() => options.onOpenBoardCheck?.());
+    headerActions.append(boardCheckButton.el);
+  }
+
+  if (options.onOpenSummary) {
+    const summaryButton = new UIButton({
+      label: options.summaryLabel ?? '前ラウンド要約',
+      variant: 'ghost',
+      preventRapid: true,
+    });
+    summaryButton.el.classList.add('backstage__header-button');
+    summaryButton.onClick(() => options.onOpenSummary?.());
+    headerActions.append(summaryButton.el);
+  }
+
+  if (headerActions.childElementCount > 0) {
+    header.append(headerActions);
+  }
+
+  const body = document.createElement('section');
+  body.className = 'backstage__body';
+  main.append(body);
+
+  const contentContainer = document.createElement('section');
+  contentContainer.className = 'intermission-backstage';
+  body.append(contentContainer);
+
+  const contentTitle = document.createElement('h2');
+  contentTitle.className = 'intermission-backstage__title';
+  contentTitle.textContent = options.title;
+  contentContainer.append(contentTitle);
+
+  const message = document.createElement('p');
+  message.className = 'intermission-backstage__message';
+  contentContainer.append(message);
+
+  const instruction = document.createElement('p');
+  instruction.className = 'intermission-backstage__instruction';
+  contentContainer.append(instruction);
+
+  const list = document.createElement('ul');
+  list.className = 'intermission-backstage__list';
+  contentContainer.append(list);
+
+  const actions = document.createElement('div');
+  actions.className = 'intermission-backstage__actions';
+  contentContainer.append(actions);
+
+  const confirmButton = new UIButton({
+    label: options.confirmLabel,
+    preventRapid: true,
+    disabled: true,
+  });
+  actions.append(confirmButton.el);
+
+  const skipButton = new UIButton({
+    label: options.skipLabel,
+    variant: 'ghost',
+    preventRapid: true,
+  });
+  skipButton.onClick(() => options.onSkip?.());
+  actions.append(skipButton.el);
+
+  const notesContainer = document.createElement('div');
+  notesContainer.className = 'backstage__notes';
+  body.append(notesContainer);
+
+  let selectedItemId: string | null = null;
+  let hasAction = options.content.hasAction;
+  const buttonMap = new Map<string, HTMLButtonElement>();
+
+  const updateSelection = (itemId: string | null) => {
+    selectedItemId = itemId;
+    buttonMap.forEach((button, id) => {
+      button.classList.toggle('intermission-backstage__button--selected', id === itemId);
+    });
+    confirmButton.setDisabled(!itemId || !hasAction);
+  };
+
+  const rebuildList = (items: BackstageRevealItemViewModel[]): void => {
+    buttonMap.clear();
+    list.replaceChildren();
+
+    items.forEach((item) => {
+      const listItem = createBackstageRevealListItem(item, options.revealLabel, (itemId) => {
+        const nextId = selectedItemId === itemId ? null : itemId;
+        updateSelection(nextId);
+      });
+      list.append(listItem);
+      const button = listItem.querySelector<HTMLButtonElement>('button');
+      if (button) {
+        buttonMap.set(item.id, button);
+      }
+    });
+
+    if (!items.some((item) => item.id === selectedItemId)) {
+      updateSelection(null);
+    }
+  };
+
+  confirmButton.onClick(() => {
+    if (!selectedItemId) {
+      return;
+    }
+    options.onConfirmSelection?.(selectedItemId);
+    updateSelection(null);
+  });
+
+  const applyContent = (content: BackstageViewContent): void => {
+    hasAction = content.hasAction;
+    message.textContent = content.message;
+
+    if (content.hasAction && content.instruction) {
+      instruction.hidden = false;
+      instruction.textContent = content.instruction ?? '';
+    } else {
+      instruction.hidden = true;
+      instruction.textContent = '';
+    }
+
+    rebuildList(content.hasAction ? content.items : []);
+
+    if (content.hasAction) {
+      list.hidden = false;
+      confirmButton.el.hidden = false;
+      confirmButton.el.removeAttribute('aria-hidden');
+      confirmButton.setDisabled(!selectedItemId);
+    } else {
+      list.hidden = true;
+      confirmButton.el.hidden = true;
+      confirmButton.el.setAttribute('aria-hidden', 'true');
+      updateSelection(null);
+    }
+  };
+
+  const applyNotes = (notes: string[]): void => {
+    notesContainer.replaceChildren();
+    if (notes.length === 0) {
+      notesContainer.hidden = true;
+      return;
+    }
+    notesContainer.hidden = false;
+    notes.forEach((noteText) => {
+      const note = document.createElement('p');
+      note.className = 'intermission-backstage__note';
+      note.textContent = noteText;
+      notesContainer.append(note);
+    });
+  };
+
+  applyContent(options.content);
+  applyNotes(options.notes ?? []);
+
+  return Object.assign(section, {
+    updateSubtitle(nextSubtitle: string) {
+      subtitle.textContent = nextSubtitle;
+    },
+    updateContent(nextContent: BackstageViewContent) {
+      applyContent(nextContent);
+    },
+    updateNotes(nextNotes: string[]) {
+      applyNotes(nextNotes);
+    },
+  });
+};

--- a/styles/base.css
+++ b/styles/base.css
@@ -1414,6 +1414,65 @@ p {
   box-shadow: 0 14px 32px rgba(248, 113, 113, 0.25);
 }
 
+.backstage-view {
+  min-height: var(--viewport-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--view-padding-block) var(--view-padding-inline);
+}
+
+.backstage {
+  width: min(720px, 100%);
+  display: grid;
+  gap: var(--panel-gap);
+  padding: var(--panel-padding);
+  border-radius: 32px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.backstage__header {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.backstage__title {
+  margin: 0;
+  font-size: clamp(1.7rem, 2.1vw + 0.95rem, 2.2rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.backstage__subtitle {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.7;
+}
+
+.backstage__header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.backstage__header-button {
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.backstage__body {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.backstage__notes {
+  display: grid;
+  gap: 0.75rem;
+}
+
 .home__subtitle {
   margin: 0;
   color: var(--color-muted);


### PR DESCRIPTION
## Summary
- バックステージフェーズ用のビューを新規作成し、ルート遷移と表示内容を整備しました
- バックステージゲートからフェーズビューへ遷移するよう処理を更新し、ボードチェックなどの操作をゲートからも利用できるようにしました
- 新しいビューに合わせたスタイル定義を追加しました

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d79745555c832a9229cd5dbd587787