### PR TITLE
スマホ表示時のヘルプボタンサイズを調整

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -239,7 +239,7 @@
   .watch__header-button--help,
   .spotlight__header-button--help {
     flex: 0 0 auto;
-    width: 2.75rem;
+    width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
   }
 
   .watch-actions {
@@ -669,7 +669,7 @@ p {
 }
 
 .scout__header-button--help {
-  width: clamp(2.25rem, 4vw, 2.75rem);
+  width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
   aspect-ratio: 1;
   padding: 0;
   font-weight: 600;
@@ -1272,7 +1272,7 @@ p {
 }
 
 .watch__header-button--help {
-  width: 3rem;
+  width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
   aspect-ratio: 1;
   padding: 0;
   justify-content: center;
@@ -2497,7 +2497,7 @@ p {
 }
 
 .spotlight__header-button--help {
-  width: 3rem;
+  width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
   aspect-ratio: 1;
   padding: 0;
   justify-content: center;
@@ -3418,7 +3418,8 @@ p {
   .scout__header-button--help,
   .watch__header-button--help,
   .spotlight__header-button--help {
-    width: 2.5rem;
+    width: max(2.2rem, calc(1rem + var(--button-padding-y) * 2));
+    font-size: 0.95rem;
   }
 
   .action-hand__card {


### PR DESCRIPTION
## Summary
- ヘルプボタンの幅を画面幅に応じて変化させ、スマホ表示で他のボタンとバランスが取れるように調整
- 極小画面向けに最小幅とフォントサイズを見直し、表示の圧迫感を軽減

## Testing
- 未実施（スタイル調整のみのため）

------
https://chatgpt.com/codex/tasks/task_e_68d8c1b7176c832a94cf4ca286391a49