### PR TITLE
バックステージ取得確認ボタンが表示されない問題を修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3428,18 +3428,15 @@ const openIntermissionBackstageDrawDialog = (): void => {
   const buttonMap = new Map<string, HTMLButtonElement>();
   let selectedItemId: string | null = null;
 
-  const decideButton = new UIButton({
-    label: INTERMISSION_BACKSTAGE_DRAW_DECIDE_LABEL,
-    preventRapid: true,
-    disabled: true,
-  });
+  const confirmActionId = 'intermission-backstage-draw-confirm';
+  let confirmActionButton: UIButton | null = null;
 
   const updateSelection = (itemId: string | null) => {
     selectedItemId = itemId;
     buttonMap.forEach((button, id) => {
       button.classList.toggle('intermission-backstage__button--selected', id === itemId);
     });
-    decideButton.setDisabled(!itemId);
+    confirmActionButton?.setDisabled(!itemId);
   };
 
   hiddenItems.forEach((item, index) => {
@@ -3456,30 +3453,35 @@ const openIntermissionBackstageDrawDialog = (): void => {
 
   container.append(list);
 
-  const actions = document.createElement('div');
-  actions.className = 'intermission-backstage__actions';
-
-  decideButton.onClick(() => {
-    if (!selectedItemId) {
-      return;
-    }
-    const result = finalizeBackstageDraw(selectedItemId);
-    if (!result) {
-      updateSelection(null);
-      return;
-    }
-    handleBackstageDrawResult(result);
-  });
-
-  actions.append(decideButton.el);
-  container.append(actions);
-
   modal.open({
     title: INTERMISSION_BACKSTAGE_DRAW_TITLE,
     body: container,
     dismissible: false,
-    actions: [],
+    actions: [
+      {
+        id: confirmActionId,
+        label: INTERMISSION_BACKSTAGE_DRAW_DECIDE_LABEL,
+        variant: 'primary',
+        preventRapid: true,
+        dismiss: false,
+        disabled: true,
+        onSelect: () => {
+          if (!selectedItemId) {
+            return;
+          }
+          const result = finalizeBackstageDraw(selectedItemId);
+          if (!result) {
+            updateSelection(null);
+            return;
+          }
+          handleBackstageDrawResult(result);
+        },
+      },
+    ],
   });
+
+  confirmActionButton = modal.getActionButton(confirmActionId);
+  confirmActionButton?.setDisabled(!selectedItemId);
 };
 
 const canRevealSpotlightKuroko = (state: GameState): boolean => {

--- a/src/ui/modal.ts
+++ b/src/ui/modal.ts
@@ -3,6 +3,7 @@ import { UIComponent } from './component.js';
 import { animationManager } from './animation.js';
 
 export interface ModalAction {
+  id?: string;
   label: string;
   variant?: ButtonVariant;
   dismiss?: boolean;
@@ -25,6 +26,7 @@ const MODAL_LABEL_FALLBACK = 'ダイアログ';
 class ModalView extends UIComponent<HTMLDivElement> {
   private readonly headingId: string;
   private readonly bodyId: string;
+  private readonly actionButtons = new Map<string, UIButton>();
 
   constructor() {
     super(document.createElement('div'));
@@ -80,6 +82,7 @@ class ModalView extends UIComponent<HTMLDivElement> {
   setActions(actions: ModalAction[] | undefined, close: () => void): void {
     const footer = this.ensureFooter();
     footer.replaceChildren();
+    this.actionButtons.clear();
     if (!actions || actions.length === 0) {
       footer.hidden = true;
       return;
@@ -94,6 +97,10 @@ class ModalView extends UIComponent<HTMLDivElement> {
         preventRapid: action.preventRapid,
         lockDuration: action.lockDuration,
       });
+      if (action.id) {
+        button.el.dataset.actionId = action.id;
+        this.actionButtons.set(action.id, button);
+      }
       button.onClick(() => {
         action.onSelect?.();
         if (action.dismiss !== false) {
@@ -102,6 +109,10 @@ class ModalView extends UIComponent<HTMLDivElement> {
       });
       footer.append(button.el);
     });
+  }
+
+  getActionButton(id: string): UIButton | undefined {
+    return this.actionButtons.get(id);
   }
 
   private ensureHeading(): HTMLHeadingElement {
@@ -221,6 +232,10 @@ export class ModalController {
 
   get opened(): boolean {
     return this.isActive;
+  }
+
+  getActionButton(id: string): UIButton | null {
+    return this.modalView.getActionButton(id) ?? null;
   }
 
   private completeClose(): void {


### PR DESCRIPTION
## Summary
- モーダルアクションに識別子を付与して対応するUIButtonを取得できるようにし、動的な状態更新を可能にしました。
- バックステージ取得モーダルの決定ボタンをフッターアクションとして表示し、カード選択時のみ有効化されるよう修正しました。

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8146bea78832a83051fa52fd5fcc4