### PR TITLE
ウォッチフェーズのカード配置を横並びに調整

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -1513,7 +1513,7 @@ p {
 .watch-stage__slots {
   display: grid;
   gap: clamp(1.15rem, 1.8vw, 1.65rem);
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .watch-stage__slot {


### PR DESCRIPTION
## Summary
- ウォッチステージのスロットを2列グリッドに固定し、役者札と黒子札が常に横並びで表示されるようにしました

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dbea6df49c832ab7f4f2400f814b30