### PR TITLE
fix: インターミッションでの手番交代順を是正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import {
   saveGame,
   saveResult,
 } from './storage.js';
+import { resolveNextIntermissionActivePlayer } from './turn.js';
 import {
   createInitialBackstageState,
   createInitialState,
@@ -5059,7 +5060,7 @@ const handleIntermissionGatePass = (router: Router): void => {
     const timestamp = Date.now();
     const currentTurn = current.turn ?? { count: 0, startedAt: timestamp };
     const previousWatchState = current.watch ?? createInitialWatchState();
-    const nextActivePlayerId = getOpponentId(current.activePlayer);
+    const nextActivePlayerId = resolveNextIntermissionActivePlayer(current);
     const backstage = getBackstageState(current);
 
     return {
@@ -5325,7 +5326,6 @@ const completeWatchDecision = (decision: WatchDecision): CompleteWatchDecisionRe
 
     const timestamp = Date.now();
     const nextRoute = WATCH_DECISION_TO_PATH[decision];
-    const nextActivePlayerId = getOpponentId(current.activePlayer);
     const nextPlayer: PlayerState = {
       ...player,
       clapCount: decision === 'clap' ? player.clapCount + 1 : player.clapCount,
@@ -5342,7 +5342,6 @@ const completeWatchDecision = (decision: WatchDecision): CompleteWatchDecisionRe
         ...current.players,
         [current.activePlayer]: nextPlayer,
       },
-      activePlayer: nextActivePlayerId,
       watch: {
         ...previousWatchState,
         decision,

--- a/src/turn.ts
+++ b/src/turn.ts
@@ -1,0 +1,18 @@
+import type { GameState, PlayerId } from './state.js';
+
+/**
+ * 指定したプレイヤーの相手側IDを返す。
+ * @param player 判定対象のプレイヤーID
+ * @returns 相手側のプレイヤーID
+ */
+export const getOpponentId = (player: PlayerId): PlayerId =>
+  player === 'lumina' ? 'nox' : 'lumina';
+
+/**
+ * インターミッション再開時の次手番プレイヤーを判定する。
+ * ブーイング成功かどうかに関わらず、常に現在の手番プレイヤーの相手を返す。
+ * @param state 現在のゲーム状態
+ * @returns 次にアクティブになるプレイヤーID
+ */
+export const resolveNextIntermissionActivePlayer = (state: GameState): PlayerId =>
+  getOpponentId(state.activePlayer);

--- a/tests/turn.test.ts
+++ b/tests/turn.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInitialState,
+  REQUIRED_BOO_COUNT,
+  type GameState,
+  type PlayerId,
+} from '../src/state.js';
+import { resolveNextIntermissionActivePlayer } from '../src/turn.js';
+
+const createState = (activePlayer: PlayerId, configure?: (state: GameState) => void): GameState => {
+  const state = createInitialState();
+  state.activePlayer = activePlayer;
+  if (configure) {
+    configure(state);
+  }
+  return state;
+};
+
+describe('resolveNextIntermissionActivePlayer', () => {
+  it('インターミッション突入ごとに手番が交互に切り替わる', () => {
+    const luminaTurn = createState('lumina');
+    expect(resolveNextIntermissionActivePlayer(luminaTurn)).toBe('nox');
+
+    const noxTurn = createState('nox');
+    expect(resolveNextIntermissionActivePlayer(noxTurn)).toBe('lumina');
+  });
+
+  it('ブーイング成功時でも次手番は相手プレイヤーになる', () => {
+    const state = createState('lumina', (draft) => {
+      draft.watch.decision = 'boo';
+      draft.players.lumina.booCount = REQUIRED_BOO_COUNT;
+      draft.players.nox.clapCount = 1;
+      draft.history.push({
+        id: 'history-watch',
+        type: 'watch',
+        turn: draft.turn.count,
+        actor: 'lumina',
+        payload: {
+          decision: 'boo',
+          outcome: 'success',
+        },
+        createdAt: draft.updatedAt,
+      });
+      draft.history.push({
+        id: 'history-spotlight',
+        type: 'spotlight',
+        turn: draft.turn.count,
+        actor: 'nox',
+        payload: {
+          result: 'mismatch',
+          winner: 'nox',
+        },
+        createdAt: draft.updatedAt + 1,
+      });
+    });
+
+    expect(resolveNextIntermissionActivePlayer(state)).toBe('nox');
+  });
+});


### PR DESCRIPTION
## Summary
- インターミッションゲート通過時の手番交代処理で共通ヘルパーを用い、次手番判定を一元化
- ウォッチ確定処理で手番を即座に切り替えないようにし、ゲート通過時のみ手番が交代する流れへ修正

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f1544e44832ab5d4ff85af57163e