### PR TITLE
[Feature] GameStateにcurtainCallReasonフィールドを追加

### DIFF
--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -35,6 +35,8 @@ export type PublicInfo = {
   round: number;
 };
 
+export type CurtainCallReason = 'joker' | 'set-last-1' | 'hand-shortage';
+
 export type GameState = {
   phase: GamePhase;
   players: [Player, Player];
@@ -45,4 +47,5 @@ export type GameState = {
   playerABooCnt: number;
   playerBBooCnt: number;
   round: number;
+  curtainCallReason: CurtainCallReason | null;
 };


### PR DESCRIPTION
## Summary
- `CurtainCallReason` 型を新規定義（`'joker' | 'set-last-1' | 'hand-shortage'`）
- `GameState` に `curtainCallReason: CurtainCallReason | null` フィールドを追加

## Issue #9 差分AC対応
Issue #4 で実装済みの型定義に、Issue #9 で追加された AC（`curtainCallReason`）を補完。

Closes #9

## Test plan
- [x] `npx tsc --noEmit` エラー0件
- [x] `npx vitest run` 13テスト全パス