### PR TITLE
Adjust mobile layout of standby action buttons

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -3728,11 +3728,13 @@ p {
     }
     .standby__actions {
       flex-direction: column;
-      align-items: stretch;
+      align-items: flex-start;
+      width: 100%;
     }
     .standby__actions .button {
-      min-width: 0;
+      flex: 0 0 auto;
       width: 100%;
+      max-width: 240px;
     }
     .standby__start-button {
       order: -1;

--- a/styles/base.css
+++ b/styles/base.css
@@ -3728,7 +3728,7 @@ p {
     }
     .standby__actions {
       flex-direction: column;
-      align-items: flex-start;
+      align-items: center;
       width: 100%;
     }
     .standby__actions .button {


### PR DESCRIPTION
## Summary
- tweak the standby actions layout on small screens so the HOME, ヘルプ, and はじめる buttons stack vertically
- constrain the button widths on phones to align with surrounding controls

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf0c6e3a0832ab6b3ac9a8c2dadf0