### PR TITLE
fix: ヘルプモーダルの読み込み失敗を修正

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -12,7 +12,7 @@ interface HelpTopicConfig {
 }
 
 const createHelpAssetUrl = (fileName: string): URL =>
-  new URL(`../help/${fileName}`, import.meta.url);
+  new URL(`./help/${fileName}`, import.meta.url);
 
 const HELP_TOPIC_CONFIGS: Record<HelpTopic, HelpTopicConfig> = {
   home: { url: createHelpAssetUrl('home.md') },


### PR DESCRIPTION
## Summary
- ヘルプMarkdownの参照パスを dist 配下に合わせて修正

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da45cd4610832ab2fddb10b46196a3