### PR TITLE
feat: PassDevice コンポーネント（長押し2秒で進む画面）

### DIFF
--- a/src/components/PassDevice.module.css
+++ b/src/components/PassDevice.module.css
@@ -1,0 +1,69 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 32px;
+  text-align: center;
+  background: var(--bg, #0f172a);
+}
+
+.icon {
+  font-size: 56px;
+}
+
+.playerName {
+  font-size: 26px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+}
+
+.title {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--text, #e0e6f0);
+}
+
+.sub {
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  line-height: 1.7;
+}
+
+.holdWrap {
+  width: 100%;
+  max-width: 280px;
+}
+
+.holdBtn {
+  width: 100%;
+  padding: 16px;
+  border: 2px solid var(--accent, #e63946);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text, #e0e6f0);
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: none;
+}
+
+.holdFill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+  width: 0;
+  background: rgba(230, 57, 70, 0.25);
+  z-index: 0;
+}
+
+.holdText {
+  position: relative;
+  z-index: 1;
+}

--- a/src/components/PassDevice.test.tsx
+++ b/src/components/PassDevice.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import PassDevice from './PassDevice';
+
+describe('PassDevice', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('プレイヤー名が表示される', () => {
+    render(<PassDevice playerName="アリス" onComplete={() => {}} />);
+    expect(screen.getByText('アリス')).toBeDefined();
+  });
+
+  it('長押し2秒でonCompleteが呼ばれる', () => {
+    const onComplete = vi.fn();
+    render(<PassDevice playerName="アリス" onComplete={onComplete} />);
+    const btn = screen.getByRole('button', { name: '長押しで進む' });
+    fireEvent.pointerDown(btn);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it('長押し中にプログレスバーが進む', () => {
+    render(<PassDevice playerName="アリス" onComplete={() => {}} />);
+    const btn = screen.getByRole('button', { name: '長押しで進む' });
+    fireEvent.pointerDown(btn);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    const bar = screen.getByRole('progressbar');
+    expect(Number(bar.getAttribute('aria-valuenow'))).toBeGreaterThan(0);
+    expect(Number(bar.getAttribute('aria-valuenow'))).toBeLessThan(100);
+  });
+
+  it('途中で離すとリセットされる', () => {
+    const onComplete = vi.fn();
+    render(<PassDevice playerName="アリス" onComplete={onComplete} />);
+    const btn = screen.getByRole('button', { name: '長押しで進む' });
+    fireEvent.pointerDown(btn);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    fireEvent.pointerUp(btn);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+    const bar = screen.getByRole('progressbar');
+    expect(Number(bar.getAttribute('aria-valuenow'))).toBe(0);
+  });
+
+  it('レンダリングテストが通る', () => {
+    const { container } = render(<PassDevice playerName="ボブ" onComplete={() => {}} />);
+    expect(container.firstElementChild).toBeDefined();
+  });
+});

--- a/src/components/PassDevice.tsx
+++ b/src/components/PassDevice.tsx
@@ -1,0 +1,71 @@
+import { useRef, useState } from 'react';
+import styles from './PassDevice.module.css';
+
+const INTERVAL_MS = 20;
+const HOLD_DURATION_MS = 2000;
+
+type Props = {
+  playerName: string;
+  onComplete: () => void;
+};
+
+export default function PassDevice({ playerName, onComplete }: Props) {
+  const [progress, setProgress] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const progressRef = useRef(0);
+
+  const startHold = () => {
+    if (intervalRef.current) return;
+    progressRef.current = 0;
+    intervalRef.current = setInterval(() => {
+      progressRef.current = Math.min(
+        progressRef.current + (INTERVAL_MS / HOLD_DURATION_MS) * 100,
+        100,
+      );
+      setProgress(progressRef.current);
+      if (progressRef.current >= 100) {
+        clearInterval(intervalRef.current!);
+        intervalRef.current = null;
+        onComplete();
+      }
+    }, INTERVAL_MS);
+  };
+
+  const cancelHold = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    progressRef.current = 0;
+    setProgress(0);
+  };
+
+  return (
+    <div className={styles.screen}>
+      <div className={styles.icon}>📱</div>
+      <div className={styles.playerName}>{playerName}</div>
+      <div className={styles.title}>さんに渡してください</div>
+      <div className={styles.sub}>準備ができたら長押しで進んでください。</div>
+      <div className={styles.holdWrap}>
+        <button
+          className={styles.holdBtn}
+          onPointerDown={startHold}
+          onPointerUp={cancelHold}
+          onPointerLeave={cancelHold}
+          onPointerCancel={cancelHold}
+          aria-label="長押しで進む"
+        >
+          <div
+            role="progressbar"
+            aria-valuenow={Math.round(progress)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            className={styles.holdFill}
+            style={{ width: `${progress}%` }}
+          />
+          <span className={styles.holdText}>長押しで進む</span>
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `PassDevice` コンポーネントを実装（`playerName: string`, `onComplete: () => void` Props）
- `setInterval` 20ms 間隔でプログレスを 0→100 更新し、2000ms 完走で `onComplete()` 呼び出し
- `onPointerDown/Up/Leave/Cancel` で長押し検出・途中離し時リセットに対応

## Test plan
- [ ] `プレイヤー名が表示される` ✅
- [ ] `長押し2秒でonCompleteが呼ばれる` ✅
- [ ] `長押し中にプログレスバーが進む` ✅
- [ ] `途中で離すとリセットされる` ✅
- [ ] `レンダリングテストが通る` ✅
- [ ] lint / typecheck クリーン ✅

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)