### PR TITLE
[Feature] ゲーム状態管理（useGameReducer）

### DIFF
--- a/src/game/context.tsx
+++ b/src/game/context.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useContext, useReducer } from 'react';
+import type { GameState } from '@/types/game';
+import { type GameAction, gameReducer, initialState } from '@/game/reducer';
+
+const GameStateContext = createContext<GameState>(initialState);
+const GameDispatchContext = createContext<React.Dispatch<GameAction>>(
+  (_action: GameAction): void => {},
+);
+
+export function GameProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(gameReducer, initialState);
+  return (
+    <GameDispatchContext.Provider value={dispatch}>
+      <GameStateContext.Provider value={state}>
+        {children}
+      </GameStateContext.Provider>
+    </GameDispatchContext.Provider>
+  );
+}
+
+export function useGameState(): GameState {
+  return useContext(GameStateContext);
+}
+
+export function useGameDispatch(): React.Dispatch<GameAction> {
+  return useContext(GameDispatchContext);
+}

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { gameReducer, initialState } from './reducer';
+import type { GameState } from '@/types/game';
+
+describe('gameReducer', () => {
+  describe('INIT_GAME', () => {
+    const state = gameReducer(initialState, {
+      type: 'INIT_GAME',
+      playerAName: 'Alice',
+      playerBName: 'Bob',
+    });
+
+    it('phase が scout になる', () => {
+      expect(state.phase).toBe('scout');
+    });
+
+    it('プレイヤーAの手札が15枚になる', () => {
+      expect(state.players[0].hand).toHaveLength(15);
+    });
+
+    it('プレイヤーBの手札が15枚になる', () => {
+      expect(state.players[1].hand).toHaveLength(15);
+    });
+
+    it('セット（deck）が13枚になる', () => {
+      expect(state.deck).toHaveLength(13);
+    });
+
+    it('setRemainingCount が 13 になる', () => {
+      expect(state.setRemainingCount).toBe(13);
+    });
+
+    it('プレイヤー名が正しくセットされる', () => {
+      expect(state.players[0].name).toBe('Alice');
+      expect(state.players[1].name).toBe('Bob');
+    });
+
+    it('round が 1 になる', () => {
+      expect(state.round).toBe(1);
+    });
+
+    it('セットにJokerが1枚含まれる', () => {
+      expect(state.deck.filter((c) => c.isJoker)).toHaveLength(1);
+    });
+  });
+
+  describe('SCOUT_CARD', () => {
+    let scoutState: GameState;
+    beforeEach(() => {
+      scoutState = gameReducer(initialState, {
+        type: 'INIT_GAME',
+        playerAName: 'Alice',
+        playerBName: 'Bob',
+      });
+    });
+
+    it('phase が action になる', () => {
+      const result = gameReducer(scoutState, { type: 'SCOUT_CARD', cardIndex: 0 });
+      expect(result.phase).toBe('action');
+    });
+
+    it('Aの手札が1枚増える', () => {
+      const result = gameReducer(scoutState, { type: 'SCOUT_CARD', cardIndex: 0 });
+      expect(result.players[0].hand).toHaveLength(16);
+    });
+
+    it('Bの手札が1枚減る', () => {
+      const result = gameReducer(scoutState, { type: 'SCOUT_CARD', cardIndex: 0 });
+      expect(result.players[1].hand).toHaveLength(14);
+    });
+
+    it('選択したカードがAの手札末尾に追加される', () => {
+      const targetCard = scoutState.players[1].hand[3];
+      const result = gameReducer(scoutState, { type: 'SCOUT_CARD', cardIndex: 3 });
+      expect(result.players[0].hand.at(-1)).toEqual(targetCard);
+    });
+  });
+
+  describe('ACTION_PLAY', () => {
+    it('phase が watch になる', () => {
+      const afterInit = gameReducer(initialState, {
+        type: 'INIT_GAME',
+        playerAName: 'Alice',
+        playerBName: 'Bob',
+      });
+      const afterScout = gameReducer(afterInit, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const result = gameReducer(afterScout, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      expect(result.phase).toBe('watch');
+    });
+
+    it('ステージにkami/shimoがセットされる', () => {
+      const afterInit = gameReducer(initialState, {
+        type: 'INIT_GAME',
+        playerAName: 'Alice',
+        playerBName: 'Bob',
+      });
+      const afterScout = gameReducer(afterInit, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const kami = afterScout.players[0].hand[0];
+      const shimo = afterScout.players[0].hand[1];
+      const result = gameReducer(afterScout, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      expect(result.stage.kami).toEqual({ ...kami, isFaceUp: true });
+      expect(result.stage.shimo).toEqual({ ...shimo, isFaceUp: false });
+    });
+  });
+
+  describe('WATCH_CLAP / WATCH_BOO', () => {
+    let watchState: GameState;
+    beforeEach(() => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
+      const s2 = gameReducer(s1, { type: 'SCOUT_CARD', cardIndex: 0 });
+      watchState = gameReducer(s2, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+    });
+
+    it('WATCH_CLAP で phase が intermission になる', () => {
+      expect(gameReducer(watchState, { type: 'WATCH_CLAP' }).phase).toBe('intermission');
+    });
+
+    it('WATCH_BOO で phase が spotlight になる', () => {
+      expect(gameReducer(watchState, { type: 'WATCH_BOO' }).phase).toBe('spotlight');
+    });
+
+    it('WATCH_BOO で playerBBooCnt が増える', () => {
+      const result = gameReducer(watchState, { type: 'WATCH_BOO' });
+      expect(result.playerBBooCnt).toBe(1);
+    });
+  });
+
+  describe('RESET_GAME', () => {
+    it('phase が standby に戻る', () => {
+      const afterInit = gameReducer(initialState, {
+        type: 'INIT_GAME',
+        playerAName: 'Alice',
+        playerBName: 'Bob',
+      });
+      const result = gameReducer(afterInit, { type: 'RESET_GAME' });
+      expect(result.phase).toBe('standby');
+    });
+
+    it('initialState と同一の値を返す', () => {
+      const afterInit = gameReducer(initialState, {
+        type: 'INIT_GAME',
+        playerAName: 'Alice',
+        playerBName: 'Bob',
+      });
+      const result = gameReducer(afterInit, { type: 'RESET_GAME' });
+      expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('不正遷移', () => {
+    it('standby フェーズで SCOUT_CARD を dispatch しても state が変わらない', () => {
+      const result = gameReducer(initialState, { type: 'SCOUT_CARD', cardIndex: 0 });
+      expect(result).toBe(initialState);
+    });
+
+    it('standby フェーズで ACTION_PLAY を dispatch しても state が変わらない', () => {
+      const result = gameReducer(initialState, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      expect(result).toBe(initialState);
+    });
+
+    it('standby フェーズで WATCH_CLAP を dispatch しても state が変わらない', () => {
+      const result = gameReducer(initialState, { type: 'WATCH_CLAP' });
+      expect(result).toBe(initialState);
+    });
+  });
+});

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -1,0 +1,221 @@
+import type { Card, CurtainCallReason, GamePhase, GameState, Player } from '@/types/game';
+import { createDeck, createDeckWithJoker, deal, shuffle } from '@/lib/deck';
+
+export type GameAction =
+  | { type: 'INIT_GAME'; playerAName: string; playerBName: string }
+  | { type: 'SCOUT_CARD'; cardIndex: number }
+  | { type: 'ACTION_PLAY'; kamiIndex: number; shimoIndex: number }
+  | { type: 'WATCH_CLAP' }
+  | { type: 'WATCH_BOO' }
+  | { type: 'SPOTLIGHT_REVEAL' }
+  | { type: 'SPOTLIGHT_OPEN_SET'; setCardIndex: number }
+  | { type: 'SPOTLIGHT_SKIP_SET' }
+  | { type: 'BACKSTAGE_OPEN' }
+  | { type: 'INTERMISSION' }
+  | { type: 'CURTAIN_CALL'; reason: CurtainCallReason }
+  | { type: 'RESET_GAME' };
+
+export const initialState: GameState = {
+  phase: 'standby',
+  players: [
+    { id: 'A', name: '', hand: [] },
+    { id: 'B', name: '', hand: [] },
+  ],
+  stage: { kami: null, shimo: null },
+  deck: [],
+  setRemainingCount: 0,
+  publicInfos: [],
+  playerABooCnt: 0,
+  playerBBooCnt: 0,
+  round: 0,
+  curtainCallReason: null,
+};
+
+function removeCardAt(cards: Card[], index: number): Card[] {
+  return [...cards.slice(0, index), ...cards.slice(index + 1)];
+}
+
+export function gameReducer(state: GameState, action: GameAction): GameState {
+  switch (action.type) {
+    case 'INIT_GAME': {
+      // 52枚シャッフルして A15枚 / B15枚 / バックステージ10枚 に配布
+      const shuffled52 = shuffle(createDeck());
+      const dealt = deal(shuffled52, [15, 15, 10]);
+      const handA: Card[] = dealt[0];
+      const handB: Card[] = dealt[1];
+      // バックステージ(backstage)は後続Issueで利用
+      // dealt[2] = backstage（10枚）は GameState に未定義のため使用しない
+      // 残り12枚 + Joker1枚 = 13枚をシャッフルしてセットに
+      const remaining12 = shuffled52.slice(40);
+      const joker = createDeckWithJoker().slice(52)[0];
+      const setDeck = shuffle([...remaining12, joker]);
+
+      const playerA: Player = { id: 'A', name: action.playerAName, hand: handA };
+      const playerB: Player = { id: 'B', name: action.playerBName, hand: handB };
+      const players: [Player, Player] = [playerA, playerB];
+
+      return {
+        ...initialState,
+        phase: 'scout',
+        players,
+        deck: setDeck,
+        setRemainingCount: setDeck.length,
+        round: 1,
+      };
+    }
+
+    case 'SCOUT_CARD': {
+      if (state.phase !== 'scout') return state;
+      const scoutedCard = state.players[1].hand[action.cardIndex];
+      if (scoutedCard === undefined) return state;
+
+      const newPlayerA: Player = {
+        ...state.players[0],
+        hand: [...state.players[0].hand, scoutedCard],
+      };
+      const newPlayerB: Player = {
+        ...state.players[1],
+        hand: removeCardAt(state.players[1].hand, action.cardIndex),
+      };
+      const players: [Player, Player] = [newPlayerA, newPlayerB];
+
+      return { ...state, phase: 'action', players };
+    }
+
+    case 'ACTION_PLAY': {
+      if (state.phase !== 'action') return state;
+      const hand = state.players[0].hand;
+      const kamiCard = hand[action.kamiIndex];
+      const shimoCard = hand[action.shimoIndex];
+      if (kamiCard === undefined || shimoCard === undefined) return state;
+      if (action.kamiIndex === action.shimoIndex) return state;
+
+      const kami: Card = { ...kamiCard, isFaceUp: true };
+      const shimo: Card = { ...shimoCard, isFaceUp: false };
+
+      // kamiIndex と shimoIndex の大きい方から順に除去してインデックスずれを防ぐ
+      const [firstRemove, secondRemove] =
+        action.kamiIndex > action.shimoIndex
+          ? [action.kamiIndex, action.shimoIndex]
+          : [action.shimoIndex, action.kamiIndex];
+      const handAfterFirst = removeCardAt(hand, firstRemove);
+      const newHand = removeCardAt(handAfterFirst, secondRemove);
+
+      const newPlayerA: Player = { ...state.players[0], hand: newHand };
+      const players: [Player, Player] = [newPlayerA, state.players[1]];
+
+      return { ...state, phase: 'watch', players, stage: { kami, shimo } };
+    }
+
+    case 'WATCH_CLAP': {
+      if (state.phase !== 'watch') return state;
+      return { ...state, phase: 'intermission' };
+    }
+
+    case 'WATCH_BOO': {
+      if (state.phase !== 'watch') return state;
+      const isPlayerA = state.round % 2 === 1;
+      return {
+        ...state,
+        phase: 'spotlight',
+        playerABooCnt: isPlayerA ? state.playerABooCnt : state.playerABooCnt,
+        playerBBooCnt: isPlayerA ? state.playerBBooCnt + 1 : state.playerBBooCnt,
+      };
+    }
+
+    case 'SPOTLIGHT_REVEAL': {
+      if (state.phase !== 'spotlight') return state;
+      if (state.stage.shimo === null) return state;
+      const revealedShimo: Card = { ...state.stage.shimo, isFaceUp: true };
+      return { ...state, stage: { ...state.stage, shimo: revealedShimo } };
+    }
+
+    case 'SPOTLIGHT_OPEN_SET': {
+      if (state.phase !== 'spotlight') return state;
+      const setCard = state.deck[action.setCardIndex];
+      if (setCard === undefined) return state;
+
+      const openedCard: Card = { ...setCard, isFaceUp: true };
+      const newDeck = [...state.deck];
+      newDeck[action.setCardIndex] = openedCard;
+      const newSetRemainingCount = state.setRemainingCount - 1;
+
+      if (openedCard.isJoker) {
+        return {
+          ...state,
+          deck: newDeck,
+          setRemainingCount: newSetRemainingCount,
+          phase: 'curtain-call',
+          curtainCallReason: 'joker',
+        };
+      }
+      if (newSetRemainingCount <= 1) {
+        return {
+          ...state,
+          deck: newDeck,
+          setRemainingCount: newSetRemainingCount,
+          phase: 'curtain-call',
+          curtainCallReason: 'set-last-1',
+        };
+      }
+
+      // ペア判定などの詳細ロジックは後続Issueで実装
+      return {
+        ...state,
+        deck: newDeck,
+        setRemainingCount: newSetRemainingCount,
+        phase: 'backstage',
+      };
+    }
+
+    case 'SPOTLIGHT_SKIP_SET': {
+      if (state.phase !== 'spotlight') return state;
+      return { ...state, phase: 'backstage' };
+    }
+
+    case 'BACKSTAGE_OPEN': {
+      if (state.phase !== 'backstage') return state;
+      return { ...state, phase: 'intermission' };
+    }
+
+    case 'INTERMISSION': {
+      if (state.phase !== 'intermission') return state;
+
+      // 手札不足チェック：次のスカウト担当（ラウンド偶数でBがスカウト）の手札0枚
+      const nextScoutIsA = state.round % 2 === 0;
+      const nextScoutHand = nextScoutIsA
+        ? state.players[0].hand
+        : state.players[1].hand;
+      const otherHand = nextScoutIsA ? state.players[1].hand : state.players[0].hand;
+
+      if (nextScoutHand.length === 0 || (nextScoutHand.length === 1 && otherHand.length === 0)) {
+        return { ...state, phase: 'curtain-call', curtainCallReason: 'hand-shortage' };
+      }
+
+      // AとBを入れ替え（ラウンド交代）、次フェーズはscout
+      const swappedPlayers: [Player, Player] = [state.players[1], state.players[0]];
+      return {
+        ...state,
+        phase: 'scout',
+        players: swappedPlayers,
+        round: state.round + 1,
+        stage: { kami: null, shimo: null },
+      };
+    }
+
+    case 'CURTAIN_CALL': {
+      return { ...state, phase: 'curtain-call', curtainCallReason: action.reason };
+    }
+
+    case 'RESET_GAME': {
+      return initialState;
+    }
+
+    default: {
+      const _exhaustive: never = action;
+      return _exhaustive;
+    }
+  }
+}
+
+export type { GamePhase };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import path from "path";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## 概要

Issue #11「ゲーム状態管理（useGameReducer）」を実装します。

Closes #11

## 変更内容

- `src/game/reducer.ts`: `GameAction` union type と `gameReducer` pure function を実装
- `src/game/context.tsx`: `GameContext` / `GameProvider` / `useGameState` / `useGameDispatch` を実装
- `src/game/reducer.test.ts`: フェーズ遷移ユニットテスト（22ケース）を追加
- `vitest.config.ts`: `@/` パスエイリアスを追加（`@/lib/deck` などのインポートをテストで解決するために必要）

## AC確認

- [x] `GameContext` が存在し、全子コンポーネントからアクセスできる（`GameProvider` + `useGameState`）
- [x] `useGameState()` で現在の `GameState` を取得できる
- [x] `useGameDispatch()` でアクションをdispatchできる
- [x] 全 `GameAction` type が定義されている（11アクション）
- [x] TypeScript strict mode でエラーが0件
- [x] reducerの基本遷移（standby→scout）のユニットテストが通る

## テスト結果

- TypeScript: エラー0件
- Vitest: 35テスト全パス（既存13 + 新規22）

🤖 Generated with [Claude Code](https://claude.com/claude-code)