### PR TITLE
feat: Title 画面実装（Issue #19）

### DIFF
--- a/src/screens/TitleScreen.module.css
+++ b/src/screens/TitleScreen.module.css
@@ -1,0 +1,75 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+  padding: 32px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 32px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: bold;
+  color: var(--muted, #7a8aaa);
+}
+
+.input {
+  padding: 12px 14px;
+  border: 1.5px solid var(--border, #2a3a5a);
+  border-radius: 8px;
+  background: var(--surface, #1e293b);
+  color: var(--text, #e0e6f0);
+  font-size: 16px;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--gold, #f0c060);
+}
+
+.error {
+  font-size: 12px;
+  color: var(--accent, #e63946);
+  margin: 0;
+}
+
+.startBtn {
+  margin-top: 8px;
+  padding: 14px;
+  border: 2px solid var(--gold, #f0c060);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--gold, #f0c060);
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.startBtn:active {
+  background: rgba(240, 192, 96, 0.12);
+}

--- a/src/screens/TitleScreen.test.tsx
+++ b/src/screens/TitleScreen.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider } from '@/game/context';
+import TitleScreen from './TitleScreen';
+
+function renderWithProvider() {
+  return render(
+    <GameProvider>
+      <TitleScreen />
+    </GameProvider>,
+  );
+}
+
+describe('TitleScreen', () => {
+  it('プレイヤーA・B名の入力フォームが表示される', () => {
+    renderWithProvider();
+    expect(screen.getByLabelText('プレイヤーA')).toBeDefined();
+    expect(screen.getByLabelText('プレイヤーB')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'ゲームスタート' })).toBeDefined();
+  });
+
+  it('空欄のままゲームスタートを押すとエラーが表示される', () => {
+    renderWithProvider();
+    fireEvent.click(screen.getByRole('button', { name: 'ゲームスタート' }));
+    expect(screen.getByText('プレイヤーA名を入力してください')).toBeDefined();
+    expect(screen.getByText('プレイヤーB名を入力してください')).toBeDefined();
+  });
+
+  it('プレイヤーA空欄のみエラーが表示される', () => {
+    renderWithProvider();
+    fireEvent.change(screen.getByLabelText('プレイヤーB'), { target: { value: 'ボブ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ゲームスタート' }));
+    expect(screen.getByText('プレイヤーA名を入力してください')).toBeDefined();
+    expect(screen.queryByText('プレイヤーB名を入力してください')).toBeNull();
+  });
+
+  it('名前が重複するとエラーが表示される', () => {
+    renderWithProvider();
+    fireEvent.change(screen.getByLabelText('プレイヤーA'), { target: { value: 'アリス' } });
+    fireEvent.change(screen.getByLabelText('プレイヤーB'), { target: { value: 'アリス' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ゲームスタート' }));
+    expect(screen.getByText('プレイヤー名が重複しています')).toBeDefined();
+  });
+
+  it('両名入力後にゲームスタートを押すとINIT_GAMEがdispatchされ画面がscoutフェーズに遷移する', () => {
+    // GameProvider 経由で state を確認するため index.tsx 相当のラッパーを使う
+    const { container } = renderWithProvider();
+    fireEvent.change(screen.getByLabelText('プレイヤーA'), { target: { value: 'アリス' } });
+    fireEvent.change(screen.getByLabelText('プレイヤーB'), { target: { value: 'ボブ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ゲームスタート' }));
+    // INIT_GAME dispatch 後は phase が scout になるため TitleScreen は再レンダーされる
+    // ここでは dispatch 後にエラーが残らないことのみ確認（reducer テストで遷移は担保済み）
+    expect(screen.queryByText('プレイヤーA名を入力してください')).toBeNull();
+    expect(screen.queryByText('プレイヤーB名を入力してください')).toBeNull();
+    expect(container.firstElementChild).toBeDefined();
+  });
+});

--- a/src/screens/TitleScreen.tsx
+++ b/src/screens/TitleScreen.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { useGameDispatch } from '@/game/context';
+import styles from './TitleScreen.module.css';
+
+export default function TitleScreen() {
+  const dispatch = useGameDispatch();
+  const [playerAName, setPlayerAName] = useState('');
+  const [playerBName, setPlayerBName] = useState('');
+  const [errors, setErrors] = useState<{ a?: string; b?: string; general?: string }>({});
+
+  const handleStart = () => {
+    const newErrors: typeof errors = {};
+
+    if (!playerAName.trim()) {
+      newErrors.a = 'プレイヤーA名を入力してください';
+    }
+    if (!playerBName.trim()) {
+      newErrors.b = 'プレイヤーB名を入力してください';
+    }
+    if (
+      playerAName.trim() &&
+      playerBName.trim() &&
+      playerAName.trim() === playerBName.trim()
+    ) {
+      newErrors.general = 'プレイヤー名が重複しています';
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    setErrors({});
+    dispatch({ type: 'INIT_GAME', playerAName: playerAName.trim(), playerBName: playerBName.trim() });
+  };
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>CurtainCall</h1>
+      <div className={styles.form}>
+        <div className={styles.field}>
+          <label htmlFor="playerA" className={styles.label}>
+            プレイヤーA
+          </label>
+          <input
+            id="playerA"
+            type="text"
+            className={styles.input}
+            value={playerAName}
+            onChange={(e) => setPlayerAName(e.target.value)}
+            placeholder="名前を入力"
+          />
+          {errors.a && <p className={styles.error}>{errors.a}</p>}
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="playerB" className={styles.label}>
+            プレイヤーB
+          </label>
+          <input
+            id="playerB"
+            type="text"
+            className={styles.input}
+            value={playerBName}
+            onChange={(e) => setPlayerBName(e.target.value)}
+            placeholder="名前を入力"
+          />
+          {errors.b && <p className={styles.error}>{errors.b}</p>}
+        </div>
+        {errors.general && <p className={styles.error}>{errors.general}</p>}
+        <button className={styles.startBtn} onClick={handleStart}>
+          ゲームスタート
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

プレイヤー名を入力してゲームを開始する Title 画面を実装。

## 変更内容

- `src/screens/TitleScreen.tsx` — プレイヤーA・B名入力フォーム、バリデーション、INIT_GAME dispatch
- `src/screens/TitleScreen.module.css` — 既存デザイントークン準拠スタイル
- `src/screens/TitleScreen.test.tsx` — バリデーション5ケース（全 PASS）

## テスト計画

- [x] 空欄エラー表示（A・B両方）
- [x] 片方のみ空欄エラー
- [x] 重複名エラー
- [x] 正常系：INIT_GAME dispatch 後エラーなし
- [x] lint クリーン

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)