### PR TITLE
Consolidate intermission utility menu

### DIFF
--- a/src/views/intermission.ts
+++ b/src/views/intermission.ts
@@ -95,37 +95,6 @@ export const createIntermissionView = (options: IntermissionViewOptions): Interm
   subtitle.textContent = options.subtitle;
   header.append(subtitle);
 
-  const headerActions = document.createElement('div');
-  headerActions.className = 'intermission__header-actions';
-
-  const headerMenu = new HamburgerMenu({
-    label: 'メニュー',
-    ariaLabel: '補助メニュー',
-  });
-  headerMenu.el.classList.add('intermission__menu');
-
-  if (options.onOpenHelp) {
-    const helpButton = new UIButton({
-      label: options.helpLabel ?? 'ヘルプ',
-      variant: 'ghost',
-      preventRapid: true,
-    });
-    helpButton.el.classList.add('intermission__header-button');
-    const ariaLabel = options.helpAriaLabel ?? options.helpLabel ?? 'ヘルプ';
-    helpButton.el.setAttribute('aria-label', ariaLabel);
-    helpButton.el.title = ariaLabel;
-    helpButton.onClick(() => options.onOpenHelp?.());
-    headerMenu.addItem(helpButton.el);
-  }
-
-  if (headerMenu.itemCount > 0) {
-    headerActions.append(headerMenu.el);
-  }
-
-  if (headerActions.childElementCount > 0) {
-    header.append(headerActions);
-  }
-
   main.setAttribute('aria-labelledby', headingId);
 
   const body = document.createElement('section');
@@ -162,6 +131,20 @@ export const createIntermissionView = (options: IntermissionViewOptions): Interm
   boardCheckButton.onClick(() => options.onOpenBoardCheck?.());
   boardCheckButton.el.classList.add('intermission__action-button');
   actionsMenu.addItem(boardCheckButton.el);
+
+  if (options.onOpenHelp) {
+    const helpButton = new UIButton({
+      label: options.helpLabel ?? 'ヘルプ',
+      variant: 'ghost',
+      preventRapid: true,
+    });
+    helpButton.el.classList.add('intermission__action-button');
+    const ariaLabel = options.helpAriaLabel ?? options.helpLabel ?? 'ヘルプ';
+    helpButton.el.setAttribute('aria-label', ariaLabel);
+    helpButton.el.title = ariaLabel;
+    helpButton.onClick(() => options.onOpenHelp?.());
+    actionsMenu.addItem(helpButton.el);
+  }
 
   if (actionsMenu.itemCount > 0) {
     actions.append(actionsMenu.el);

--- a/styles/base.css
+++ b/styles/base.css
@@ -2613,11 +2613,6 @@ p {
   gap: 0.75rem;
 }
 
-.intermission__header-button {
-  min-width: 0;
-  white-space: nowrap;
-}
-
 .intermission__body {
   display: grid;
   gap: clamp(1.5rem, 3vh, 2.25rem);


### PR DESCRIPTION
## Summary
- remove the extra hamburger menu from the intermission view header
- add the help action to the existing actions menu so board check and help share a single menu
- clean up the unused intermission header button styles

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dfe45d94d0832a857fc2d781756fe1