### PR TITLE
ゲートモーダルのMarkdown読み込み不具合を修正

### DIFF
--- a/scripts/copy-help.mjs
+++ b/scripts/copy-help.mjs
@@ -6,8 +6,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const projectRoot = resolve(__dirname, '..');
-const sourceDir = resolve(projectRoot, 'help');
-const targetDir = resolve(projectRoot, 'dist', 'help');
+const assetDirs = ['help', 'modal'];
 
 const pathExists = async (path) => {
   try {
@@ -21,16 +20,25 @@ const pathExists = async (path) => {
   }
 };
 
-const main = async () => {
+const copyAssetDirectory = async (dirName) => {
+  const sourceDir = resolve(projectRoot, dirName);
+  const targetDir = resolve(projectRoot, 'dist', dirName);
+
   if (!(await pathExists(sourceDir))) {
-    console.warn('help ディレクトリが見つからないためコピーをスキップしました。');
+    console.warn(`${dirName} ディレクトリが見つからないためコピーをスキップしました。`);
     return;
   }
 
   await rm(targetDir, { recursive: true, force: true });
   await mkdir(dirname(targetDir), { recursive: true });
   await cp(sourceDir, targetDir, { recursive: true });
-  console.log('help ディレクトリを dist/help にコピーしました。');
+  console.log(`${dirName} ディレクトリを dist/${dirName} にコピーしました。`);
+};
+
+const main = async () => {
+  for (const dirName of assetDirs) {
+    await copyAssetDirectory(dirName);
+  }
 };
 
 main().catch((error) => {

--- a/src/modal-content.ts
+++ b/src/modal-content.ts
@@ -1,7 +1,13 @@
 import { MODAL_MARKDOWN_ERROR_MESSAGE, MODAL_MARKDOWN_LOADING_MESSAGE } from './messages.js';
 import { fetchMarkdown, renderMarkdownToHtml } from './markdown.js';
 
-const createModalAssetUrl = (fileName: string): URL => new URL(`../modal/${fileName}`, import.meta.url);
+const moduleUrl = import.meta.url;
+const modulePath = new URL(moduleUrl).pathname;
+const modalAssetBaseUrl = modulePath.includes('/dist/')
+  ? new URL('./modal/', moduleUrl)
+  : new URL('../modal/', moduleUrl);
+
+const createModalAssetUrl = (fileName: string): URL => new URL(fileName, modalAssetBaseUrl);
 
 const MODAL_CONTENT_CONFIGS = {
   handoffDefault: { url: createModalAssetUrl('handoff-default.md') },


### PR DESCRIPTION
## Summary
- ビルド成果物からモーダル用Markdownを解決できるようパスを調整
- build スクリプトで modal ディレクトリも dist にコピーするよう変更

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db254e4f18832aa6a260022005e39b