### PR TITLE
ボードチェックのセット／バックからペア済みカードを除外

### DIFF
--- a/src/ui/board-check.ts
+++ b/src/ui/board-check.ts
@@ -256,6 +256,7 @@ const renderSetSection = (state: GameState): HTMLDivElement => {
 
   const cardElements: HTMLElement[] = [];
   state.set.opened
+    .filter((reveal) => !reveal.assignedTo)
     .slice()
     .sort((a, b) => a.openedAt - b.openedAt)
     .forEach((reveal) => {
@@ -292,7 +293,9 @@ const renderBackstageSection = (state: GameState): HTMLDivElement => {
     return section;
   }
 
-  const publicItems = items
+  const remainingItems = items.filter((item) => item.stagePairId == null);
+
+  const publicItems = remainingItems
     .filter((item) => item.isPublic)
     .sort((a, b) => {
       const timeDiff = (a.revealedAt ?? Number.MAX_SAFE_INTEGER) - (b.revealedAt ?? Number.MAX_SAFE_INTEGER);
@@ -302,7 +305,7 @@ const renderBackstageSection = (state: GameState): HTMLDivElement => {
       return a.position - b.position;
     });
 
-  const hiddenCount = items.length - publicItems.length;
+  const hiddenCount = remainingItems.length - publicItems.length;
 
   const cardElements: HTMLElement[] = [];
   publicItems.forEach((item) => {


### PR DESCRIPTION
## Summary
- ボードチェックのセット一覧からペア成立済みのセットカードを除外
- バックステージ一覧からステージ上のペアに組み込まれたカードを除外し、秘匿枚数の計算を調整

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7aa2faef4832a9c5cee8d228f76a2