### PR TITLE
アクション手札のスクロール位置を調整

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -1095,7 +1095,7 @@ p {
   grid-auto-flow: column;
   grid-auto-columns: minmax(clamp(104px, 15vw, 140px), 1fr);
   gap: clamp(0.65rem, min(1.5vw, 2.5vh), 1.1rem);
-  justify-content: center;
+  justify-content: start;
   justify-items: center;
   align-items: start;
   align-content: start;


### PR DESCRIPTION
## Summary
- アクションフェーズの手札リストの配置を先頭揃えに変更し、最後のカードまでスクロールできるように修正

## Testing
- not run (CSS のみ変更)

------
https://chatgpt.com/codex/tasks/task_e_68d7e2ab34e4832aafb31aca594c1de3