### PR TITLE
fix: allow standby view to scroll when needed

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -342,13 +342,14 @@
 }
 
 html {
-  height: var(--viewport-height);
+  min-height: 100%;
+  min-height: var(--viewport-height);
 }
 
 body {
   margin: 0;
   min-height: 100%;
-  height: var(--viewport-height);
+  min-height: var(--viewport-height);
   font-family: var(--font-sans);
   color: var(--color-text);
   background:


### PR DESCRIPTION
## Summary
- allow the document height to grow beyond the viewport so standby can scroll when content exceeds the screen

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbf5391b60832a9d64a2f888ac0231