### PR TITLE
[Review] Phase 1 sign-off（Issue #12）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,13 +1,15 @@
 # .ai-context.md
 
 ## Status
-Phase 0 完了・Sign-off済み。Next.js 16.1.6 + TypeScript (strict) + ESLint + Vitest 設定済み。Issue #9 着手可能。
+Phase 1 完了・Sign-off済み。コアドメイン層（型定義・デッキユーティリティ・ゲーム状態管理）実装済み。Issue #13 着手可能。
 
 ## Active Issues
-- **#9: コア型定義（Card / GameState / Phase）** ← 次のターゲット（feature/issue-9 ブランチで作業）
-- #10: デッキユーティリティ（createDeck / shuffle / deal）
-- #11: ゲーム状態管理（useGameReducer）
-- #12〜38: UI コンポーネント / フェーズ実装 / スコアリング等
+- **#13: Card コンポーネント** ← 次のターゲット（Phase 2: UI コンポーネント）
+- #14: Stage レイアウトコンポーネント（Kami / Shimo エリア）
+- #15: PhaseHeader コンポーネント
+- #16: InfoOverlay コンポーネント
+- #17: PassDevice 画面
+- #18〜38: 後続フェーズ実装等
 
 ## In-Progress PRs
 （なし）
@@ -16,6 +18,10 @@ Phase 0 完了・Sign-off済み。Next.js 16.1.6 + TypeScript (strict) + ESLint 
 - Issue #1: Next.js + TypeScript 初期化（main push）
 - Issue #2: ESLint + Vitest 設定（PR#39 マージ済み）
 - Issue #3: Phase 0 レビュー・Sign-off（クローズ済み）
+- Issue #9: コア型定義（PR#41/43 マージ済み）
+- Issue #10: デッキユーティリティ（PR#42 マージ済み）
+- Issue #11: ゲーム状態管理（PR#44 マージ済み）
+- Issue #12: Phase 1 レビュー・Sign-off（クローズ済み）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -26,13 +32,17 @@ Phase 0 完了・Sign-off済み。Next.js 16.1.6 + TypeScript (strict) + ESLint 
 - Issue #1: main に直接 push（初回セットアップのため許容。Issue #2 以降は feature branch → PR）
 - ESLint: v9 フラットコンフィグ (`eslint.config.mjs`)、next/core-web-vitals ルール
 - Vitest: jsdom 環境、`src/**/*.test.{ts,tsx}` 収集、passWithNoTests: true
+- vitest.config.ts に `resolve.alias` (`@/` → `./src`) を追加（@/ エイリアス解決のため）
+- GameState/Reducer 設計: State と Dispatch を別 Context に分離（不要な再レンダー防止）
+- 不正遷移ガード: reducer の各アクションで phase をチェック、不正時は同一参照を返す（pure function）
 
 ## Next actions
-1. Issue #9: コア型定義（feature/issue-9 ブランチで作業）
+1. Issue #13: Card コンポーネント（feature/issue-13 ブランチで作業）
 
 ## Known pitfalls
 - `create-next-app` はディレクトリ名を npm package name に使う。大文字NG → `/tmp` 等で生成して移動する
 - ESLint v9 は `.eslintrc.*` 非対応。フラットコンフィグ（`eslint.config.mjs`）を使うこと
+- Vitest は tsconfig の `paths` を自動解決しない。`vitest.config.ts` に `resolve.alias` を明示すること
 
 ## Commands
 - format: TODO（Prettier 未設定）
@@ -45,3 +55,4 @@ Phase 0 完了・Sign-off済み。Next.js 16.1.6 + TypeScript (strict) + ESLint 
 ## CI Notes
 - `./os/scripts/run lint` / `./os/scripts/run test` が実効的に動作するようになった
 - CI は macos-latest で `./os/scripts/run ci` を実行（lint → typecheck → test）
+- PR #44 の CI: ci/dependency-scan/guardrail/lcg/secret-scan すべて SUCCESS


### PR DESCRIPTION
## Summary

- Issue #9・#10・#11（コア型定義・デッキユーティリティ・ゲーム状態管理）の全 AC 達成を確認
- rulebook.md の全フェーズ（standby/scout/action/watch/spotlight/backstage/intermission/curtain-call）が `GamePhase` に含まれていることを確認
- 全 35 テスト通過・`tsc --noEmit` エラー 0 件
- PR #44 の CI 全チェック SUCCESS 確認

## Test plan

- [x] `npx vitest run` → 35 passed
- [x] `npx tsc --noEmit` → エラーなし
- [x] CI チェック（ci / dependency-scan / guardrail / lcg / secret-scan）→ 全 SUCCESS

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)