### PR TITLE
Fix modal gate markdown loading error

### DIFF
--- a/src/modal-content.ts
+++ b/src/modal-content.ts
@@ -1,7 +1,7 @@
 import { MODAL_MARKDOWN_ERROR_MESSAGE, MODAL_MARKDOWN_LOADING_MESSAGE } from './messages.js';
 import { fetchMarkdown, renderMarkdownToHtml } from './markdown.js';
 
-const createModalAssetUrl = (fileName: string): URL => new URL(`./modal/${fileName}`, import.meta.url);
+const createModalAssetUrl = (fileName: string): URL => new URL(`../modal/${fileName}`, import.meta.url);
 
 const MODAL_CONTENT_CONFIGS = {
   handoffDefault: { url: createModalAssetUrl('handoff-default.md') },


### PR DESCRIPTION
## Summary
- fix the modal markdown asset URL so gate dialogs can load their content correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dab45941b0832a84222ead825df8ac