### PR TITLE
feat: コア型定義を追加（Card / GameState / GamePhase / Player / Stage / PublicInfo）

### DIFF
--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,48 @@
+export type Suit = 'spades' | 'hearts' | 'diamonds' | 'clubs';
+
+export type Card = {
+  suit: Suit;
+  rank: number; // 1-13, 0 for Joker
+  isJoker: boolean;
+  isFaceUp: boolean;
+};
+
+export type Player = {
+  id: string;
+  name: string;
+  hand: Card[];
+};
+
+export type Stage = {
+  kami: Card | null;
+  shimo: Card | null;
+};
+
+export type GamePhase =
+  | 'standby'
+  | 'scout'
+  | 'action'
+  | 'watch'
+  | 'spotlight'
+  | 'backstage'
+  | 'intermission'
+  | 'curtain-call'
+  | 'result';
+
+export type PublicInfo = {
+  playerId: string;
+  card: Card;
+  round: number;
+};
+
+export type GameState = {
+  phase: GamePhase;
+  players: [Player, Player];
+  stage: Stage;
+  deck: Card[];
+  setRemainingCount: number; // 裏向きカード数（セット残枚数）
+  publicInfos: PublicInfo[];
+  playerABooCnt: number;
+  playerBBooCnt: number;
+  round: number;
+};


### PR DESCRIPTION
## Summary
- `src/types/game.ts` にゲーム全体で使用するTypeScript型定義を集約
- Card / Player / Stage / GamePhase / PublicInfo / GameState を定義
- GameState にブーイング回数カウント（playerABooCnt / playerBBooCnt）・セット残枚数（setRemainingCount）を含める

## Test plan
- [ ] `npx tsc --noEmit` でエラー0件を確認済み

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)