### PR TITLE
セットオープン選択モーダルのレイアウトを調整

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -2169,7 +2169,7 @@ p {
   display: flex;
   justify-content: center;
   align-items: stretch;
-  overflow: auto;
+  overflow: hidden;
 }
 
 .modal--spotlight-set-picker .modal__body > .spotlight-set-picker {
@@ -3382,12 +3382,15 @@ p {
 
 .spotlight-set-picker {
   width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
+  align-items: stretch;
 }
 
 .spotlight-set-picker__panel {
-  width: min(100%, 1680px);
+  width: min(100%, 960px);
+  max-height: min(75vh, 640px);
   padding: clamp(1.25rem, 3.5vh, 1.75rem) clamp(1.5rem, 4vw, 2.25rem);
   border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 28px;
@@ -3397,7 +3400,9 @@ p {
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.5);
   backdrop-filter: blur(14px);
   display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
   gap: clamp(0.75rem, min(3vw, 4vh), 1.1rem);
+  overflow: hidden;
 }
 
 .spotlight-set-picker__header {
@@ -3431,19 +3436,19 @@ p {
   list-style: none;
   width: 100%;
   display: grid;
-  grid-template-rows: repeat(2, auto);
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(clamp(96px, 16vw, 140px), 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(clamp(96px, 28vw, 140px), 1fr));
   gap: clamp(0.65rem, min(1.5vw, 2.5vh), 1.1rem);
   justify-items: center;
   align-items: start;
-  overflow-x: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 0.25rem;
   padding-bottom: 0.25rem;
-  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
 }
 
 .spotlight-set-picker__list::-webkit-scrollbar {
-  height: 6px;
+  width: 6px;
 }
 
 .spotlight-set-picker__list::-webkit-scrollbar-track {


### PR DESCRIPTION
## Summary
- モーダル本体のサイズ上限を設定し、内部のパネルを画面内に収めるよう調整
- セットカード一覧を縦スクロール可能なグリッドに変更し、スクロールバーのスタイルを更新

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbfcb86280832a82d6cd98e0104840