### PR TITLE
Fix: スポットライト公開対象の伏せ札選択を修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2022,6 +2022,21 @@ const findLatestCompleteStagePair = (stage: StageArea | undefined): StagePair | 
   return null;
 };
 
+const findLatestHiddenStagePair = (stage: StageArea | undefined): StagePair | null => {
+  if (!stage) {
+    return null;
+  }
+
+  for (let index = stage.pairs.length - 1; index >= 0; index -= 1) {
+    const pair = stage.pairs[index];
+    if (pair?.actor?.card && pair.kuroko?.card?.face === 'down') {
+      return pair;
+    }
+  }
+
+  return null;
+};
+
 const findLatestWatchStagePair = (state: GameState): StagePair | null => {
   const opponentId = getOpponentId(state.activePlayer);
   const opponent = state.players[opponentId];
@@ -2071,14 +2086,24 @@ const mapWatchStage = (state: GameState): WatchStageViewModel => {
 
 const findLatestSpotlightPair = (state: GameState): StagePair | null => {
   const activePlayer = state.players[state.activePlayer];
-  const activePair = findLatestCompleteStagePair(activePlayer?.stage);
+  const opponentId = getOpponentId(state.activePlayer);
+  const opponent = state.players[opponentId];
 
+  const activeHiddenPair = findLatestHiddenStagePair(activePlayer?.stage);
+  if (activeHiddenPair) {
+    return activeHiddenPair;
+  }
+
+  const opponentHiddenPair = findLatestHiddenStagePair(opponent?.stage);
+  if (opponentHiddenPair) {
+    return opponentHiddenPair;
+  }
+
+  const activePair = findLatestCompleteStagePair(activePlayer?.stage);
   if (activePair) {
     return activePair;
   }
 
-  const opponentId = getOpponentId(state.activePlayer);
-  const opponent = state.players[opponentId];
   return findLatestCompleteStagePair(opponent?.stage);
 };
 


### PR DESCRIPTION
## Summary
- 伏せたままの黒子を持つ最新のペアを優先的に取得するヘルパーを追加
- スポットライト遷移時に公開対象ペアの選択が先に公開済みカードを指さないように修正

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d815d20e08832a8c6525385e811335