### PR TITLE
ウォッチフェーズのペア選択不具合を修正

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ import { getOpponentId, resolveNextIntermissionActivePlayer } from './turn.js';
 import {
   findLatestCompleteStagePair,
   findLatestWatchStagePair,
-  findStagePairById,
+  resolveActiveWatchStagePair,
 } from './watch-stage.js';
 import {
   createInitialBackstageState,
@@ -2307,17 +2307,8 @@ const findLatestHiddenStagePair = (stage: StageArea | undefined): StagePair | nu
   return null;
 };
 
-const findActiveWatchStagePair = (state: GameState): StagePair | null => {
-  const watchPairId = state.watch?.pairId ?? null;
-  if (watchPairId) {
-    const selectedPair = findStagePairById(state, watchPairId);
-    if (selectedPair) {
-      return selectedPair;
-    }
-  }
-
-  return findLatestWatchStagePair(state);
-};
+const findActiveWatchStagePair = (state: GameState): StagePair | null =>
+  resolveActiveWatchStagePair(state) ?? findLatestWatchStagePair(state);
 
 const mapWatchStage = (state: GameState): WatchStageViewModel => {
   const latestPair = findActiveWatchStagePair(state);

--- a/src/watch-stage.ts
+++ b/src/watch-stage.ts
@@ -72,3 +72,28 @@ export const findLatestWatchStagePair = (state: GameState): StagePair | null => 
 
   return findLatestCompleteStagePair(activePlayer?.stage);
 };
+
+const isStagePairComplete = (pair: StagePair | null): pair is StagePair =>
+  Boolean(pair?.actor?.card && pair?.kuroko?.card);
+
+const getCreatedAt = (pair: StagePair | null): number =>
+  Number.isFinite(pair?.createdAt) ? (pair?.createdAt as number) : Number.NEGATIVE_INFINITY;
+
+export const resolveActiveWatchStagePair = (state: GameState): StagePair | null => {
+  const watchPairId = state.watch?.pairId ?? null;
+  const selectedPair = watchPairId ? findStagePairById(state, watchPairId) : null;
+  const latestPair = findLatestWatchStagePair(state);
+
+  if (!latestPair) {
+    return isStagePairComplete(selectedPair) ? selectedPair : null;
+  }
+
+  if (!isStagePairComplete(selectedPair)) {
+    return latestPair;
+  }
+
+  const selectedCreatedAt = getCreatedAt(selectedPair);
+  const latestCreatedAt = getCreatedAt(latestPair);
+
+  return latestCreatedAt > selectedCreatedAt ? latestPair : selectedPair;
+};

--- a/tests/watch-stage.test.ts
+++ b/tests/watch-stage.test.ts
@@ -6,6 +6,7 @@ import {
   findLatestCompleteStagePair,
   findLatestWatchStagePair,
   findStagePairById,
+  resolveActiveWatchStagePair,
 } from '../src/watch-stage.js';
 
 const createCard = (id: string, rank: CardSnapshot['rank'] = 'A'): CardSnapshot => ({
@@ -107,5 +108,28 @@ describe('watch-stage helpers', () => {
     expect(findStagePairById(state, 'lumina-pair')).toBe(luminaPair);
     expect(findStagePairById(state, 'nox-pair')).toBe(noxPair);
     expect(findStagePairById(state, 'unknown')).toBeNull();
+  });
+
+  it('resolveActiveWatchStagePairはより新しいペアを優先する', () => {
+    const state = createInitialState();
+    state.activePlayer = 'nox';
+    const olderPair = createPair('older', 'action', 'lumina', 1);
+    const newerPair = createPair('newer', 'action', 'lumina', 10);
+    state.players.lumina.stage.pairs = [olderPair, newerPair];
+    state.watch.pairId = olderPair.id;
+
+    const result = resolveActiveWatchStagePair(state);
+    expect(result).toBe(newerPair);
+  });
+
+  it('resolveActiveWatchStagePairは選択済みペアが有効な場合は維持する', () => {
+    const state = createInitialState();
+    state.activePlayer = 'nox';
+    const existingPair = createPair('current', 'action', 'lumina', 5);
+    state.players.lumina.stage.pairs = [existingPair];
+    state.watch.pairId = existingPair.id;
+
+    const result = resolveActiveWatchStagePair(state);
+    expect(result).toBe(existingPair);
   });
 });


### PR DESCRIPTION
## Summary
- ウォッチ表示用のペア決定ロジックを拡張し、最新の完全なペアを優先するように変更
- アプリ側の利用箇所を新しいヘルパーに切り替え、回帰テストを追加

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9229e5078832abe8a28acadbd19f2