### PR TITLE
Fix: スカウト手番の交代ロジックを修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1749,6 +1749,7 @@ const completeScoutPick = (): CardSnapshot | null => {
         ...current.scout,
         selectedOpponentCardId: null,
       },
+      lastScoutPlayer: activePlayerId,
       recentScoutedCard: recentCard,
       revision: current.revision + 1,
       updatedAt: timestamp,
@@ -6707,6 +6708,18 @@ const buildRouteDefinitions = (router: Router): RouteDefinition[] =>
               return;
             }
             hasTriggeredAutoAdvance = true;
+            gameStore.setState((current) => {
+              if (current.lastScoutPlayer === current.activePlayer) {
+                return current;
+              }
+              const timestamp = Date.now();
+              return {
+                ...current,
+                lastScoutPlayer: current.activePlayer,
+                updatedAt: timestamp,
+                revision: current.revision + 1,
+              };
+            });
             if (typeof window !== 'undefined') {
               window.curtainCall?.modal?.close();
             }

--- a/src/state.ts
+++ b/src/state.ts
@@ -252,6 +252,7 @@ export interface GameState extends Record<string, unknown> {
   history: HistoryEntry[];
   meta: GameMeta;
   resume?: ResumeSnapshot;
+  lastScoutPlayer: PlayerId | null;
   recentScoutedCard: CardSnapshot | null;
   scout: ScoutState;
   action: ActionState;
@@ -409,6 +410,7 @@ export const createInitialState = (): GameState => {
       composition: { ...CARD_COMPOSITION },
     },
     resume: undefined,
+    lastScoutPlayer: null,
     recentScoutedCard: null,
     scout: {
       selectedOpponentCardId: null,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -256,10 +256,15 @@ const normalizeBackstageState = (value: unknown): BackstageState => {
   };
 };
 
-const normalizeGameStateForLoad = (state: GameState): GameState => ({
-  ...state,
-  backstage: normalizeBackstageState((state as Record<string, unknown>).backstage),
-});
+const normalizeGameStateForLoad = (state: GameState): GameState => {
+  const record = state as Record<string, unknown>;
+  const lastScoutPlayer = isPlayerId(record.lastScoutPlayer) ? record.lastScoutPlayer : null;
+  return {
+    ...state,
+    lastScoutPlayer,
+    backstage: normalizeBackstageState(record.backstage),
+  };
+};
 
 const isResultHistoryEntry = (value: unknown): value is ResultHistoryEntry => {
   if (!value || typeof value !== 'object') {

--- a/src/turn.ts
+++ b/src/turn.ts
@@ -10,9 +10,15 @@ export const getOpponentId = (player: PlayerId): PlayerId =>
 
 /**
  * インターミッション再開時の次手番プレイヤーを判定する。
- * ブーイング成功かどうかに関わらず、常に現在の手番プレイヤーの相手を返す。
+ * ブーイング成功などでアクティブプレイヤーが入れ替わっていても、
+ * 直前のスカウトを担当したプレイヤーの相手を次のアクティブとして返す。
  * @param state 現在のゲーム状態
  * @returns 次にアクティブになるプレイヤーID
  */
-export const resolveNextIntermissionActivePlayer = (state: GameState): PlayerId =>
-  getOpponentId(state.activePlayer);
+export const resolveNextIntermissionActivePlayer = (state: GameState): PlayerId => {
+  const lastScoutPlayer = state.lastScoutPlayer;
+  if (lastScoutPlayer === 'lumina' || lastScoutPlayer === 'nox') {
+    return getOpponentId(lastScoutPlayer);
+  }
+  return getOpponentId(state.activePlayer);
+};


### PR DESCRIPTION
## Summary
- スカウトを担当したプレイヤーを状態として保持し、次ターンの手番決定に利用するように変更
- 相手手札がゼロでスカウトが自動スキップされた場合でも手番記録が更新されるように調整
- 既存セーブデータ読み込み時に手番記録が初期化されるように更新

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80bdc6dec832aa0141cc8ba8f9ae0