### PR TITLE
Remove hidden kuroko description text

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -280,7 +280,6 @@ const {
   WATCH_WARNING_BADGE_LABEL,
   WATCH_CLAP_WARNING_MESSAGE,
   WATCH_STAGE_EMPTY_MESSAGE,
-  WATCH_KUROKO_DEFAULT_DESCRIPTION,
   WATCH_DECISION_CONFIRM_TITLES,
   WATCH_DECISION_CONFIRM_MESSAGES,
   WATCH_DECISION_CONFIRM_OK_LABEL,
@@ -442,7 +441,6 @@ const CURTAINCALL_REASON_DESCRIPTIONS: Record<CurtainCallReason, string> = {
   handDepleted: '終了条件：手札枯渇',
 };
 const SPOTLIGHT_STAGE_EMPTY_MESSAGE = WATCH_STAGE_EMPTY_MESSAGE;
-const SPOTLIGHT_KUROKO_HIDDEN_DESCRIPTION = WATCH_KUROKO_DEFAULT_DESCRIPTION;
 
 const createWatchDecisionConfirmMessage = (decision: WatchDecision, playerName: string): string => {
   const base = WATCH_DECISION_CONFIRM_MESSAGES[decision];
@@ -2442,7 +2440,8 @@ const mapWatchStage = (state: GameState): WatchStageViewModel => {
           suit: kurokoCard.suit,
           faceDown: true,
           annotation: kurokoCard.annotation,
-          description: WATCH_KUROKO_DEFAULT_DESCRIPTION,
+          description:
+            kurokoCard.face === 'up' ? formatCardLabel(kurokoCard) : undefined,
         }
       : null,
     kurokoEmptyMessage: WATCH_STAGE_EMPTY_MESSAGE,
@@ -2502,9 +2501,7 @@ const mapSpotlightStage = (state: GameState): SpotlightStageViewModel => {
           faceDown: kurokoCard.face === 'down',
           annotation: kurokoCard.annotation,
           description:
-            kurokoCard.face === 'up'
-              ? formatCardLabel(kurokoCard)
-              : SPOTLIGHT_KUROKO_HIDDEN_DESCRIPTION,
+            kurokoCard.face === 'up' ? formatCardLabel(kurokoCard) : undefined,
         }
       : null,
     kurokoEmptyMessage: SPOTLIGHT_STAGE_EMPTY_MESSAGE,

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -185,7 +185,6 @@ export const WATCH_REMAINING_PLACEHOLDER = '—';
 export const WATCH_WARNING_BADGE_LABEL = 'ブーイング不足注意';
 export const WATCH_CLAP_WARNING_MESSAGE = '残り機会的にブーイングが必要です';
 export const WATCH_STAGE_EMPTY_MESSAGE = 'ステージにカードが配置されていません。';
-export const WATCH_KUROKO_DEFAULT_DESCRIPTION = '黒子のカードはまだ公開されていません。';
 export const WATCH_REDIRECTING_SUBTITLE = '宣言結果に応じた画面へ移動しています…';
 export const WATCH_GUARD_REDIRECTING_SUBTITLE =
   '秘匿情報を再表示するにはウォッチゲートを通過してください。';


### PR DESCRIPTION
## Summary
- remove the unused watch kuroko default description message
- prevent watch and spotlight views from showing copy for unrevealed kuroko cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfe46e8df0832a9a07dbe0bbca5878