### PR TITLE
バックステージ公開ポップアップのカード表示を2段構成に変更

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -2585,6 +2585,37 @@ p {
   text-align: center;
 }
 
+.intermission-backstage__reveal {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+.intermission-backstage__reveal-section {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.5rem, 1vw, 0.75rem);
+  align-items: center;
+}
+
+.intermission-backstage__reveal-label {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.intermission-backstage__reveal-cards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(0.75rem, 1.5vw, 1.25rem);
+}
+
+.intermission-backstage__reveal-card--matched {
+  border-color: rgba(34, 197, 94, 0.65);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.35);
+}
+
 .intermission-backstage__pair {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- バックステージ公開結果モーダルのカード描画をセットと選択カードの2段構成に刷新
- 選択カードの一致時に視覚的な強調を加え、カード自体に説明を含めないデザインへ変更
- 新レイアウトに対応するスタイルを追加

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e9df728c832a9e37f0286a648fef