### PR TITLE
[Feature] InfoOverlay コンポーネント (#16)

### DIFF
--- a/src/components/InfoOverlay.module.css
+++ b/src/components/InfoOverlay.module.css
@@ -1,0 +1,183 @@
+.backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 200;
+  align-items: flex-start;
+  justify-content: flex-end;
+}
+
+.open {
+  display: flex;
+}
+
+.panel {
+  width: min(360px, 100%);
+  height: 100dvh;
+  background: var(--surface, #16213e);
+  border-left: 1px solid var(--border, #1e2d50);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.backdropArea {
+  flex: 1;
+  height: 100%;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border, #1e2d50);
+  position: sticky;
+  top: 0;
+  background: var(--surface, #16213e);
+  z-index: 1;
+}
+
+.header h3 {
+  font-size: 15px;
+  margin: 0;
+}
+
+.closeBtn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--border, #1e2d50);
+  border: none;
+  color: var(--text, #e0e6f0);
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.section {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border, #1e2d50);
+}
+
+.sectionTitle {
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: var(--muted, #7a8aaa);
+  text-transform: uppercase;
+  margin: 0 0 10px;
+}
+
+.scoreCompare {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.scoreDivider {
+  width: 1px;
+  background: var(--border, #1e2d50);
+}
+
+.scoreCol {
+  flex: 1;
+  text-align: center;
+}
+
+.sName {
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+}
+
+.sTotal {
+  font-size: 28px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+}
+
+.sRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+  margin-top: 3px;
+}
+
+.sRow span:last-child {
+  color: var(--text, #e0e6f0);
+}
+
+.booPlayer {
+  margin-bottom: 8px;
+}
+
+.booPlayerName {
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+  margin-bottom: 4px;
+}
+
+.booBar {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.booDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--border, #1e2d50);
+}
+
+.booDotFilled {
+  background: var(--accent, #e63946);
+}
+
+.booCount {
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+  margin-left: 4px;
+}
+
+.setRemaining {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.setRemainingLabel {
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+}
+
+.setCount {
+  font-size: 22px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+}
+
+.knownCardsList {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.knownCardRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  padding: 5px 8px;
+  background: var(--bg, #0f172a);
+  border-radius: 6px;
+}
+
+.knownCardLoc {
+  color: var(--muted, #7a8aaa);
+  font-size: 10px;
+}

--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import InfoOverlay from './InfoOverlay';
+import type { GameState } from '@/types/game';
+
+const baseState: GameState = {
+  phase: 'scout',
+  players: [
+    { id: 'a', name: 'アリス', hand: [] },
+    { id: 'b', name: 'ボブ', hand: [] },
+  ],
+  stage: { kami: null, shimo: null },
+  deck: [],
+  setRemainingCount: 9,
+  publicInfos: [],
+  playerABooCnt: 1,
+  playerBBooCnt: 2,
+  round: 1,
+  curtainCallReason: null,
+};
+
+describe('InfoOverlay', () => {
+  it('isOpen=trueでパネルが表示される', () => {
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={baseState} />);
+    expect(screen.getByRole('dialog', { name: 'ゲーム情報' })).toBeDefined();
+  });
+
+  it('isOpen=falseでパネルが非表示になる（aria-hidden）', () => {
+    const { container } = render(
+      <InfoOverlay isOpen={false} onClose={() => {}} gameState={baseState} />
+    );
+    const backdrop = container.firstElementChild;
+    expect(backdrop?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('スコア速報のプレイヤー名が表示される', () => {
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={baseState} />);
+    expect(screen.getAllByText('アリス').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('ボブ').length).toBeGreaterThan(0);
+  });
+
+  it('ブーイング数が3ドット形式で表示される', () => {
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={baseState} />);
+    expect(screen.getByText('1 / 3')).toBeDefined();
+    expect(screen.getByText('2 / 3')).toBeDefined();
+  });
+
+  it('セット残枚数が表示される', () => {
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={baseState} />);
+    expect(screen.getByText('9 枚')).toBeDefined();
+  });
+
+  it('公開情報（バックステージ既知カード）の表示エリアがある', () => {
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={baseState} />);
+    expect(screen.getByText('バックステージ（公開情報）', { exact: false })).toBeDefined();
+  });
+
+  it('publicInfosがある場合カード情報が表示される', () => {
+    const state: GameState = {
+      ...baseState,
+      publicInfos: [
+        {
+          playerId: 'a',
+          card: { suit: 'spades', rank: 5, isJoker: false, isFaceUp: true },
+          round: 1,
+        },
+      ],
+    };
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={state} />);
+    expect(screen.getByText('♠5')).toBeDefined();
+  });
+
+  it('バックドロップタップでonCloseが呼ばれる', () => {
+    const handleClose = vi.fn();
+    render(<InfoOverlay isOpen={true} onClose={handleClose} gameState={baseState} />);
+    fireEvent.click(screen.getByLabelText('オーバーレイを閉じる'));
+    expect(handleClose).toHaveBeenCalledOnce();
+  });
+
+  it('閉じるボタンクリックでonCloseが呼ばれる', () => {
+    const handleClose = vi.fn();
+    render(<InfoOverlay isOpen={true} onClose={handleClose} gameState={baseState} />);
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+    expect(handleClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -1,0 +1,127 @@
+import type { GameState, Card } from '@/types/game';
+import styles from './InfoOverlay.module.css';
+
+const BOO_MAX = 3;
+
+function rankLabel(card: Card): string {
+  if (card.isJoker) return 'JK';
+  const labels: Record<number, string> = { 1: 'A', 11: 'J', 12: 'Q', 13: 'K' };
+  return labels[card.rank] ?? String(card.rank);
+}
+
+function suitLabel(card: Card): string {
+  const suits: Record<string, string> = {
+    spades: '♠',
+    hearts: '♥',
+    diamonds: '♦',
+    clubs: '♣',
+  };
+  return suits[card.suit] ?? card.suit;
+}
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  gameState: GameState;
+};
+
+export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
+  const { players, playerABooCnt, playerBBooCnt, setRemainingCount, publicInfos } = gameState;
+  const [playerA, playerB] = players;
+
+  const booCounts = [playerABooCnt, playerBBooCnt];
+
+  return (
+    <div
+      className={`${styles.backdrop} ${isOpen ? styles.open : ''}`}
+      aria-hidden={!isOpen}
+    >
+      <div
+        className={styles.backdropArea}
+        onClick={onClose}
+        aria-label="オーバーレイを閉じる"
+      />
+      <div className={styles.panel} role="dialog" aria-label="ゲーム情報">
+        <div className={styles.header}>
+          <h3>📊 ゲーム情報</h3>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="閉じる">
+            ×
+          </button>
+        </div>
+
+        {/* スコア速報 */}
+        <div className={styles.section}>
+          <h4 className={styles.sectionTitle}>スコア（暫定）</h4>
+          <div className={styles.scoreCompare}>
+            {[playerA, playerB].map((player) => (
+              <div key={player.id} className={styles.scoreCol}>
+                <div className={styles.sName}>{player.name}</div>
+                <div className={styles.sTotal}>{player.hand.length}</div>
+                <div className={styles.sRow}>
+                  <span>手札</span>
+                  <span>{player.hand.length} 枚</span>
+                </div>
+              </div>
+            ))}
+            <div className={styles.scoreDivider} />
+          </div>
+        </div>
+
+        {/* ブーイング回数 */}
+        <div className={styles.section}>
+          <h4 className={styles.sectionTitle}>ブーイング回数（規定：各{BOO_MAX}回）</h4>
+          {[playerA, playerB].map((player, i) => (
+            <div key={player.id} className={styles.booPlayer}>
+              <div className={styles.booPlayerName}>{player.name}</div>
+              <div className={styles.booBar}>
+                {Array.from({ length: BOO_MAX }, (_, j) => (
+                  <div
+                    key={j}
+                    className={`${styles.booDot} ${j < booCounts[i] ? styles.booDotFilled : ''}`}
+                    aria-hidden="true"
+                  />
+                ))}
+                <span className={styles.booCount}>
+                  {booCounts[i]} / {BOO_MAX}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* セット残枚数 */}
+        <div className={styles.section}>
+          <h4 className={styles.sectionTitle}>セット</h4>
+          <div className={styles.setRemaining}>
+            <span className={styles.setRemainingLabel}>裏向き残り</span>
+            <span className={styles.setCount}>{setRemainingCount} 枚</span>
+          </div>
+        </div>
+
+        {/* バックステージ公開情報 */}
+        <div className={styles.section}>
+          <h4 className={styles.sectionTitle}>バックステージ（公開情報）</h4>
+          <div className={styles.knownCardsList}>
+            {publicInfos.length === 0 ? (
+              <div className={styles.knownCardRow}>
+                <span style={{ color: 'var(--muted, #7a8aaa)' }}>公開情報なし</span>
+              </div>
+            ) : (
+              publicInfos.map((info, i) => (
+                <div key={i} className={styles.knownCardRow}>
+                  <span>
+                    {suitLabel(info.card)}
+                    {rankLabel(info.card)}
+                  </span>
+                  <span className={styles.knownCardLoc}>
+                    {players.find((p) => p.id === info.playerId)?.name ?? info.playerId}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #16「InfoOverlay コンポーネント」の実装。

## 変更内容

- `src/components/InfoOverlay.tsx`: スライドパネル型オーバーレイコンポーネント
- `src/components/InfoOverlay.module.css`: mockup準拠のスタイル
- `src/components/InfoOverlay.test.tsx`: 9テスト（全通過）

## Acceptance Criteria 確認

- [x] isOpen=trueでパネルが表示される
- [x] isOpen=falseでパネルが非表示になる（aria-hidden="true"）
- [x] スコア速報（プレイヤー名・手札枚数）が表示される
- [x] ブーイング数が3ドット形式で表示される
- [x] セット残枚数が表示される
- [x] 公開情報（バックステージ既知カード）の表示エリアがある
- [x] バックドロップタップでonCloseが呼ばれる

## テスト結果

```
Tests: 9 passed (9)
lint: OK
typecheck: OK
```

Closes #16