### PR TITLE
スタンバイ画面のUI改善

### DIFF
--- a/src/views/standby.ts
+++ b/src/views/standby.ts
@@ -89,7 +89,7 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
     labelName.textContent = player.label;
     label.append(labelName);
 
-    if (player.role) {
+    if (player.role && player.role !== player.label) {
       const role = document.createElement('span');
       role.className = 'standby-player__role';
       role.textContent = player.role;
@@ -191,18 +191,22 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
   firstPlayerFieldset.append(firstPlayerOptions);
   content.append(firstPlayerFieldset);
 
-  const initializationFieldset = document.createElement('fieldset');
-  initializationFieldset.className = 'standby__fieldset standby__fieldset--initialization';
+  const initializationDetails = document.createElement('details');
+  initializationDetails.className =
+    'standby__fieldset standby__fieldset--initialization standby__details';
 
-  const initializationLegend = document.createElement('legend');
-  initializationLegend.className = 'standby__legend';
-  initializationLegend.textContent = '初期化';
-  initializationFieldset.append(initializationLegend);
+  const initializationSummary = document.createElement('summary');
+  initializationSummary.className = 'standby__legend standby__details-summary';
+  initializationSummary.textContent = '初期化';
+  initializationDetails.append(initializationSummary);
+
+  const initializationBody = document.createElement('div');
+  initializationBody.className = 'standby__details-body';
 
   const initializationStatus = document.createElement('p');
   initializationStatus.className = 'standby__initial-status';
   initializationStatus.textContent = 'セットとバックステージのシャッフル準備OK';
-  initializationFieldset.append(initializationStatus);
+  initializationBody.append(initializationStatus);
 
   const seedToggle = document.createElement('label');
   seedToggle.className = 'standby-seed-toggle';
@@ -211,6 +215,10 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
   seedCheckbox.type = 'checkbox';
   seedCheckbox.className = 'standby-seed-toggle__input';
   seedCheckbox.checked = Boolean(options.seedLockEnabled);
+
+  if (seedCheckbox.checked) {
+    initializationDetails.open = true;
+  }
 
   const seedLabel = document.createElement('span');
   seedLabel.className = 'standby-seed-toggle__label';
@@ -239,6 +247,9 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
     if (!seedCheckbox.checked) {
       currentSeedValue = null;
     }
+    if (seedCheckbox.checked) {
+      initializationDetails.open = true;
+    }
     updateSeedStatus();
     options.onSeedLockChange?.(seedCheckbox.checked);
   });
@@ -246,8 +257,9 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
   updateSeedStatus();
 
   seedToggle.append(seedCheckbox, seedLabel, seedStatus);
-  initializationFieldset.append(seedToggle);
-  content.append(initializationFieldset);
+  initializationBody.append(seedToggle);
+  initializationDetails.append(initializationBody);
+  content.append(initializationDetails);
 
   main.append(content);
 
@@ -280,6 +292,7 @@ export const createStandbyView = (options: StandbyViewOptions): HTMLElement => {
     variant: 'primary',
     disabled: !currentFirstPlayer,
   });
+  startButton.el.classList.add('standby__start-button');
 
   const updateStartButtonState = () => {
     startButton.setDisabled(!currentFirstPlayer);

--- a/styles/base.css
+++ b/styles/base.css
@@ -456,6 +456,46 @@ p {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.standby__details {
+  padding: 0;
+  overflow: hidden;
+}
+.standby__details-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: clamp(1.1rem, 3.5vh, 1.5rem);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  list-style: none;
+}
+.standby__details-summary::marker,
+.standby__details-summary::-webkit-details-marker {
+  display: none;
+}
+.standby__details-summary::after {
+  content: '';
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid rgba(148, 163, 184, 0.85);
+  border-bottom: 2px solid rgba(148, 163, 184, 0.85);
+  transform: rotate(45deg);
+  transition: transform 150ms ease;
+}
+.standby__details[open] .standby__details-summary::after {
+  transform: rotate(-135deg);
+}
+.standby__details-body {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0 clamp(1.1rem, 3.5vh, 1.5rem) clamp(1.1rem, 3.5vh, 1.5rem);
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+}
 
 .standby__players {
   display: grid;
@@ -529,7 +569,7 @@ p {
 }
 
 .standby__initial-status {
-  margin: 0 0 0.75rem;
+  margin: 0;
   color: var(--color-muted);
   font-size: 0.95rem;
 }
@@ -3663,15 +3703,32 @@ p {
     max-width: 100%;
   }
 
-  .standby__fieldset {
-    padding: clamp(0.9rem, 4.5vh, 1.25rem);
-  }
+    .standby__fieldset {
+      padding: clamp(0.9rem, 4.5vh, 1.25rem);
+    }
+    .standby__details-summary {
+      padding: clamp(0.9rem, 4.5vh, 1.25rem);
+    }
+    .standby__details-body {
+      padding: 0 clamp(0.9rem, 4.5vh, 1.25rem) clamp(0.9rem, 4.5vh, 1.25rem);
+    }
 
-  .standby-player__label {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25rem;
-  }
+    .standby-player__label {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.25rem;
+    }
+    .standby__actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    .standby__actions .button {
+      min-width: 0;
+      width: 100%;
+    }
+    .standby__start-button {
+      order: -1;
+    }
 
   .scout__header-actions .button,
   .action__actions .button,


### PR DESCRIPTION
## Summary
- プレイヤー名ラベルと役割表示の重複を解消し、初期化セクションを折りたたみ式の details に変更しました
- モバイル表示時のアクションボタンを再配置し、「はじめる」ボタンが最上部に来るように調整しました

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbe985ae64832a90a92d3123b6657d