### PR TITLE
fix: フェーズ担当プレイヤーの切り替えを修正

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -207,6 +207,8 @@ export interface HistoryEntry {
 export interface TurnState {
   count: number;
   startedAt: number;
+  presenter: PlayerId;
+  watcher: PlayerId;
 }
 
 export interface GameMeta {
@@ -400,6 +402,8 @@ export const createInitialState = (): GameState => {
     turn: {
       count: 1,
       startedAt: timestamp,
+      presenter: 'lumina',
+      watcher: 'nox',
     },
     set: {
       cards: [],

--- a/src/turn.ts
+++ b/src/turn.ts
@@ -8,6 +8,43 @@ import type { GameState, PlayerId } from './state.js';
 export const getOpponentId = (player: PlayerId): PlayerId =>
   player === 'lumina' ? 'nox' : 'lumina';
 
+const isPlayerId = (value: unknown): value is PlayerId => value === 'lumina' || value === 'nox';
+
+/**
+ * 現在のターンで提示側となっているプレイヤーIDを解決する。
+ * `turn.presenter` が設定されていればそれを優先し、無効な場合は
+ * 直近のスカウト担当者、さらにそれも無ければ現在のアクティブプレイヤーを返す。
+ * @param state ゲーム状態
+ * @returns 現在の提示側プレイヤーID
+ */
+export const resolveTurnPresenter = (state: GameState): PlayerId => {
+  const presenter = state.turn?.presenter;
+  if (isPlayerId(presenter)) {
+    return presenter;
+  }
+
+  const lastScoutPlayer = state.lastScoutPlayer;
+  if (isPlayerId(lastScoutPlayer)) {
+    return lastScoutPlayer;
+  }
+
+  return state.activePlayer;
+};
+
+/**
+ * 現在のターンでウォッチ側となっているプレイヤーIDを解決する。
+ * @param state ゲーム状態
+ * @returns 現在のウォッチ側プレイヤーID
+ */
+export const resolveTurnWatcher = (state: GameState): PlayerId => {
+  const watcher = state.turn?.watcher;
+  if (isPlayerId(watcher)) {
+    return watcher;
+  }
+
+  return getOpponentId(resolveTurnPresenter(state));
+};
+
 /**
  * インターミッション再開時の次手番プレイヤーを判定する。
  * ブーイング成功などでアクティブプレイヤーが入れ替わっていても、
@@ -17,8 +54,8 @@ export const getOpponentId = (player: PlayerId): PlayerId =>
  */
 export const resolveNextIntermissionActivePlayer = (state: GameState): PlayerId => {
   const lastScoutPlayer = state.lastScoutPlayer;
-  if (lastScoutPlayer === 'lumina' || lastScoutPlayer === 'nox') {
+  if (isPlayerId(lastScoutPlayer)) {
     return getOpponentId(lastScoutPlayer);
   }
-  return getOpponentId(state.activePlayer);
+  return getOpponentId(resolveTurnPresenter(state));
 };


### PR DESCRIPTION
## Summary
- ターン状態に提示側/ウォッチ側の情報を追加し、各フェーズで正しいプレイヤーが操作するように更新
- インターミッションのガイダンスと遷移処理を見直し、次手番プレイヤーを正しく案内
- 保存データの読み込みを拡張し、新しいターン情報へ正規化
- ターン周りのロジックに対するユニットテストを追加

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d943293990832aa86e75a3045c0bf2