### PR TITLE
fix: インターミッション手番の次プレイヤー判定を修正

### DIFF
--- a/src/turn.ts
+++ b/src/turn.ts
@@ -1,0 +1,18 @@
+import type { GameState, PlayerId } from './state.js';
+
+/**
+ * 指定したプレイヤーの相手側IDを返す。
+ * @param player 判定対象のプレイヤーID
+ * @returns 相手側のプレイヤーID
+ */
+export const getOpponentId = (player: PlayerId): PlayerId =>
+  player === 'lumina' ? 'nox' : 'lumina';
+
+/**
+ * インターミッション再開時の次手番プレイヤーを判定する。
+ * ブーイング成功かどうかに関わらず、常に現在の手番プレイヤーの相手を返す。
+ * @param state 現在のゲーム状態
+ * @returns 次にアクティブになるプレイヤーID
+ */
+export const resolveNextIntermissionActivePlayer = (state: GameState): PlayerId =>
+  getOpponentId(state.activePlayer);

--- a/tests/turn.test.ts
+++ b/tests/turn.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInitialState,
+  REQUIRED_BOO_COUNT,
+  type GameState,
+  type PlayerId,
+} from '../src/state.js';
+import { resolveNextIntermissionActivePlayer } from '../src/turn.js';
+
+const createState = (activePlayer: PlayerId, configure?: (state: GameState) => void): GameState => {
+  const state = createInitialState();
+  state.activePlayer = activePlayer;
+  if (configure) {
+    configure(state);
+  }
+  return state;
+};
+
+describe('resolveNextIntermissionActivePlayer', () => {
+  it('インターミッション突入ごとに手番が交互に切り替わる', () => {
+    const luminaTurn = createState('lumina');
+    expect(resolveNextIntermissionActivePlayer(luminaTurn)).toBe('nox');
+
+    const noxTurn = createState('nox');
+    expect(resolveNextIntermissionActivePlayer(noxTurn)).toBe('lumina');
+  });
+
+  it('ブーイング成功時でも次手番は相手プレイヤーになる', () => {
+    const state = createState('lumina', (draft) => {
+      draft.watch.decision = 'boo';
+      draft.players.lumina.booCount = REQUIRED_BOO_COUNT;
+      draft.players.nox.clapCount = 1;
+      draft.history.push({
+        id: 'history-watch',
+        type: 'watch',
+        turn: draft.turn.count,
+        actor: 'lumina',
+        payload: {
+          decision: 'boo',
+          outcome: 'success',
+        },
+        createdAt: draft.updatedAt,
+      });
+      draft.history.push({
+        id: 'history-spotlight',
+        type: 'spotlight',
+        turn: draft.turn.count,
+        actor: 'nox',
+        payload: {
+          result: 'mismatch',
+          winner: 'nox',
+        },
+        createdAt: draft.updatedAt + 1,
+      });
+    });
+
+    expect(resolveNextIntermissionActivePlayer(state)).toBe('nox');
+  });
+});


### PR DESCRIPTION
## Summary
- インターミッション再開時の手番判定を常に相手プレイヤーへ切り替えるようにし、不要な分岐を整理
- ブーイング成功時も相手側が次手番になることを確認するユニットテストを追加

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f1544e44832ab5d4ff85af57163e