### PR TITLE
ハンバーガーメニューのレスポンシブ表示を修正

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -1993,7 +1993,6 @@ p {
 }
 
 .hamburger-menu__toggle {
-  display: none;
   gap: 0.45rem;
 }
 
@@ -2017,10 +2016,16 @@ p {
   box-shadow: 0 0 0 currentColor;
 }
 
-.hamburger-menu__panel {
-  display: flex;
-  align-items: center;
-  gap: clamp(0.5rem, 2vw, 0.85rem);
+@media (min-width: 721px) {
+  .hamburger-menu__toggle {
+    display: none;
+  }
+
+  .hamburger-menu__panel {
+    display: flex;
+    align-items: center;
+    gap: clamp(0.5rem, 2vw, 0.85rem);
+  }
 }
 
 .button--ghost {


### PR DESCRIPTION
## 概要
- ハンバーガーメニューのトグルとパネルの表示制御をブレークポイントごとに整理
- 幅721px以上の環境でのみトグルボタンを非表示にし、パネルを常時表示するよう修正
- モバイル環境でメニューが強制的に展開される不具合を解消

## テスト
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dbf508e804832a85ba34bdb4e2ff2d