### PR TITLE
[Feature] Card コンポーネント実装 #13

### DIFF
--- a/src/components/Card.module.css
+++ b/src/components/Card.module.css
@@ -1,0 +1,86 @@
+.card {
+  width: var(--card-w, 52px);
+  height: var(--card-h, 76px);
+  border-radius: 7px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  flex-shrink: 0;
+  position: relative;
+  user-select: none;
+  cursor: default;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:active {
+  opacity: 0.75;
+}
+
+/* 表向き */
+.face {
+  background: #fff;
+  color: #222;
+  border: 1.5px solid #ccc;
+}
+
+.suit {
+  font-size: 20px;
+  line-height: 1;
+}
+
+.rank {
+  font-size: 13px;
+  font-weight: bold;
+}
+
+.red .suit {
+  color: #e74c3c;
+}
+
+.red .rank {
+  color: #e74c3c;
+}
+
+/* 裏向き */
+.back {
+  background: linear-gradient(135deg, #1a2a4a 0%, #0f3460 50%, #1a2a4a 100%);
+  border: 1.5px solid #0f3460;
+}
+
+.back::after {
+  content: '◈';
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.15);
+}
+
+/* ジョーカー */
+.joker {
+  background: linear-gradient(135deg, #f39c12, #e74c3c);
+  border: 1.5px solid #f39c12;
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.jokerLabel {
+  font-size: 10px;
+  font-weight: bold;
+  letter-spacing: 1px;
+}
+
+/* 選択状態 */
+.selected {
+  box-shadow: 0 0 0 2.5px #e94560;
+  transform: translateY(-6px);
+}
+
+.selectedShimo {
+  box-shadow: 0 0 0 2.5px #7b52e8;
+  transform: translateY(-6px);
+}

--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Card from './Card';
+import type { Card as CardType } from '@/types/game';
+
+const faceUpCard = (suit: CardType['suit'], rank: number): CardType => ({
+  suit,
+  rank,
+  isJoker: false,
+  isFaceUp: true,
+});
+
+const faceDownCard = (): CardType => ({
+  suit: 'spades',
+  rank: 1,
+  isJoker: false,
+  isFaceUp: false,
+});
+
+const jokerCard = (): CardType => ({
+  suit: 'spades',
+  rank: 0,
+  isJoker: true,
+  isFaceUp: true,
+});
+
+describe('Card', () => {
+  it('表向きカードがスートとランクを表示する', () => {
+    render(<Card card={faceUpCard('spades', 1)} />);
+    expect(screen.getByText('♠')).toBeDefined();
+    expect(screen.getByText('A')).toBeDefined();
+  });
+
+  it('数字カード（2-10）をそのまま表示する', () => {
+    render(<Card card={faceUpCard('hearts', 7)} />);
+    expect(screen.getByText('♥')).toBeDefined();
+    expect(screen.getByText('7')).toBeDefined();
+  });
+
+  it('絵札（J/Q/K）を正しく表示する', () => {
+    const { rerender } = render(<Card card={faceUpCard('clubs', 11)} />);
+    expect(screen.getByText('J')).toBeDefined();
+
+    rerender(<Card card={faceUpCard('diamonds', 12)} />);
+    expect(screen.getByText('Q')).toBeDefined();
+
+    rerender(<Card card={faceUpCard('clubs', 13)} />);
+    expect(screen.getByText('K')).toBeDefined();
+  });
+
+  it('裏向きカードはスート・ランクを表示しない', () => {
+    render(<Card card={faceDownCard()} />);
+    expect(screen.queryByText('♠')).toBeNull();
+    expect(screen.queryByText('A')).toBeNull();
+  });
+
+  it('ジョーカーがJOKERラベルを表示する', () => {
+    render(<Card card={jokerCard()} />);
+    expect(screen.getByText('JOKER')).toBeDefined();
+  });
+
+  it('selected状態でselectedクラスが付く', () => {
+    const { container } = render(<Card card={faceUpCard('spades', 5)} isSelected />);
+    expect(container.firstChild?.toString()).toBeTruthy();
+    const el = container.querySelector('[class*="selected"]');
+    expect(el).toBeTruthy();
+  });
+
+  it('isSelectedShimo状態でselectedShimoクラスが付く', () => {
+    const { container } = render(<Card card={faceUpCard('clubs', 3)} isSelectedShimo />);
+    const el = container.querySelector('[class*="selectedShimo"]');
+    expect(el).toBeTruthy();
+  });
+
+  it('onClick が呼ばれる', () => {
+    const handleClick = vi.fn();
+    render(<Card card={faceUpCard('hearts', 10)} onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,65 @@
+import type { Card as CardType } from '@/types/game';
+import styles from './Card.module.css';
+
+const SUIT_SYMBOL: Record<string, string> = {
+  spades: '♠',
+  hearts: '♥',
+  diamonds: '♦',
+  clubs: '♣',
+};
+
+const RED_SUITS = new Set(['hearts', 'diamonds']);
+
+const RANK_LABEL: Record<number, string> = {
+  1: 'A',
+  11: 'J',
+  12: 'Q',
+  13: 'K',
+};
+
+function rankLabel(rank: number): string {
+  return RANK_LABEL[rank] ?? String(rank);
+}
+
+type Props = {
+  card: CardType;
+  isSelected?: boolean;
+  isSelectedShimo?: boolean;
+  onClick?: () => void;
+};
+
+export default function Card({ card, isSelected, isSelectedShimo, onClick }: Props) {
+  const classNames = [styles.card];
+
+  if (isSelected) classNames.push(styles.selected);
+  else if (isSelectedShimo) classNames.push(styles.selectedShimo);
+
+  if (onClick) classNames.push(styles.clickable);
+
+  if (card.isJoker) {
+    classNames.push(styles.joker);
+    return (
+      <div className={classNames.join(' ')} onClick={onClick} role={onClick ? 'button' : undefined}>
+        <span className={styles.jokerLabel}>JOKER</span>
+      </div>
+    );
+  }
+
+  if (!card.isFaceUp) {
+    classNames.push(styles.back);
+    return (
+      <div className={classNames.join(' ')} onClick={onClick} role={onClick ? 'button' : undefined} />
+    );
+  }
+
+  const isRed = RED_SUITS.has(card.suit);
+  classNames.push(styles.face);
+  if (isRed) classNames.push(styles.red);
+
+  return (
+    <div className={classNames.join(' ')} onClick={onClick} role={onClick ? 'button' : undefined}>
+      <span className={styles.suit}>{SUIT_SYMBOL[card.suit]}</span>
+      <span className={styles.rank}>{rankLabel(card.rank)}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #13 の Card コンポーネントを実装しました。

## 変更内容

- `src/components/Card.tsx`: 表向き / 裏向き / ジョーカーの3状態に対応したカードコンポーネント
- `src/components/Card.module.css`: mockup のデザインを再現したスタイル
- `src/components/Card.test.tsx`: 各状態・インタラクションの Vitest テスト（8件）

## Acceptance Criteria 確認

- [x] 表向きカードが rank（A/2-10/J/Q/K）と suit（♠♥♦♣）を表示する
- [x] 裏向きカードがカード背面デザインを表示する
- [x] ジョーカーが専用表示になる
- [x] selected 状態で視覚的なハイライトがある
- [x] selected-shimo 状態で別のハイライトがある
- [x] onClick が呼ばれる
- [x] Vitest でコンポーネントの基本レンダリングテストが通る

## テスト

```
Test Files  1 passed (1)
Tests       8 passed (8)
```

lint・typecheck・test すべて通過済み。

Closes #13