### PR TITLE
スタンバイヘルプをアクションボタン列に移動

### DIFF
--- a/src/views/standby.ts
+++ b/src/views/standby.ts
@@ -56,25 +56,6 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
 
   main.setAttribute('aria-labelledby', titleId);
 
-  if (options.onOpenHelp) {
-    const headerActions = document.createElement('div');
-    headerActions.className = 'standby__header-actions';
-
-    const helpButton = new UIButton({
-      label: options.helpLabel ?? 'ヘルプ',
-      variant: 'ghost',
-      preventRapid: true,
-    });
-    helpButton.el.classList.add('standby__header-button');
-    const helpAriaLabel = options.helpAriaLabel ?? options.helpLabel ?? 'ヘルプ';
-    helpButton.el.setAttribute('aria-label', helpAriaLabel);
-    helpButton.el.title = helpAriaLabel;
-    helpButton.onClick(() => options.onOpenHelp?.());
-    headerActions.append(helpButton.el);
-
-    main.append(headerActions);
-  }
-
   const content = document.createElement('div');
   content.className = 'standby__content';
 
@@ -270,14 +251,28 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
 
   main.append(content);
 
-  const actions = document.createElement('div');
-  actions.className = 'standby__actions';
-
   const homeButton = new UIButton({ label: 'HOMEに戻る', variant: 'ghost' });
   if (options.onReturnHome) {
     homeButton.onClick(() => {
       options.onReturnHome?.();
     });
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'standby__actions';
+
+  let helpButtonElement: HTMLElement | null = null;
+  if (options.onOpenHelp) {
+    const helpButton = new UIButton({
+      label: options.helpLabel ?? 'ヘルプ',
+      variant: 'ghost',
+      preventRapid: true,
+    });
+    const helpAriaLabel = options.helpAriaLabel ?? options.helpLabel ?? 'ヘルプ';
+    helpButton.el.setAttribute('aria-label', helpAriaLabel);
+    helpButton.el.title = helpAriaLabel;
+    helpButton.onClick(() => options.onOpenHelp?.());
+    helpButtonElement = helpButton.el;
   }
 
   const startButton = new UIButton({
@@ -410,7 +405,11 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
   updateFirstPlayerButtons();
   updateStartButtonState();
 
-  actions.append(homeButton.el, startButton.el);
+  actions.append(homeButton.el);
+  if (helpButtonElement) {
+    actions.append(helpButtonElement);
+  }
+  actions.append(startButton.el);
   main.append(actions);
 
   section.append(main, overlay);

--- a/styles/base.css
+++ b/styles/base.css
@@ -428,18 +428,6 @@ p {
   font-size: 1rem;
 }
 
-.standby__header-actions {
-  margin-top: clamp(0.85rem, 2vh, 1.25rem);
-  display: flex;
-  justify-content: center;
-  gap: 0.75rem;
-}
-
-.standby__header-button {
-  min-width: 0;
-  white-space: nowrap;
-}
-
 .standby__content {
   display: grid;
   gap: clamp(1.25rem, min(2.5vw, 4vh), 2rem);


### PR DESCRIPTION
## Summary
- スタンバイ画面のヘルプボタンをHOME/はじめると同列に並べ、操作エリアに集約しました
- 不要になったヘッダー用スタイルを削除しました

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db609a566c832a9b7416c9a203b7e8