### PR TITLE
Fix spotlight dialog default focus to avoid unintended skip

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4135,10 +4135,6 @@ const showSpotlightRevealResultDialog = (
   const actions = canOpenSet
     ? [
         {
-          ...skipAction,
-          variant: 'ghost' as const,
-        },
-        {
           label: SPOTLIGHT_SET_OPEN_BUTTON_LABEL,
           variant: 'primary' as const,
           preventRapid: true,
@@ -4147,6 +4143,10 @@ const showSpotlightRevealResultDialog = (
             modal.close();
             requestSpotlightSetOpen(openPlayerId);
           },
+        },
+        {
+          ...skipAction,
+          variant: 'ghost' as const,
         },
       ]
     : [


### PR DESCRIPTION
## Summary
- reorder the spotlight result dialog actions so the set-open button is focused before the skip option to prevent accidental skips

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe450638c832a9b71de1a8be54c79