### PR TITLE
Reduce card footprint with vertical rank/suit layout

### DIFF
--- a/src/ui/card.ts
+++ b/src/ui/card.ts
@@ -50,14 +50,23 @@ export class CardComponent extends UIComponent<HTMLDivElement> {
   private renderFace(): void {
     if (this.faceDown) {
       this.element.classList.add('card--face-down');
-      this.element.textContent = '';
+      this.element.replaceChildren();
       this.element.setAttribute('aria-label', '伏せ札');
       return;
     }
 
     this.element.classList.remove('card--face-down');
     const symbol = SUIT_SYMBOL[this.suit];
-    this.element.textContent = `${this.rank}${symbol}`;
+
+    const rankElement = document.createElement('span');
+    rankElement.className = 'card__rank';
+    rankElement.textContent = this.rank;
+
+    const suitElement = document.createElement('span');
+    suitElement.className = 'card__suit';
+    suitElement.textContent = symbol;
+
+    this.element.replaceChildren(rankElement, suitElement);
     this.element.setAttribute('aria-label', `${this.suit} の ${this.rank}`);
   }
 }

--- a/styles/base.css
+++ b/styles/base.css
@@ -2521,15 +2521,27 @@ p {
 }
 
 .card {
-  width: 64px;
-  height: 92px;
-  border-radius: 10px;
+  width: 56px;
+  height: 80px;
+  border-radius: 8px;
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(148, 163, 184, 0.35);
-  display: grid;
-  place-items: center;
-  font-size: 1.15rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.15rem;
+  font-size: 1.05rem;
   font-weight: 600;
+  line-height: 1;
+}
+
+.card__rank {
+  font-size: 1em;
+}
+
+.card__suit {
+  font-size: 0.9em;
 }
 
 .card--face-down {


### PR DESCRIPTION
## Summary
- render card rank and suit on separate lines to support a more compact layout
- shrink the base card dimensions and update styling for the new vertical arrangement

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbf9094088832a9a0fa0517e6be8e4