### PR TITLE
バックステージ取得カード通知の改善

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -183,6 +183,7 @@ const {
   INTERMISSION_BACKSTAGE_DRAW_DECIDE_LABEL,
   INTERMISSION_BACKSTAGE_DRAW_CONFIRM_TITLE,
   INTERMISSION_BACKSTAGE_DRAW_CONFIRM_MESSAGE,
+  INTERMISSION_BACKSTAGE_DRAW_RESULT_MESSAGE,
   BACKSTAGE_GATE_TITLE,
   BACKSTAGE_GATE_CONFIRM_LABEL,
   BACKSTAGE_GATE_MESSAGE,
@@ -2482,6 +2483,7 @@ const finalizeBackstageDraw = (itemId: string): BackstageDrawResult | null => {
     const nextItems = latestBackstage.items.slice();
     const cardForHand = cloneCardSnapshot(item.card);
     cardForHand.face = 'down';
+    const cardLabel = formatCardLabel(cardForHand);
 
     nextItems[itemIndex] = {
       ...item,
@@ -2496,6 +2498,8 @@ const finalizeBackstageDraw = (itemId: string): BackstageDrawResult | null => {
       actedThisIntermission: true,
       canActPlayer: latestBackstage.canActPlayer,
       pile: Math.max(0, latestBackstage.pile - 1),
+      lastResult: 'mismatch',
+      lastResultMessage: INTERMISSION_BACKSTAGE_DRAW_RESULT_MESSAGE(cardLabel),
       lastCompletionMessage: INTERMISSION_BACKSTAGE_COMPLETE_MESSAGE,
     };
 
@@ -3046,6 +3050,23 @@ const openBackstageDrawResultDialog = (
   });
 };
 
+const announceBackstageDrawResult = (result: BackstageDrawResult): void => {
+  const message = INTERMISSION_BACKSTAGE_DRAW_RESULT_MESSAGE(formatCardLabel(result.card));
+
+  if (typeof window === 'undefined') {
+    console.info(message);
+    return;
+  }
+
+  const toast = window.curtainCall?.toast;
+  if (toast) {
+    toast.show({ message, variant: 'info' });
+    return;
+  }
+
+  console.info(message);
+};
+
 const startBackstageRevealFlow = (itemId: string): void => {
   if (typeof window === 'undefined') {
     const outcome = finalizeBackstageReveal(itemId);
@@ -3115,6 +3136,7 @@ const openIntermissionBackstageDrawDialog = (): void => {
   if (typeof window === 'undefined') {
     const result = finalizeBackstageDraw(hiddenItems[0].id);
     if (result) {
+      announceBackstageDrawResult(result);
       autoAdvanceFromBackstage();
     }
     return;
@@ -3124,6 +3146,7 @@ const openIntermissionBackstageDrawDialog = (): void => {
   if (!modal) {
     const result = finalizeBackstageDraw(hiddenItems[0].id);
     if (result) {
+      announceBackstageDrawResult(result);
       autoAdvanceFromBackstage();
     }
     return;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -66,7 +66,9 @@ export const INTERMISSION_BACKSTAGE_STAGE_MOVE_MESSAGE = (playerName: string): s
 export const INTERMISSION_BACKSTAGE_DRAW_DECIDE_LABEL = '決定';
 export const INTERMISSION_BACKSTAGE_DRAW_CONFIRM_TITLE = 'カードを取得しました';
 export const INTERMISSION_BACKSTAGE_DRAW_CONFIRM_MESSAGE = (cardLabel: string): string =>
-  `${cardLabel}を手札に加えました。`;
+  `引いたカードは${cardLabel}です。手札に加えました。`;
+export const INTERMISSION_BACKSTAGE_DRAW_RESULT_MESSAGE = (cardLabel: string): string =>
+  `バックステージから${cardLabel}を取得しました。`;
 
 export const BACKSTAGE_GATE_TITLE = 'バックステージ';
 export const BACKSTAGE_GATE_CONFIRM_LABEL = 'バックステージへ';


### PR DESCRIPTION
## Summary
- バックステージでカードを取得した際のポップアップ文言を引いたカード名が分かる内容に変更
- バックステージでカードを取得した結果を状態とトーストに残し、ゲート遷移後も把握しやすく調整

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d7af3736d0832aa3cb20d617c78e47