### PR TITLE
feat: インターミッション画面を整備

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -65,6 +65,10 @@ import {
   type BackstageRevealItemViewModel,
 } from './views/backstage.js';
 import {
+  createIntermissionView,
+  type IntermissionResumeInfo,
+} from './views/intermission.js';
+import {
   createCurtainCallView,
   CurtainCallPlayerSummaryViewModel,
   CurtainCallResultViewModel,
@@ -184,6 +188,18 @@ const {
   INTERMISSION_BACKSTAGE_DRAW_CONFIRM_TITLE,
   INTERMISSION_BACKSTAGE_DRAW_CONFIRM_MESSAGE,
   INTERMISSION_BACKSTAGE_DRAW_RESULT_MESSAGE,
+  INTERMISSION_VIEW_GATE_LABEL,
+  INTERMISSION_VIEW_RESUME_LABEL,
+  INTERMISSION_VIEW_RESUME_TITLE,
+  INTERMISSION_VIEW_RESUME_CAPTION,
+  INTERMISSION_VIEW_RESUME_EMPTY,
+  INTERMISSION_VIEW_RESUME_SAVED_AT_PREFIX,
+  INTERMISSION_VIEW_SUMMARY_TITLE,
+  INTERMISSION_VIEW_NOTES_TITLE,
+  INTERMISSION_TASK_NEXT_PLAYER,
+  INTERMISSION_TASK_REVIEW,
+  INTERMISSION_TASK_RESUME,
+  INTERMISSION_TASK_GATE,
   BACKSTAGE_GATE_TITLE,
   BACKSTAGE_GATE_CONFIRM_LABEL,
   BACKSTAGE_GATE_MESSAGE,
@@ -2228,6 +2244,39 @@ const createIntermissionBackstageNotes = (state: GameState): string[] => {
   }
 
   return notes;
+};
+
+const createIntermissionTasks = (state: GameState): string[] => {
+  const nextPlayerName = getPlayerDisplayName(state, state.activePlayer);
+  return [
+    INTERMISSION_TASK_NEXT_PLAYER(nextPlayerName),
+    INTERMISSION_TASK_REVIEW,
+    INTERMISSION_TASK_RESUME,
+    INTERMISSION_TASK_GATE,
+  ];
+};
+
+const mapIntermissionResumeInfo = (): IntermissionResumeInfo => {
+  const metadata = getSavedGameMetadata();
+
+  if (!metadata) {
+    return {
+      available: false,
+      summary: INTERMISSION_VIEW_RESUME_EMPTY,
+      savedAtLabel: null,
+    };
+  }
+
+  const savedAt = formatResumeTimestamp(metadata.savedAt);
+  const savedAtLabel = savedAt
+    ? `${INTERMISSION_VIEW_RESUME_SAVED_AT_PREFIX}${savedAt}`
+    : null;
+
+  return {
+    available: true,
+    summary: createResumeSummary(metadata.activePlayer, metadata.phase),
+    savedAtLabel,
+  };
 };
 
 const findLatestStagePairForIntermission = (state: GameState): StagePair | null => {
@@ -6132,6 +6181,7 @@ let activeTurnIndicatorCleanup: (() => void) | null = null;
 let activeScoutCleanup: (() => void) | null = null;
 let activeActionCleanup: (() => void) | null = null;
 let activeWatchCleanup: (() => void) | null = null;
+let activeIntermissionCleanup: (() => void) | null = null;
 let activeBackstageCleanup: (() => void) | null = null;
 let activeSpotlightCleanup: (() => void) | null = null;
 let activeCurtainCallCleanup: (() => void) | null = null;
@@ -6175,6 +6225,14 @@ const cleanupActiveWatchView = (): void => {
   }
 };
 
+const cleanupActiveIntermissionView = (): void => {
+  if (activeIntermissionCleanup) {
+    const cleanup = activeIntermissionCleanup;
+    activeIntermissionCleanup = null;
+    cleanup();
+  }
+};
+
 const cleanupActiveBackstageView = (): void => {
   if (activeBackstageCleanup) {
     const cleanup = activeBackstageCleanup;
@@ -6214,6 +6272,7 @@ const withRouteCleanup = (
     cleanupActiveScoutView();
     cleanupActiveActionView();
     cleanupActiveWatchView();
+    cleanupActiveIntermissionView();
     cleanupActiveBackstageView();
     cleanupActiveSpotlightView();
     cleanupActiveCurtainCallView();
@@ -6883,6 +6942,74 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
             revokeSpotlightSecretAccess();
             isSpotlightSecretPairInProgress = false;
             isSpotlightExitInProgress = false;
+          };
+
+          return view;
+        },
+      };
+    } else if (route.path === '#/phase/intermission') {
+      definition = {
+        path: route.path,
+        title: route.title,
+        render: ({ router: contextRouter }) => {
+          const state = gameStore.getState();
+
+          if (shouldEnterBackstagePhase(state)) {
+            if (contextRouter) {
+              contextRouter.go(BACKSTAGE_GATE_PATH);
+            } else {
+              navigateToBackstageGate();
+            }
+
+            return createPlaceholderView({
+              title: route.heading,
+              subtitle: INTERMISSION_BACKSTAGE_PENDING_MESSAGE,
+            });
+          }
+
+          const view = createIntermissionView({
+            title: route.heading,
+            subtitle: createIntermissionGateSubtitle(state),
+            message: createTurnGateMessage(state, INTERMISSION_GATE_CONFIRM_LABEL),
+            tasks: createIntermissionTasks(state),
+            summaryTitle: INTERMISSION_VIEW_SUMMARY_TITLE,
+            summaryContent: createIntermissionSummaryView(state),
+            notesTitle: INTERMISSION_VIEW_NOTES_TITLE,
+            notes: createIntermissionBackstageNotes(state),
+            boardCheckLabel: INTERMISSION_BOARD_CHECK_LABEL,
+            summaryLabel: INTERMISSION_SUMMARY_LABEL,
+            resumeLabel: INTERMISSION_VIEW_RESUME_LABEL,
+            resumeTitle: INTERMISSION_VIEW_RESUME_TITLE,
+            resumeCaption: INTERMISSION_VIEW_RESUME_CAPTION,
+            resumeInfo: mapIntermissionResumeInfo(),
+            gateLabel: INTERMISSION_VIEW_GATE_LABEL,
+            onOpenBoardCheck: () => showBoardCheck(),
+            onOpenSummary: () => openIntermissionSummaryDialog(),
+            onOpenResume: () => contextRouter.go('#/resume/gate'),
+            onOpenGate: () => contextRouter.go('#/phase/intermission/gate'),
+          });
+
+          view.setGateDisabled(shouldEnterBackstagePhase(state));
+
+          const unsubscribe = gameStore.subscribe((nextState) => {
+            if (shouldEnterBackstagePhase(nextState)) {
+              view.setGateDisabled(true);
+              navigateToBackstageGate();
+              return;
+            }
+
+            view.updateSubtitle(createIntermissionGateSubtitle(nextState));
+            view.updateMessage(
+              createTurnGateMessage(nextState, INTERMISSION_GATE_CONFIRM_LABEL),
+            );
+            view.updateTasks(createIntermissionTasks(nextState));
+            view.updateSummary(createIntermissionSummaryView(nextState));
+            view.updateNotes(createIntermissionBackstageNotes(nextState));
+            view.setResumeInfo(mapIntermissionResumeInfo());
+          });
+
+          activeIntermissionCleanup = () => {
+            unsubscribe();
           };
 
           return view;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -70,6 +70,24 @@ export const INTERMISSION_BACKSTAGE_DRAW_CONFIRM_MESSAGE = (cardLabel: string): 
 export const INTERMISSION_BACKSTAGE_DRAW_RESULT_MESSAGE = (cardLabel: string): string =>
   `バックステージから${cardLabel}を取得しました。`;
 
+export const INTERMISSION_VIEW_GATE_LABEL = 'ハンドオフゲートへ';
+export const INTERMISSION_VIEW_RESUME_LABEL = '続きから';
+export const INTERMISSION_VIEW_RESUME_TITLE = 'セーブデータ';
+export const INTERMISSION_VIEW_RESUME_CAPTION =
+  'セーブデータの確認と復元フローは今後実装されます。';
+export const INTERMISSION_VIEW_RESUME_EMPTY = 'セーブデータはまだ保存されていません。';
+export const INTERMISSION_VIEW_RESUME_SAVED_AT_PREFIX = '保存日時：';
+export const INTERMISSION_VIEW_SUMMARY_TITLE = '公開情報のハイライト';
+export const INTERMISSION_VIEW_NOTES_TITLE = '直前のバックステージ結果';
+export const INTERMISSION_TASK_NEXT_PLAYER = (playerName: string): string =>
+  `次は${playerName}の番です。端末を渡す準備を整えましょう。`;
+export const INTERMISSION_TASK_REVIEW =
+  '公開情報を確認するときは「ボードチェック」や「前ラウンド要約」を開いて整理しましょう。';
+export const INTERMISSION_TASK_RESUME =
+  '途中で中断する場合は「続きから」からセーブデータを扱います（復元フローは準備中です）。';
+export const INTERMISSION_TASK_GATE =
+  '準備が整ったら「ハンドオフゲートへ」を押して次のフェーズへ進みます。';
+
 export const BACKSTAGE_GATE_TITLE = 'バックステージ';
 export const BACKSTAGE_GATE_CONFIRM_LABEL = 'バックステージへ';
 export const BACKSTAGE_GATE_MESSAGE =

--- a/src/views/intermission.ts
+++ b/src/views/intermission.ts
@@ -1,0 +1,243 @@
+import { UIButton } from '../ui/button.js';
+
+export interface IntermissionResumeInfo {
+  available: boolean;
+  summary: string;
+  savedAtLabel?: string | null;
+}
+
+export interface IntermissionViewOptions {
+  title: string;
+  subtitle: string;
+  message: string;
+  tasks: string[];
+  summaryTitle: string;
+  summaryContent: HTMLElement;
+  notesTitle: string;
+  notes: string[];
+  boardCheckLabel: string;
+  summaryLabel: string;
+  resumeLabel: string;
+  resumeTitle: string;
+  resumeCaption: string;
+  resumeInfo: IntermissionResumeInfo;
+  gateLabel: string;
+  onOpenBoardCheck?: () => void;
+  onOpenSummary?: () => void;
+  onOpenResume?: () => void;
+  onOpenGate?: () => void;
+}
+
+export interface IntermissionViewElement extends HTMLElement {
+  updateSubtitle: (subtitle: string) => void;
+  updateMessage: (message: string) => void;
+  updateTasks: (tasks: string[]) => void;
+  updateSummary: (content: HTMLElement) => void;
+  updateNotes: (notes: string[]) => void;
+  setResumeInfo: (info: IntermissionResumeInfo) => void;
+  setGateDisabled: (disabled: boolean) => void;
+}
+
+const createTaskList = (tasks: string[]): HTMLOListElement => {
+  const list = document.createElement('ol');
+  list.className = 'intermission__tasks';
+
+  tasks.forEach((task) => {
+    const item = document.createElement('li');
+    item.className = 'intermission__task';
+    item.textContent = task;
+    list.append(item);
+  });
+
+  return list;
+};
+
+const createNotesList = (notes: string[]): HTMLUListElement => {
+  const list = document.createElement('ul');
+  list.className = 'intermission__notes-list';
+
+  notes.forEach((note) => {
+    const item = document.createElement('li');
+    item.className = 'intermission__note-item';
+    item.textContent = note;
+    list.append(item);
+  });
+
+  return list;
+};
+
+export const createIntermissionView = (options: IntermissionViewOptions): IntermissionViewElement => {
+  const section = document.createElement('section');
+  section.className = 'view intermission-view';
+
+  const main = document.createElement('main');
+  main.className = 'intermission';
+  section.append(main);
+
+  const headingId = `intermission-title-${Math.random().toString(36).slice(2, 8)}`;
+
+  const header = document.createElement('header');
+  header.className = 'intermission__header';
+  main.append(header);
+
+  const heading = document.createElement('h1');
+  heading.className = 'intermission__title';
+  heading.id = headingId;
+  heading.textContent = options.title;
+  header.append(heading);
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'intermission__subtitle';
+  subtitle.textContent = options.subtitle;
+  header.append(subtitle);
+
+  main.setAttribute('aria-labelledby', headingId);
+
+  const body = document.createElement('section');
+  body.className = 'intermission__body';
+  main.append(body);
+
+  const message = document.createElement('p');
+  message.className = 'intermission__message';
+  message.textContent = options.message;
+  body.append(message);
+
+  const taskContainer = document.createElement('div');
+  taskContainer.className = 'intermission__tasks-wrapper';
+  body.append(taskContainer);
+
+  let taskList = createTaskList(options.tasks);
+  taskContainer.append(taskList);
+
+  const actions = document.createElement('div');
+  actions.className = 'intermission__actions';
+  body.append(actions);
+
+  const boardCheckButton = new UIButton({
+    label: options.boardCheckLabel,
+    variant: 'ghost',
+    preventRapid: true,
+  });
+  boardCheckButton.onClick(() => options.onOpenBoardCheck?.());
+  boardCheckButton.el.classList.add('intermission__action-button');
+  actions.append(boardCheckButton.el);
+
+  const summaryButton = new UIButton({
+    label: options.summaryLabel,
+    variant: 'ghost',
+    preventRapid: true,
+  });
+  summaryButton.onClick(() => options.onOpenSummary?.());
+  summaryButton.el.classList.add('intermission__action-button');
+  actions.append(summaryButton.el);
+
+  const resumeButton = new UIButton({
+    label: options.resumeLabel,
+    variant: 'ghost',
+    preventRapid: true,
+    disabled: !options.resumeInfo.available,
+  });
+  resumeButton.onClick(() => options.onOpenResume?.());
+  resumeButton.el.classList.add('intermission__action-button');
+  actions.append(resumeButton.el);
+
+  const gateButton = new UIButton({
+    label: options.gateLabel,
+    preventRapid: true,
+  });
+  gateButton.onClick(() => options.onOpenGate?.());
+  gateButton.el.classList.add('intermission__action-button', 'intermission__action-button--primary');
+  actions.append(gateButton.el);
+
+  const resumeSection = document.createElement('section');
+  resumeSection.className = 'intermission__resume';
+  body.append(resumeSection);
+
+  const resumeTitle = document.createElement('h2');
+  resumeTitle.className = 'intermission__section-title';
+  resumeTitle.textContent = options.resumeTitle;
+  resumeSection.append(resumeTitle);
+
+  const resumeCaption = document.createElement('p');
+  resumeCaption.className = 'intermission__resume-caption';
+  resumeCaption.textContent = options.resumeCaption;
+  resumeSection.append(resumeCaption);
+
+  const resumeSummary = document.createElement('p');
+  resumeSummary.className = 'intermission__resume-summary';
+  resumeSection.append(resumeSummary);
+
+  const resumeSavedAt = document.createElement('p');
+  resumeSavedAt.className = 'intermission__resume-saved-at';
+  resumeSection.append(resumeSavedAt);
+
+  const summarySection = document.createElement('section');
+  summarySection.className = 'intermission__summary';
+  body.append(summarySection);
+
+  const summaryTitle = document.createElement('h2');
+  summaryTitle.className = 'intermission__section-title';
+  summaryTitle.textContent = options.summaryTitle;
+  summarySection.append(summaryTitle);
+
+  const summaryContainer = document.createElement('div');
+  summaryContainer.className = 'intermission__summary-content';
+  summarySection.append(summaryContainer);
+  summaryContainer.append(options.summaryContent);
+
+  const notesSection = document.createElement('section');
+  notesSection.className = 'intermission__notes';
+  body.append(notesSection);
+
+  const notesTitle = document.createElement('h2');
+  notesTitle.className = 'intermission__section-title';
+  notesTitle.textContent = options.notesTitle;
+  notesSection.append(notesTitle);
+
+  let notesList = createNotesList(options.notes);
+  notesSection.append(notesList);
+  notesSection.hidden = options.notes.length === 0;
+
+  const applyResumeInfo = (info: IntermissionResumeInfo) => {
+    resumeSummary.textContent = info.summary;
+    if (info.savedAtLabel) {
+      resumeSavedAt.textContent = info.savedAtLabel;
+      resumeSavedAt.hidden = false;
+    } else {
+      resumeSavedAt.textContent = '';
+      resumeSavedAt.hidden = true;
+    }
+    resumeButton.setDisabled(!info.available);
+  };
+
+  applyResumeInfo(options.resumeInfo);
+
+  return Object.assign(section, {
+    updateSubtitle: (value: string) => {
+      subtitle.textContent = value;
+    },
+    updateMessage: (value: string) => {
+      message.textContent = value;
+    },
+    updateTasks: (tasks: string[]) => {
+      const nextList = createTaskList(tasks);
+      taskList.replaceWith(nextList);
+      taskList = nextList;
+    },
+    updateSummary: (content: HTMLElement) => {
+      summaryContainer.replaceChildren(content);
+    },
+    updateNotes: (notes: string[]) => {
+      const nextList = createNotesList(notes);
+      notesList.replaceWith(nextList);
+      notesList = nextList;
+      notesSection.hidden = notes.length === 0;
+    },
+    setResumeInfo: (info: IntermissionResumeInfo) => {
+      applyResumeInfo(info);
+    },
+    setGateDisabled: (disabled: boolean) => {
+      gateButton.setDisabled(disabled);
+    },
+  });
+};

--- a/styles/base.css
+++ b/styles/base.css
@@ -1999,6 +1999,140 @@ p {
   }
 }
 
+.intermission {
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding: clamp(1.5rem, 3vw, 2.5rem) clamp(1.25rem, 4vw, 3rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vh, 2.5rem);
+}
+
+.intermission__header {
+  display: grid;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.intermission__title {
+  margin: 0;
+  font-size: clamp(1.6rem, 3.2vw, 1.95rem);
+}
+
+.intermission__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-muted);
+}
+
+.intermission__body {
+  display: grid;
+  gap: clamp(1.5rem, 3vh, 2.25rem);
+}
+
+.intermission__message {
+  margin: 0;
+  font-size: clamp(1rem, 2.5vw, 1.1rem);
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.intermission__tasks-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.intermission__tasks {
+  margin: 0;
+  padding-left: clamp(1.25rem, 3vw, 2rem);
+  display: grid;
+  gap: clamp(0.65rem, 2vh, 0.9rem);
+  max-width: 640px;
+  font-size: clamp(0.95rem, 2.2vw, 1.05rem);
+}
+
+.intermission__task {
+  line-height: 1.6;
+  color: var(--color-muted);
+}
+
+.intermission__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.intermission__action-button {
+  min-width: clamp(160px, 35vw, 240px);
+  justify-content: center;
+}
+
+.intermission__action-button--primary {
+  font-weight: 700;
+}
+
+.intermission__resume,
+.intermission__summary,
+.intermission__notes {
+  display: grid;
+  gap: 0.65rem;
+  padding: clamp(1.15rem, 2.6vw, 1.75rem);
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.intermission__section-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.intermission__resume-caption,
+.intermission__resume-summary,
+.intermission__resume-saved-at {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.intermission__resume-summary {
+  font-size: 0.98rem;
+}
+
+.intermission__resume-saved-at {
+  font-size: 0.9rem;
+}
+
+.intermission__summary-content {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.intermission__notes-list {
+  margin: 0;
+  padding-left: clamp(1.25rem, 3vw, 2rem);
+  display: grid;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.intermission__note-item {
+  line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+  .intermission__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .intermission__action-button {
+    width: 100%;
+  }
+}
+
 .intermission-summary {
   display: grid;
   gap: 1.25rem;


### PR DESCRIPTION
## Summary
- インターミッション用のビューを新規実装し、振り返り・続きから・ゲート遷移などの操作を集約
- ゲーム状態に合わせてインターミッション画面の表示内容やボタン制御を更新するロジックを追加
- インターミッション画面向けのスタイルとメッセージ定義を整備

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7ebf18bd8832aaf5fa8b828fcb542