### PR TITLE
feat: Standby フェーズ実装（Issue #20）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,14 +1,13 @@
 # .ai-context.md
 
 ## Status
-Phase 2（UI コンポーネント）完了。Issue #13/14/15/16/17 実装済み・全PR マージ済み。Issue #18（Phase 2 レビュー）進行中。
+Phase 3（スクリーン実装）進行中。Issue #19/20 実装済み・PR作成済み。
 
 ## Active Issues
-- **#18: Phase 2 レビュー・Sign-off** ← 現在のターゲット
-- #19〜38: 後続フェーズ実装等
+- **#21〜38: 後続フェーズ実装等** ← 次のターゲット
 
 ## In-Progress PRs
-（なし）
+- PR #53: Issue #20 StandbyScreen（レビュー待ち）
 
 ## Completed
 - Issue #1: Next.js + TypeScript 初期化（main push）
@@ -23,6 +22,9 @@ Phase 2（UI コンポーネント）完了。Issue #13/14/15/16/17 実装済み
 - Issue #15: PhaseHeader コンポーネント（PR#48 マージ済み）
 - Issue #16: InfoOverlay コンポーネント（PR#49 マージ済み）
 - Issue #17: PassDevice 画面（PR#50 マージ済み）
+- Issue #18: Phase 2 プレビューページ（PR#51 マージ済み）
+- Issue #19: TitleScreen（PR#52 マージ済み）
+- Issue #20: StandbyScreen（PR#53 レビュー待ち）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -36,10 +38,12 @@ Phase 2（UI コンポーネント）完了。Issue #13/14/15/16/17 実装済み
 - vitest.config.ts に `resolve.alias` (`@/` → `./src`) を追加（@/ エイリアス解決のため）
 - GameState/Reducer 設計: State と Dispatch を別 Context に分離（不要な再レンダー防止）
 - 不正遷移ガード: reducer の各アクションで phase をチェック、不正時は同一参照を返す（pure function）
+- INIT_GAME は standby フェーズ維持（カード配布完了後も standby）。START_SCOUT で scout へ遷移
+  - 理由: StandbyScreen（配布サマリー）を INIT_GAME 後に表示するため
+- GameState.backstage: Card[] 追加（INIT_GAME 時に deal[2] = 10枚 を格納）
 
 ## Next actions
-1. Issue #18: Phase 2 レビュー・Sign-off（feature/issue-18 ブランチで作業中）
-2. Issue #19〜: 後続フェーズ実装
+1. Issue #21 以降のスクリーン実装（PR#53 のマージ後に確認）
 
 ## Known pitfalls
 - `create-next-app` はディレクトリ名を npm package name に使う。大文字NG → `/tmp` 等で生成して移動する

--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -11,6 +11,7 @@ const baseState: GameState = {
   ],
   stage: { kami: null, shimo: null },
   deck: [],
+  backstage: [],
   setRemainingCount: 9,
   publicInfos: [],
   playerABooCnt: 1,

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -10,8 +10,8 @@ describe('gameReducer', () => {
       playerBName: 'Bob',
     });
 
-    it('phase が scout になる', () => {
-      expect(state.phase).toBe('scout');
+    it('phase が standby のまま（START_SCOUT 前）', () => {
+      expect(state.phase).toBe('standby');
     });
 
     it('プレイヤーAの手札が15枚になる', () => {
@@ -20,6 +20,10 @@ describe('gameReducer', () => {
 
     it('プレイヤーBの手札が15枚になる', () => {
       expect(state.players[1].hand).toHaveLength(15);
+    });
+
+    it('バックステージが10枚になる', () => {
+      expect(state.backstage).toHaveLength(10);
     });
 
     it('セット（deck）が13枚になる', () => {
@@ -44,14 +48,43 @@ describe('gameReducer', () => {
     });
   });
 
-  describe('SCOUT_CARD', () => {
-    let scoutState: GameState;
-    beforeEach(() => {
-      scoutState = gameReducer(initialState, {
+  describe('START_SCOUT', () => {
+    it('INIT_GAME 後に START_SCOUT で phase が scout になる', () => {
+      const afterInit = gameReducer(initialState, {
         type: 'INIT_GAME',
         playerAName: 'Alice',
         playerBName: 'Bob',
       });
+      const result = gameReducer(afterInit, { type: 'START_SCOUT' });
+      expect(result.phase).toBe('scout');
+    });
+
+    it('プレイヤー名が未設定の standby では START_SCOUT が無効', () => {
+      const result = gameReducer(initialState, { type: 'START_SCOUT' });
+      expect(result).toBe(initialState);
+    });
+
+    it('standby 以外のフェーズでは START_SCOUT が無効', () => {
+      const afterInit = gameReducer(initialState, {
+        type: 'INIT_GAME',
+        playerAName: 'Alice',
+        playerBName: 'Bob',
+      });
+      const scoutState = gameReducer(afterInit, { type: 'START_SCOUT' });
+      const result = gameReducer(scoutState, { type: 'START_SCOUT' });
+      expect(result).toBe(scoutState);
+    });
+  });
+
+  describe('SCOUT_CARD', () => {
+    let scoutState: GameState;
+    beforeEach(() => {
+      const afterInit = gameReducer(initialState, {
+        type: 'INIT_GAME',
+        playerAName: 'Alice',
+        playerBName: 'Bob',
+      });
+      scoutState = gameReducer(afterInit, { type: 'START_SCOUT' });
     });
 
     it('phase が action になる', () => {
@@ -83,7 +116,8 @@ describe('gameReducer', () => {
         playerAName: 'Alice',
         playerBName: 'Bob',
       });
-      const afterScout = gameReducer(afterInit, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const afterStart = gameReducer(afterInit, { type: 'START_SCOUT' });
+      const afterScout = gameReducer(afterStart, { type: 'SCOUT_CARD', cardIndex: 0 });
       const result = gameReducer(afterScout, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
       expect(result.phase).toBe('watch');
     });
@@ -94,7 +128,8 @@ describe('gameReducer', () => {
         playerAName: 'Alice',
         playerBName: 'Bob',
       });
-      const afterScout = gameReducer(afterInit, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const afterStart = gameReducer(afterInit, { type: 'START_SCOUT' });
+      const afterScout = gameReducer(afterStart, { type: 'SCOUT_CARD', cardIndex: 0 });
       const kami = afterScout.players[0].hand[0];
       const shimo = afterScout.players[0].hand[1];
       const result = gameReducer(afterScout, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
@@ -107,8 +142,9 @@ describe('gameReducer', () => {
     let watchState: GameState;
     beforeEach(() => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
-      const s2 = gameReducer(s1, { type: 'SCOUT_CARD', cardIndex: 0 });
-      watchState = gameReducer(s2, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      watchState = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
     });
 
     it('WATCH_CLAP で phase が intermission になる', () => {
@@ -132,7 +168,8 @@ describe('gameReducer', () => {
         playerAName: 'Alice',
         playerBName: 'Bob',
       });
-      const result = gameReducer(afterInit, { type: 'RESET_GAME' });
+      const afterStart = gameReducer(afterInit, { type: 'START_SCOUT' });
+      const result = gameReducer(afterStart, { type: 'RESET_GAME' });
       expect(result.phase).toBe('standby');
     });
 
@@ -142,7 +179,8 @@ describe('gameReducer', () => {
         playerAName: 'Alice',
         playerBName: 'Bob',
       });
-      const result = gameReducer(afterInit, { type: 'RESET_GAME' });
+      const afterStart = gameReducer(afterInit, { type: 'START_SCOUT' });
+      const result = gameReducer(afterStart, { type: 'RESET_GAME' });
       expect(result).toEqual(initialState);
     });
   });

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -3,6 +3,7 @@ import { createDeck, createDeckWithJoker, deal, shuffle } from '@/lib/deck';
 
 export type GameAction =
   | { type: 'INIT_GAME'; playerAName: string; playerBName: string }
+  | { type: 'START_SCOUT' }
   | { type: 'SCOUT_CARD'; cardIndex: number }
   | { type: 'ACTION_PLAY'; kamiIndex: number; shimoIndex: number }
   | { type: 'WATCH_CLAP' }
@@ -23,6 +24,7 @@ export const initialState: GameState = {
   ],
   stage: { kami: null, shimo: null },
   deck: [],
+  backstage: [],
   setRemainingCount: 0,
   publicInfos: [],
   playerABooCnt: 0,
@@ -43,8 +45,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       const dealt = deal(shuffled52, [15, 15, 10]);
       const handA: Card[] = dealt[0];
       const handB: Card[] = dealt[1];
-      // バックステージ(backstage)は後続Issueで利用
-      // dealt[2] = backstage（10枚）は GameState に未定義のため使用しない
+      const backstage: Card[] = dealt[2];
       // 残り12枚 + Joker1枚 = 13枚をシャッフルしてセットに
       const remaining12 = shuffled52.slice(40);
       const joker = createDeckWithJoker().slice(52)[0];
@@ -56,12 +57,19 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
       return {
         ...initialState,
-        phase: 'scout',
+        phase: 'standby',
         players,
         deck: setDeck,
+        backstage,
         setRemainingCount: setDeck.length,
         round: 1,
       };
+    }
+
+    case 'START_SCOUT': {
+      if (state.phase !== 'standby') return state;
+      if (state.players[0].name === '') return state;
+      return { ...state, phase: 'scout' };
     }
 
     case 'SCOUT_CARD': {

--- a/src/screens/StandbyScreen.module.css
+++ b/src/screens/StandbyScreen.module.css
@@ -1,0 +1,63 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+  padding: 32px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 320px;
+  background: var(--surface, #1e293b);
+  border: 1.5px solid var(--border, #2a3a5a);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.label {
+  font-size: 14px;
+  color: var(--muted, #7a8aaa);
+}
+
+.count {
+  font-size: 16px;
+  font-weight: bold;
+  color: var(--text, #e0e6f0);
+}
+
+.readyBtn {
+  padding: 14px 40px;
+  border: 2px solid var(--gold, #f0c060);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--gold, #f0c060);
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.readyBtn:active {
+  background: rgba(240, 192, 96, 0.12);
+}

--- a/src/screens/StandbyScreen.test.tsx
+++ b/src/screens/StandbyScreen.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameState } from '@/game/context';
+import { useGameDispatch } from '@/game/context';
+import StandbyScreen from './StandbyScreen';
+
+// INIT_GAME を dispatch してから StandbyScreen を描画するラッパー
+function StandbyWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.players[0].name === '') {
+    return (
+      <button
+        onClick={() =>
+          dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })
+        }
+      >
+        init
+      </button>
+    );
+  }
+  return <StandbyScreen />;
+}
+
+function renderStandby() {
+  render(
+    <GameProvider>
+      <StandbyWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+}
+
+describe('StandbyScreen', () => {
+  it('配布サマリーが表示される', () => {
+    renderStandby();
+    expect(screen.getByText('カード配布完了')).toBeDefined();
+    expect(screen.getByText('アリス の手札')).toBeDefined();
+    expect(screen.getByText('ボブ の手札')).toBeDefined();
+    expect(screen.getByText('バックステージ')).toBeDefined();
+    expect(screen.getByText('セット')).toBeDefined();
+  });
+
+  it('各プレイヤーに15枚の手札が表示される', () => {
+    renderStandby();
+    const counts = screen.getAllByText('15 枚');
+    expect(counts).toHaveLength(2);
+  });
+
+  it('バックステージが10枚と表示される', () => {
+    renderStandby();
+    expect(screen.getByText('10 枚')).toBeDefined();
+  });
+
+  it('セットが13枚と表示される', () => {
+    renderStandby();
+    expect(screen.getByText('13 枚')).toBeDefined();
+  });
+
+  it('「準備完了」ボタンが表示される', () => {
+    renderStandby();
+    expect(screen.getByRole('button', { name: '準備完了' })).toBeDefined();
+  });
+
+  it('「準備完了」押下でPassDevice画面に遷移する', () => {
+    renderStandby();
+    fireEvent.click(screen.getByRole('button', { name: '準備完了' }));
+    expect(screen.getByText('さんに渡してください')).toBeDefined();
+    expect(screen.getByRole('button', { name: '長押しで進む' })).toBeDefined();
+  });
+});

--- a/src/screens/StandbyScreen.tsx
+++ b/src/screens/StandbyScreen.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { useGameDispatch, useGameState } from '@/game/context';
+import PassDevice from '@/components/PassDevice';
+import styles from './StandbyScreen.module.css';
+
+export default function StandbyScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+  const [showPassDevice, setShowPassDevice] = useState(false);
+
+  if (showPassDevice) {
+    return (
+      <PassDevice
+        playerName={state.players[0].name}
+        onComplete={() => dispatch({ type: 'START_SCOUT' })}
+      />
+    );
+  }
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>カード配布完了</h1>
+      <div className={styles.summary}>
+        <div className={styles.row}>
+          <span className={styles.label}>{state.players[0].name} の手札</span>
+          <span className={styles.count}>{state.players[0].hand.length} 枚</span>
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>{state.players[1].name} の手札</span>
+          <span className={styles.count}>{state.players[1].hand.length} 枚</span>
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>バックステージ</span>
+          <span className={styles.count}>{state.backstage.length} 枚</span>
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>セット</span>
+          <span className={styles.count}>{state.deck.length} 枚</span>
+        </div>
+      </div>
+      <button className={styles.readyBtn} onClick={() => setShowPassDevice(true)}>
+        準備完了
+      </button>
+    </div>
+  );
+}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -42,6 +42,7 @@ export type GameState = {
   players: [Player, Player];
   stage: Stage;
   deck: Card[];
+  backstage: Card[];
   setRemainingCount: number; // 裏向きカード数（セット残枚数）
   publicInfos: PublicInfo[];
   playerABooCnt: number;


### PR DESCRIPTION
## 概要

Issue #20「Standby フェーズ（配布 + 画面）」の実装。

## 変更内容

### reducer / 型定義
- `GameState` に `backstage: Card[]` フィールドを追加
- `INIT_GAME` アクション: フェーズを `standby` のまま維持（カード配布・backstage 保存）
- `START_SCOUT` アクション追加: `standby` → `scout` 遷移

### StandbyScreen コンポーネント
- 配布サマリー（手札15枚×2、バックステージ10枚、セット13枚）を表示
- 「準備完了」ボタン → PassDevice 画面 → `START_SCOUT` dispatch → scout フェーズへ

## AC 確認

- [x] スタンバイ画面が表示される
- [x] 各プレイヤーに15枚の手札が配布される（GameState + UI 表示）
- [x] バックステージに10枚配置される（GameState.backstage + UI 表示）
- [x] セットに13枚（ジョーカー含む）配置される（GameState.deck + UI 表示）
- [x] 「準備完了」押下でPassDevice→Scout遷移する

## テスト

全84テストパス（reducer.test.ts 更新 + StandbyScreen.test.tsx 新規追加）

Closes #20