### PR TITLE
Fix viewport height handling for full screen layout

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -106,6 +106,7 @@ import {
 import * as messages from './messages.js';
 import { TurnIndicator, type TurnIndicatorState } from './ui/turn-indicator.js';
 import { SettingsForm } from './ui/settings-form.js';
+import { initializeViewportHeightObserver } from './ui/viewport.js';
 import { openHelpTopic } from './help.js';
 import { createModalContentElement, type ModalContentKey } from './modal-content.js';
 
@@ -157,6 +158,8 @@ declare global {
     };
   }
 }
+
+initializeViewportHeightObserver();
 
 const NAVIGATION_BLOCKED_PHASES = new Set<PhaseKey>([
   'standby',

--- a/src/ui/viewport.ts
+++ b/src/ui/viewport.ts
@@ -1,0 +1,79 @@
+const CSS_VARIABLE_NAME = '--viewport-height';
+const HEIGHT_DIFF_THRESHOLD = 0.5;
+
+/**
+ * ビューポートの実寸にあわせて CSS 変数 `--viewport-height` を更新する。
+ * モバイル端末ではアドレスバーの表示/非表示で `100vh` が実画面とズレやすいため、
+ * `window.visualViewport` や `window.innerHeight` を監視して高さを補正する。
+ * requestAnimationFrame で更新をまとめることでリサイズ連打時の負荷を抑える。
+ */
+export const initializeViewportHeightObserver = (): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  if (!root) {
+    return;
+  }
+
+  let lastHeight = 0;
+  let rafId = 0;
+
+  const readViewportHeight = (): number => {
+    const viewport = window.visualViewport;
+    if (viewport) {
+      return viewport.height;
+    }
+    return window.innerHeight;
+  };
+
+  const applyViewportHeight = (height: number) => {
+    if (!Number.isFinite(height) || height <= 0) {
+      return;
+    }
+
+    if (Math.abs(height - lastHeight) < HEIGHT_DIFF_THRESHOLD) {
+      return;
+    }
+
+    lastHeight = height;
+    root.style.setProperty(CSS_VARIABLE_NAME, `${height}px`);
+  };
+
+  const updateViewportHeight = () => {
+    rafId = 0;
+    applyViewportHeight(readViewportHeight());
+  };
+
+  const requestViewportUpdate = () => {
+    if (rafId !== 0) {
+      return;
+    }
+
+    rafId = window.requestAnimationFrame(updateViewportHeight);
+  };
+
+  updateViewportHeight();
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible') {
+      requestViewportUpdate();
+    }
+  };
+
+  window.addEventListener('resize', requestViewportUpdate, { passive: true });
+  window.addEventListener('orientationchange', requestViewportUpdate, {
+    passive: true,
+  });
+  document.addEventListener('visibilitychange', handleVisibilityChange, {
+    passive: true,
+  });
+
+  const viewport = window.visualViewport;
+  if (viewport) {
+    viewport.addEventListener('resize', requestViewportUpdate, { passive: true });
+    viewport.addEventListener('scroll', requestViewportUpdate, { passive: true });
+  }
+};
+

--- a/styles/base.css
+++ b/styles/base.css
@@ -273,9 +273,14 @@
   box-sizing: border-box;
 }
 
+html {
+  height: var(--viewport-height);
+}
+
 body {
   margin: 0;
-  min-height: var(--viewport-height);
+  min-height: 100%;
+  height: var(--viewport-height);
   font-family: var(--font-sans);
   color: var(--color-text);
   background:
@@ -321,6 +326,7 @@ p {
 
 .app-shell {
   min-height: var(--viewport-height);
+  height: var(--viewport-height);
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -329,6 +335,7 @@ p {
 
 .view {
   min-height: var(--viewport-height);
+  height: var(--viewport-height);
   padding: var(--view-padding-block) var(--view-padding-inline);
   animation: view-fade-in var(--motion-duration-medium) var(--motion-ease-out) both;
 }


### PR DESCRIPTION
## Summary
- add a viewport height observer that keeps the CSS variable in sync with the real screen size
- update the app shell and view containers to consume the corrected height so screens fill without scrolling

## Testing
- npm run build *(fails: npm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd8b62908832aaaf8ea44979c01c2