### PR TITLE
Enable hand modal access in backstage phase

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -362,6 +362,7 @@ const SCOUT_TO_ACTION_PATH = '#/phase/action';
 const INTERMISSION_TO_SCOUT_PATH = '#/phase/scout';
 
 const SCOUT_MY_HAND_LABEL = MY_HAND_LABEL;
+const INTERMISSION_MY_HAND_LABEL = MY_HAND_LABEL;
 const SCOUT_RECENT_TAKEN_HISTORY_LIMIT = 5;
 
 const ACTION_TO_WATCH_PATH = '#/phase/watch/gate';
@@ -6702,10 +6703,12 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
             revealLabel: INTERMISSION_BACKSTAGE_REVEAL_LABEL,
             boardCheckLabel: INTERMISSION_BOARD_CHECK_LABEL,
             summaryLabel: INTERMISSION_SUMMARY_LABEL,
+            myHandLabel: INTERMISSION_MY_HAND_LABEL,
             onConfirmSelection: (itemId) => startBackstageRevealFlow(itemId),
             onSkip: () => completeBackstageSkip(),
             onOpenBoardCheck: () => showBoardCheck(),
             onOpenSummary: () => openIntermissionSummaryDialog(),
+            onOpenMyHand: () => openMyHandDialog(),
           });
 
           const unsubscribe = gameStore.subscribe((nextState) => {

--- a/src/views/backstage.ts
+++ b/src/views/backstage.ts
@@ -26,10 +26,12 @@ export interface BackstageViewOptions {
   revealLabel: string;
   boardCheckLabel?: string;
   summaryLabel?: string;
+  myHandLabel?: string;
   onConfirmSelection?: (itemId: string) => void;
   onSkip?: () => void;
   onOpenBoardCheck?: () => void;
   onOpenSummary?: () => void;
+  onOpenMyHand?: () => void;
 }
 
 export interface BackstageViewElement extends HTMLElement {
@@ -110,6 +112,17 @@ export const createBackstageView = (options: BackstageViewOptions): BackstageVie
     boardCheckButton.el.classList.add('backstage__header-button');
     boardCheckButton.onClick(() => options.onOpenBoardCheck?.());
     headerActions.append(boardCheckButton.el);
+  }
+
+  if (options.onOpenMyHand) {
+    const myHandButton = new UIButton({
+      label: options.myHandLabel ?? '自分の手札',
+      variant: 'ghost',
+      preventRapid: true,
+    });
+    myHandButton.el.classList.add('backstage__header-button');
+    myHandButton.onClick(() => options.onOpenMyHand?.());
+    headerActions.append(myHandButton.el);
   }
 
   if (options.onOpenSummary) {


### PR DESCRIPTION
## Summary
- add an optional "自分の手札" header action to the backstage view
- wire backstage phase routing to pass the label and open the existing hand modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7b14ce114832a95dd20f940d049f3