### PR TITLE
feat: Stage レイアウトコンポーネント（Issue #14）

### DIFF
--- a/src/components/Stage.module.css
+++ b/src/components/Stage.module.css
@@ -1,0 +1,76 @@
+/* ─── PlayerStage ──────────────────────────────────────────── */
+
+.playerStage {
+  background: var(--surface, #16213e);
+  border: 1px solid var(--border, #1e2d50);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.playerStage.active {
+  border-color: var(--accent, #e94560);
+  box-shadow: 0 0 0 1px var(--accent, #e94560);
+}
+
+.playerName {
+  font-size: 11px;
+  font-weight: bold;
+  color: var(--muted, #7a8aaa);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.playerStage.active .playerName {
+  color: var(--accent, #e94560);
+}
+
+.stageSlots {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.cardSlot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.slotLabel {
+  font-size: 10px;
+  color: var(--muted, #7a8aaa);
+  letter-spacing: 1px;
+}
+
+/* ─── Placeholder ──────────────────────────────────────────── */
+
+.cardPlaceholder {
+  width: var(--card-w, 52px);
+  height: var(--card-h, 76px);
+  border-radius: 7px;
+  border: 1.5px dashed var(--border, #1e2d50);
+  background: transparent;
+  flex-shrink: 0;
+}
+
+/* ─── MainStage ────────────────────────────────────────────── */
+
+.mainStage {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  justify-content: flex-start;
+}
+
+/* ─── BackstageArea ────────────────────────────────────────── */
+
+.backstageArea {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  justify-content: flex-start;
+}

--- a/src/components/Stage.test.tsx
+++ b/src/components/Stage.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PlayerStage, MainStage, BackstageArea } from './Stage';
+import type { Card as CardType } from '@/types/game';
+
+const faceUpCard = (suit: CardType['suit'], rank: number): CardType => ({
+  suit,
+  rank,
+  isJoker: false,
+  isFaceUp: true,
+});
+
+const faceDownCard = (): CardType => ({
+  suit: 'spades',
+  rank: 1,
+  isJoker: false,
+  isFaceUp: false,
+});
+
+describe('PlayerStage', () => {
+  it('プレイヤー名を表示する', () => {
+    render(<PlayerStage playerName="アリス" kamiCard={null} shimoCard={null} />);
+    expect(screen.getByText('アリス')).toBeDefined();
+  });
+
+  it('カミとシモのラベルを表示する', () => {
+    render(<PlayerStage playerName="アリス" kamiCard={null} shimoCard={null} />);
+    expect(screen.getByText('カミ')).toBeDefined();
+    expect(screen.getByText('シモ')).toBeDefined();
+  });
+
+  it('kamiCard=nullのとき空プレースホルダーを表示する', () => {
+    render(<PlayerStage playerName="アリス" kamiCard={null} shimoCard={null} />);
+    const placeholders = screen.getAllByLabelText(/空の.*スロット/);
+    expect(placeholders.length).toBe(2);
+  });
+
+  it('kamiCardがあるときCardを表示する', () => {
+    render(<PlayerStage playerName="アリス" kamiCard={faceUpCard('spades', 1)} shimoCard={null} />);
+    expect(screen.getByText('♠')).toBeDefined();
+    expect(screen.getByText('A')).toBeDefined();
+  });
+
+  it('isActive=trueでactiveクラスが付く', () => {
+    const { container } = render(
+      <PlayerStage playerName="アリス" kamiCard={null} shimoCard={null} isActive />
+    );
+    const el = container.querySelector('[class*="active"]');
+    expect(el).toBeTruthy();
+  });
+
+  it('isActive未指定でactiveクラスが付かない', () => {
+    const { container } = render(
+      <PlayerStage playerName="ボブ" kamiCard={null} shimoCard={null} />
+    );
+    const el = container.querySelector('[class*="active"]');
+    expect(el).toBeNull();
+  });
+});
+
+describe('MainStage', () => {
+  it('13枚のカードを表示する', () => {
+    const cards = Array.from({ length: 13 }, (_, i) => faceDownCard());
+    const { container } = render(<MainStage cards={cards} />);
+    // 13枚のCardコンポーネント（裏向きは空div）
+    const cardEls = container.querySelectorAll('[class*="card"]');
+    expect(cardEls.length).toBe(13);
+  });
+
+  it('カードが0枚のとき13個のプレースホルダーを表示する', () => {
+    const { container } = render(<MainStage cards={[]} />);
+    const placeholders = container.querySelectorAll('[class*="cardPlaceholder"]');
+    expect(placeholders.length).toBe(13);
+  });
+
+  it('カードが5枚のとき残り8個のプレースホルダーを表示する', () => {
+    const cards = Array.from({ length: 5 }, () => faceDownCard());
+    const { container } = render(<MainStage cards={cards} />);
+    const placeholders = container.querySelectorAll('[class*="cardPlaceholder"]');
+    expect(placeholders.length).toBe(8);
+  });
+
+  it('aria-label "メインステージ" を持つ', () => {
+    render(<MainStage cards={[]} />);
+    expect(screen.getByLabelText('メインステージ')).toBeDefined();
+  });
+});
+
+describe('BackstageArea', () => {
+  it('10枚のカードを表示する', () => {
+    const cards = Array.from({ length: 10 }, () => faceDownCard());
+    const { container } = render(<BackstageArea cards={cards} />);
+    const cardEls = container.querySelectorAll('[class*="card"]');
+    expect(cardEls.length).toBe(10);
+  });
+
+  it('カードが0枚のとき10個のプレースホルダーを表示する', () => {
+    const { container } = render(<BackstageArea cards={[]} />);
+    const placeholders = container.querySelectorAll('[class*="cardPlaceholder"]');
+    expect(placeholders.length).toBe(10);
+  });
+
+  it('aria-label "バックステージ" を持つ', () => {
+    render(<BackstageArea cards={[]} />);
+    expect(screen.getByLabelText('バックステージ')).toBeDefined();
+  });
+});

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -1,0 +1,86 @@
+import type { Card as CardType } from '@/types/game';
+import Card from './Card';
+import styles from './Stage.module.css';
+
+// ─── PlayerStage ─────────────────────────────────────────────
+
+type PlayerStageProps = {
+  playerName: string;
+  kamiCard: CardType | null;
+  shimoCard: CardType | null;
+  isActive?: boolean;
+};
+
+export function PlayerStage({ playerName, kamiCard, shimoCard, isActive }: PlayerStageProps) {
+  const wrapClass = [styles.playerStage, isActive ? styles.active : ''].filter(Boolean).join(' ');
+
+  return (
+    <div className={wrapClass} aria-label={`${playerName}のステージ`}>
+      <div className={styles.playerName}>{playerName}</div>
+      <div className={styles.stageSlots}>
+        <div className={styles.cardSlot}>
+          <span className={styles.slotLabel}>シモ</span>
+          {shimoCard ? (
+            <Card card={shimoCard} />
+          ) : (
+            <div className={styles.cardPlaceholder} aria-label="空のシモスロット" />
+          )}
+        </div>
+        <div className={styles.cardSlot}>
+          <span className={styles.slotLabel}>カミ</span>
+          {kamiCard ? (
+            <Card card={kamiCard} />
+          ) : (
+            <div className={styles.cardPlaceholder} aria-label="空のカミスロット" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── MainStage ────────────────────────────────────────────────
+
+const MAIN_STAGE_SIZE = 13;
+
+type MainStageProps = {
+  cards: CardType[];
+};
+
+export function MainStage({ cards }: MainStageProps) {
+  const placeholderCount = Math.max(0, MAIN_STAGE_SIZE - cards.length);
+
+  return (
+    <div className={styles.mainStage} aria-label="メインステージ">
+      {cards.map((card, i) => (
+        <Card key={i} card={card} />
+      ))}
+      {Array.from({ length: placeholderCount }).map((_, i) => (
+        <div key={`ph-${i}`} className={styles.cardPlaceholder} />
+      ))}
+    </div>
+  );
+}
+
+// ─── BackstageArea ────────────────────────────────────────────
+
+const BACKSTAGE_SIZE = 10;
+
+type BackstageAreaProps = {
+  cards: CardType[];
+};
+
+export function BackstageArea({ cards }: BackstageAreaProps) {
+  const placeholderCount = Math.max(0, BACKSTAGE_SIZE - cards.length);
+
+  return (
+    <div className={styles.backstageArea} aria-label="バックステージ">
+      {cards.map((card, i) => (
+        <Card key={i} card={card} />
+      ))}
+      {Array.from({ length: placeholderCount }).map((_, i) => (
+        <div key={`ph-${i}`} className={styles.cardPlaceholder} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `PlayerStage` コンポーネント（カミ/シモエリア）を実装
- `MainStage` コンポーネント（13枚グリッド）を実装
- `BackstageArea` コンポーネント（10枚グリッド）を実装
- `Stage.module.css` でmockupデザインを再現
- `Stage.test.tsx` に13テストを追加（全通過）

## Acceptance Criteria チェック
- [x] PlayerStageにカミ（右）とシモ（左）エリアが存在する
- [x] カードがnullの場合は空のプレースホルダーが表示される
- [x] isActive=trueで現在のアクティブプレイヤーが視覚的に区別される（accentカラーのボーダー）
- [x] MainStageが13枚のグリッドを表示する
- [x] BackstageAreaが10枚のグリッドを表示する

## Test plan
- [ ] `npx vitest run` で全テスト通過を確認
- [ ] `npx eslint .` でlintエラーなし
- [ ] `npx tsc --noEmit` でtypecheckエラーなし

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)