### PR TITLE
Add popup preview for matched backstage pairs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2904,6 +2904,51 @@ const createBackstageRevealResultList = (
   return list;
 };
 
+const createBackstageMatchPairView = (
+  revealCard: CardSnapshot,
+  matchedCard: CardSnapshot,
+): HTMLDivElement => {
+  const pairContainer = document.createElement('div');
+  pairContainer.className = 'intermission-backstage__pair';
+
+  const createPairCard = (label: string, card: CardSnapshot): HTMLDivElement => {
+    const item = document.createElement('div');
+    item.className = 'intermission-backstage__pair-card';
+
+    const component = new CardComponent({
+      rank: card.rank,
+      suit: card.suit,
+      faceDown: card.face === 'down',
+      annotation: card.annotation,
+    });
+    component.el.classList.add('intermission-backstage__card');
+    item.append(component.el);
+
+    const caption = document.createElement('p');
+    caption.className = 'intermission-backstage__pair-label';
+    caption.textContent = `${label}：${formatCardLabel(card)}`;
+    item.append(caption);
+
+    return item;
+  };
+
+  const actorCard = cloneCardSnapshot(revealCard);
+  actorCard.face = 'up';
+  const backstageCard = cloneCardSnapshot(matchedCard);
+  backstageCard.face = 'up';
+
+  pairContainer.append(createPairCard('セットカード', actorCard));
+
+  const separator = document.createElement('span');
+  separator.className = 'intermission-backstage__pair-separator';
+  separator.textContent = '×';
+  pairContainer.append(separator);
+
+  pairContainer.append(createPairCard('バックステージカード', backstageCard));
+
+  return pairContainer;
+};
+
 const resolveBackstageRevealContext = (itemIds: string[]): BackstageRevealContext | null => {
   const state = gameStore.getState();
   const backstage = getBackstageState(state);
@@ -3069,6 +3114,11 @@ const openBackstageRevealResultDialog = (
     ? INTERMISSION_BACKSTAGE_RESULT_MATCH
     : INTERMISSION_BACKSTAGE_RESULT_MISMATCH;
   container.append(message);
+
+  const matchedEntry = outcome.revealedCards.find((entry) => entry.matched);
+  if (outcome.matched && matchedEntry) {
+    container.append(createBackstageMatchPairView(outcome.reveal.card, matchedEntry.card));
+  }
 
   container.append(createBackstageRevealResultList(outcome.reveal.card, outcome.revealedCards));
 

--- a/styles/base.css
+++ b/styles/base.css
@@ -2585,6 +2585,36 @@ p {
   text-align: center;
 }
 
+.intermission-backstage__pair {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.intermission-backstage__pair-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 128px;
+}
+
+.intermission-backstage__pair-label {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: center;
+  color: var(--color-text);
+}
+
+.intermission-backstage__pair-separator {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  color: var(--color-accent, var(--color-primary));
+}
+
 .intermission-backstage__actions .button {
   min-width: clamp(8rem, 18vw, 10rem);
 }


### PR DESCRIPTION
## Summary
- show a dedicated popup section when a backstage reveal forms a matched pair
- highlight the paired set and backstage cards with new styling for the modal view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7e34b8b58832ab43b60b5a0f6edaf