### PR TITLE
review: Phase 0 sign-off（Issue #3）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,14 +1,21 @@
 # .ai-context.md
 
 ## Status
-works — Next.js 16.1.6 + TypeScript (strict) 初期化済み。`npm run build` 通過。
+Phase 0 完了・Sign-off済み。Next.js 16.1.6 + TypeScript (strict) + ESLint + Vitest 設定済み。Issue #9 着手可能。
 
 ## Active Issues
-- **#2 [Feature] ESLint / Vitest 設定** ← 次のターゲット
-- #9: コア型定義（Card / GameState / Phase）
+- **#9: コア型定義（Card / GameState / Phase）** ← 次のターゲット（feature/issue-9 ブランチで作業）
 - #10: デッキユーティリティ（createDeck / shuffle / deal）
 - #11: ゲーム状態管理（useGameReducer）
 - #12〜38: UI コンポーネント / フェーズ実装 / スコアリング等
+
+## In-Progress PRs
+（なし）
+
+## Completed
+- Issue #1: Next.js + TypeScript 初期化（main push）
+- Issue #2: ESLint + Vitest 設定（PR#39 マージ済み）
+- Issue #3: Phase 0 レビュー・Sign-off（クローズ済み）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -17,24 +24,24 @@ works — Next.js 16.1.6 + TypeScript (strict) 初期化済み。`npm run build`
 - ディレクトリ構成: `src/` 採用
 - TypeScript: `strict: true`
 - Issue #1: main に直接 push（初回セットアップのため許容。Issue #2 以降は feature branch → PR）
+- ESLint: v9 フラットコンフィグ (`eslint.config.mjs`)、next/core-web-vitals ルール
+- Vitest: jsdom 環境、`src/**/*.test.{ts,tsx}` 収集、passWithNoTests: true
 
 ## Next actions
-1. Issue #2: ESLint + Vitest 設定（feature/issue-2-eslint-vitest ブランチで作業）
-2. Issue #9: コア型定義
+1. Issue #9: コア型定義（feature/issue-9 ブランチで作業）
 
 ## Known pitfalls
 - `create-next-app` はディレクトリ名を npm package name に使う。大文字NG → `/tmp` 等で生成して移動する
-- Issue #1 は main に直接 push した。Issue #2 以降は必ず feature branch を切る
-- `os-template.yml` の lint/test は Issue #2 まで `echo 'skip'` のまま（意図的）
+- ESLint v9 は `.eslintrc.*` 非対応。フラットコンフィグ（`eslint.config.mjs`）を使うこと
 
 ## Commands
-- format: TODO（Issue #2 で設定予定、Prettier）
-- lint: echo 'skip'（TODO: Issue #2 で ESLint 設定）
+- format: TODO（Prettier 未設定）
+- lint: `npx eslint .`（os-template.yml 設定済み）
 - typecheck: `npx tsc --noEmit`
-- test: echo 'skip'（TODO: Issue #2 で Vitest 設定）
+- test: `npx vitest run`（os-template.yml 設定済み）
 - build: `npm run build`
 - dev: `npm run dev`
 
 ## CI Notes
-- .github/workflows/ci.yml は存在するが、lint/test が skip のため実質通過するのみ
-- Issue #2 後に実効的な CI になる
+- `./os/scripts/run lint` / `./os/scripts/run test` が実効的に動作するようになった
+- CI は macos-latest で `./os/scripts/run ci` を実行（lint → typecheck → test）


### PR DESCRIPTION
## Summary

- Issue #1・#2 の全 AC を確認し、Phase 0 の品質基盤を Sign-off
- `.ai-context.md` を Phase 0 完了状態に更新

## レビュー結果

| AC | 結果 |
|---|---|
| Issue #1・#2 の全 AC 達成 | ✅ |
| CI が green | ✅ |
| TypeScript strict mode 型エラー 0 件 | ✅ |
| lint / test 通過 | ✅ |

## Test plan

- [ ] CI green 確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)