### PR TITLE
Fix watch phase pair selection to prefer latest action pair

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,11 @@ import {
 } from './storage.js';
 import { resolveNextIntermissionActivePlayer } from './turn.js';
 import {
+  findLatestCompleteStagePair,
+  findLatestWatchStagePair,
+  findStagePairById,
+} from './watch-stage.js';
+import {
   createInitialBackstageState,
   createInitialState,
   createInitialWatchState,
@@ -2288,42 +2293,6 @@ const notifyActionGuardStatus = (state: GameState, options: { force?: boolean } 
   }
 };
 
-const findLatestCompleteStagePair = (stage: StageArea | undefined): StagePair | null => {
-  if (!stage) {
-    return null;
-  }
-
-  for (let index = stage.pairs.length - 1; index >= 0; index -= 1) {
-    const pair = stage.pairs[index];
-    if (pair?.actor && pair.kuroko) {
-      return pair;
-    }
-  }
-
-  return null;
-};
-
-const findStagePairById = (state: GameState, pairId: string): StagePair | null => {
-  if (!pairId) {
-    return null;
-  }
-
-  const players = state.players ?? {};
-
-  for (const player of Object.values(players)) {
-    const stage = player?.stage;
-    if (!stage?.pairs?.length) {
-      continue;
-    }
-    const target = stage.pairs.find((pair) => pair?.id === pairId);
-    if (target) {
-      return target;
-    }
-  }
-
-  return null;
-};
-
 const findLatestHiddenStagePair = (stage: StageArea | undefined): StagePair | null => {
   if (!stage) {
     return null;
@@ -2337,19 +2306,6 @@ const findLatestHiddenStagePair = (stage: StageArea | undefined): StagePair | nu
   }
 
   return null;
-};
-
-const findLatestWatchStagePair = (state: GameState): StagePair | null => {
-  const opponentId = getOpponentId(state.activePlayer);
-  const opponent = state.players[opponentId];
-  const opponentPair = findLatestCompleteStagePair(opponent?.stage);
-
-  if (opponentPair) {
-    return opponentPair;
-  }
-
-  const activePlayer = state.players[state.activePlayer];
-  return findLatestCompleteStagePair(activePlayer?.stage);
 };
 
 const findActiveWatchStagePair = (state: GameState): StagePair | null => {

--- a/src/watch-stage.ts
+++ b/src/watch-stage.ts
@@ -1,0 +1,74 @@
+import type { GameState, StageArea, StagePair } from './state.js';
+import { getOpponentId } from './turn.js';
+
+const findLatestStagePair = (
+  stage: StageArea | undefined,
+  predicate?: (pair: StagePair) => boolean,
+): StagePair | null => {
+  if (!stage?.pairs?.length) {
+    return null;
+  }
+
+  for (let index = stage.pairs.length - 1; index >= 0; index -= 1) {
+    const pair = stage.pairs[index];
+    if (!pair?.actor?.card || !pair.kuroko?.card) {
+      continue;
+    }
+    if (predicate && !predicate(pair)) {
+      continue;
+    }
+    return pair;
+  }
+
+  return null;
+};
+
+export const findLatestCompleteStagePair = (stage: StageArea | undefined): StagePair | null =>
+  findLatestStagePair(stage);
+
+export const findLatestActionStagePair = (stage: StageArea | undefined): StagePair | null =>
+  findLatestStagePair(stage, (pair) => pair.origin === 'action');
+
+export const findStagePairById = (state: GameState, pairId: string): StagePair | null => {
+  if (!pairId) {
+    return null;
+  }
+
+  const players = state.players ?? {};
+
+  for (const player of Object.values(players)) {
+    const stage = player?.stage;
+    if (!stage?.pairs?.length) {
+      continue;
+    }
+    const target = stage.pairs.find((pair) => pair?.id === pairId);
+    if (target) {
+      return target;
+    }
+  }
+
+  return null;
+};
+
+export const findLatestWatchStagePair = (state: GameState): StagePair | null => {
+  const opponentId = getOpponentId(state.activePlayer);
+  const opponent = state.players[opponentId];
+  const activePlayer = state.players[state.activePlayer];
+
+  const opponentActionPair = findLatestActionStagePair(opponent?.stage);
+  if (opponentActionPair) {
+    return opponentActionPair;
+  }
+
+  const activeActionPair = findLatestActionStagePair(activePlayer?.stage);
+  if (activeActionPair) {
+    return activeActionPair;
+  }
+
+  const opponentPair = findLatestCompleteStagePair(opponent?.stage);
+  if (opponentPair) {
+    return opponentPair;
+  }
+
+  return findLatestCompleteStagePair(activePlayer?.stage);
+};

--- a/tests/watch-stage.test.ts
+++ b/tests/watch-stage.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialState } from '../src/state.js';
+import type { CardSnapshot, StageCardPlacement, StagePair } from '../src/state.js';
+import {
+  findLatestActionStagePair,
+  findLatestCompleteStagePair,
+  findLatestWatchStagePair,
+  findStagePairById,
+} from '../src/watch-stage.js';
+
+const createCard = (id: string, rank: CardSnapshot['rank'] = 'A'): CardSnapshot => ({
+  id,
+  rank,
+  suit: 'spades',
+  value: 1,
+  face: 'up',
+});
+
+const createPlacement = (
+  card: CardSnapshot,
+  face: CardSnapshot['face'],
+  placedAt: number,
+): StageCardPlacement => ({
+  card: { ...card, face },
+  from: 'hand',
+  placedAt,
+});
+
+const createPair = (
+  id: string,
+  origin: StagePair['origin'],
+  owner: StagePair['owner'],
+  createdAt: number,
+  actorFace: CardSnapshot['face'] = 'up',
+  kurokoFace: CardSnapshot['face'] = 'down',
+): StagePair => {
+  const actorCard = createCard(`${id}-actor`);
+  const kurokoCard = createCard(`${id}-kuroko`, 'K');
+
+  return {
+    id,
+    origin,
+    owner,
+    createdAt,
+    actor: createPlacement(actorCard, actorFace, createdAt),
+    kuroko: createPlacement(kurokoCard, kurokoFace, createdAt),
+  };
+};
+
+describe('watch-stage helpers', () => {
+  it('findLatestCompleteStagePairは末尾の完全なペアを返す', () => {
+    const stage = { pairs: [createPair('p1', 'spotlight', 'lumina', 1), createPair('p2', 'joker', 'lumina', 2)] };
+    expect(findLatestCompleteStagePair(stage)).toBe(stage.pairs[1]);
+  });
+
+  it('findLatestActionStagePairはアクション由来の最新ペアを優先する', () => {
+    const stage = {
+      pairs: [
+        createPair('p1', 'spotlight', 'lumina', 1),
+        createPair('p2', 'action', 'lumina', 2),
+        createPair('p3', 'spotlight', 'lumina', 3),
+      ],
+    };
+    expect(findLatestActionStagePair(stage)).toBe(stage.pairs[1]);
+  });
+
+  it('findLatestWatchStagePairは相手のアクション由来ペアを優先する', () => {
+    const state = createInitialState();
+    state.activePlayer = 'nox';
+    const actionPair = createPair('action-1', 'action', 'lumina', 1);
+    const spotlightPair = createPair('spotlight-1', 'spotlight', 'lumina', 2);
+    state.players.lumina.stage.pairs = [actionPair, spotlightPair];
+
+    const result = findLatestWatchStagePair(state);
+    expect(result).toBe(actionPair);
+  });
+
+  it('findLatestWatchStagePairは相手にアクションペアが無い場合は自分のアクションペアを返す', () => {
+    const state = createInitialState();
+    state.activePlayer = 'nox';
+    const ownActionPair = createPair('action-2', 'action', 'nox', 3);
+    state.players.lumina.stage.pairs = [createPair('spotlight-2', 'spotlight', 'lumina', 1)];
+    state.players.nox.stage.pairs = [ownActionPair];
+
+    const result = findLatestWatchStagePair(state);
+    expect(result).toBe(ownActionPair);
+  });
+
+  it('findLatestWatchStagePairはアクションペアが無ければ最新の完全なペアを返す', () => {
+    const state = createInitialState();
+    state.activePlayer = 'nox';
+    const fallbackPair = createPair('spotlight-3', 'spotlight', 'lumina', 5);
+    state.players.lumina.stage.pairs = [fallbackPair];
+    state.players.nox.stage.pairs = [];
+
+    const result = findLatestWatchStagePair(state);
+    expect(result).toBe(fallbackPair);
+  });
+
+  it('findStagePairByIdは両プレイヤーのステージから一致するペアを探す', () => {
+    const state = createInitialState();
+    const luminaPair = createPair('lumina-pair', 'action', 'lumina', 1);
+    const noxPair = createPair('nox-pair', 'spotlight', 'nox', 2);
+    state.players.lumina.stage.pairs = [luminaPair];
+    state.players.nox.stage.pairs = [noxPair];
+
+    expect(findStagePairById(state, 'lumina-pair')).toBe(luminaPair);
+    expect(findStagePairById(state, 'nox-pair')).toBe(noxPair);
+    expect(findStagePairById(state, 'unknown')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add watch-stage helpers to select the latest action-origin stage pair for the watch phase
- refactor app.ts to use the new helpers when rendering watch and spotlight stages
- cover the new selection logic with dedicated unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8812a83ac832a83c3cf5e4b687e7b