### PR TITLE
Update help buttons for mobile

### DIFF
--- a/src/views/scout.ts
+++ b/src/views/scout.ts
@@ -95,7 +95,7 @@ export const createScoutView = (options: ScoutViewOptions): ScoutViewElement => 
 
   if (options.onOpenHelp) {
     const helpButton = new UIButton({
-      label: options.helpLabel ?? '？',
+      label: options.helpLabel ?? 'ヘルプ',
       variant: 'ghost',
       preventRapid: false,
     });

--- a/src/views/spotlight.ts
+++ b/src/views/spotlight.ts
@@ -159,7 +159,7 @@ export const createSpotlightView = (options: SpotlightViewOptions): SpotlightVie
 
   if (options.onOpenHelp) {
     const helpButton = new UIButton({
-      label: options.helpLabel ?? '？',
+      label: options.helpLabel ?? 'ヘルプ',
       variant: 'ghost',
       preventRapid: false,
     });

--- a/src/views/watch.ts
+++ b/src/views/watch.ts
@@ -183,7 +183,7 @@ export const createWatchView = (options: WatchViewOptions): WatchViewElement => 
 
   if (options.onOpenHelp) {
     const helpButton = new UIButton({
-      label: options.helpLabel ?? '？',
+      label: options.helpLabel ?? 'ヘルプ',
       variant: 'ghost',
       preventRapid: false,
     });

--- a/styles/base.css
+++ b/styles/base.css
@@ -235,13 +235,6 @@
     flex: 1 1 160px;
   }
 
-  .scout__header-button--help,
-  .watch__header-button--help,
-  .spotlight__header-button--help {
-    flex: 0 0 auto;
-    width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
-  }
-
   .watch-actions {
     grid-template-columns: 1fr;
   }
@@ -669,11 +662,7 @@ p {
 }
 
 .scout__header-button--help {
-  width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
-  aspect-ratio: 1;
-  padding: 0;
   font-weight: 600;
-  border-radius: 999px;
 }
 
 .scout__title {
@@ -1272,10 +1261,7 @@ p {
 }
 
 .watch__header-button--help {
-  width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
-  aspect-ratio: 1;
-  padding: 0;
-  justify-content: center;
+  font-weight: 600;
 }
 
 .watch-status {
@@ -2497,10 +2483,7 @@ p {
 }
 
 .spotlight__header-button--help {
-  width: min(2.75rem, max(2.2rem, calc(4vw + 1rem)));
-  aspect-ratio: 1;
-  padding: 0;
-  justify-content: center;
+  font-weight: 600;
 }
 
 .spotlight-stage {
@@ -3332,10 +3315,10 @@ p {
     gap: 0.25rem;
   }
 
-  .scout__header-actions .button:not(.scout__header-button--help),
+  .scout__header-actions .button,
   .action__actions .button,
-  .watch__header-actions .button:not(.watch__header-button--help),
-  .spotlight__header-actions .button:not(.spotlight__header-button--help),
+  .watch__header-actions .button,
+  .spotlight__header-actions .button,
   .curtaincall__header .button {
     flex-basis: 100%;
   }
@@ -3413,13 +3396,6 @@ p {
   .spotlight__header-actions,
   .curtaincall__header {
     gap: 0.6rem;
-  }
-
-  .scout__header-button--help,
-  .watch__header-button--help,
-  .spotlight__header-button--help {
-    width: max(2.2rem, calc(1rem + var(--button-padding-y) * 2));
-    font-size: 0.95rem;
   }
 
   .action-hand__card {


### PR DESCRIPTION
## Summary
- change help button defaults to show 「ヘルプ」 instead of 「？」 in scout, watch, and spotlight views
- adjust responsive styles so help buttons align with other header actions on small screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9fabc0238832a83c31fd02271ff64