### PR TITLE
feat: Action フェーズ画面とロジックを実装（Issue #23）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,13 +1,13 @@
 # .ai-context.md
 
 ## Status
-Phase 4（メインターンフェーズ）進行中。Issue #22 Scout フェーズ実装完了・PR #55 レビュー待ち。
+Phase 4（メインターンフェーズ）進行中。Issue #23 Action フェーズ実装完了・PR #56 レビュー待ち。
 
 ## Active Issues
-- **#23〜38: 後続フェーズ実装等** ← 次のターゲット
+- **#24〜38: 後続フェーズ実装等** ← 次のターゲット
 
 ## In-Progress PRs
-- PR #55: Issue #22 Scout フェーズ（レビュー待ち）
+- PR #56: Issue #23 Action フェーズ（レビュー待ち）
 
 ## Completed
 - Issue #1: Next.js + TypeScript 初期化（main push）
@@ -26,7 +26,8 @@ Phase 4（メインターンフェーズ）進行中。Issue #22 Scout フェー
 - Issue #19: TitleScreen（PR#52 マージ済み）
 - Issue #20: StandbyScreen（PR#53 マージ済み）
 - Issue #21: Phase 3 レビュー・Sign-off（PR#54 マージ済み）
-- Issue #22: Scout フェーズ（PR#55 レビュー待ち）
+- Issue #22: Scout フェーズ（PR#55 マージ済み）
+- Issue #23: Action フェーズ（PR#56 レビュー待ち）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -45,7 +46,7 @@ Phase 4（メインターンフェーズ）進行中。Issue #22 Scout フェー
 - GameState.backstage: Card[] 追加（INIT_GAME 時に deal[2] = 10枚 を格納）
 
 ## Next actions
-1. PR #55（Issue #22 Scout フェーズ）マージ確認後、Issue #23 Action フェーズ実装へ
+1. PR #56（Issue #23 Action フェーズ）マージ確認後、Issue #24 以降へ
 
 ## Known pitfalls
 - `create-next-app` はディレクトリ名を npm package name に使う。大文字NG → `/tmp` 等で生成して移動する

--- a/src/screens/ActionScreen.module.css
+++ b/src/screens/ActionScreen.module.css
@@ -1,0 +1,81 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 24px 16px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.sub {
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+  text-align: center;
+}
+
+.preview {
+  display: flex;
+  gap: 24px;
+  justify-content: center;
+}
+
+.previewSlot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.slotLabel {
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+  letter-spacing: 0.05em;
+}
+
+.emptySlot {
+  width: 56px;
+  height: 80px;
+  border: 1px dashed var(--muted, #7a8aaa);
+  border-radius: 8px;
+  opacity: 0.4;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.confirmBtn {
+  padding: 14px 40px;
+  border: 2px solid var(--gold, #f0c060);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--gold, #f0c060);
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.confirmBtn:disabled {
+  border-color: var(--muted, #7a8aaa);
+  color: var(--muted, #7a8aaa);
+  cursor: not-allowed;
+}
+
+.confirmBtn:not(:disabled):active {
+  background: rgba(240, 192, 96, 0.12);
+}

--- a/src/screens/ActionScreen.test.tsx
+++ b/src/screens/ActionScreen.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
+import ActionScreen from './ActionScreen';
+
+// INIT_GAME → START_SCOUT → SCOUT_CARD → action フェーズまで進めるラッパー
+function ActionWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return (
+      <button
+        onClick={() =>
+          dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })
+        }
+      >
+        init
+      </button>
+    );
+  }
+  if (state.phase === 'standby') {
+    return <button onClick={() => dispatch({ type: 'START_SCOUT' })}>start</button>;
+  }
+  if (state.phase === 'scout') {
+    return (
+      <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
+    );
+  }
+  if (state.phase === 'action') {
+    return <ActionScreen />;
+  }
+  return <div data-testid="after-action">phase: {state.phase}</div>;
+}
+
+function renderAction() {
+  render(
+    <GameProvider>
+      <ActionWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+  fireEvent.click(screen.getByRole('button', { name: 'start' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+}
+
+describe('ActionScreen', () => {
+  it('アクション画面が表示される', () => {
+    renderAction();
+    expect(screen.getByText('アクション')).toBeDefined();
+  });
+
+  it('手札が表向きで表示される', () => {
+    renderAction();
+    // 表向きカードはスート・ランクのいずれかが含まれる（role="button"でclickable）
+    // 少なくとも16枚（スカウト後: 15+1=16枚）表示される
+    const buttons = screen.getAllByRole('button');
+    // ステージへ出すボタン + 手札分
+    expect(buttons.length).toBeGreaterThanOrEqual(16);
+  });
+
+  it('初期状態で「ステージへ出す」ボタンはdisabled', () => {
+    renderAction();
+    const btn = screen.getByRole('button', { name: 'ステージへ出す' });
+    expect(btn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('役者札を選択するとプレビューエリアに表示される', () => {
+    renderAction();
+    const cardButtons = screen.getAllByRole('button').filter(
+      (b) => b.getAttribute('aria-label') !== 'ステージへ出す',
+    );
+    fireEvent.click(cardButtons[0]);
+    expect(screen.getByText('役者（カミ）')).toBeDefined();
+    // 確定ボタンはまだdisabled（黒子未選択）
+    expect(screen.getByRole('button', { name: 'ステージへ出す' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it('役者札を選択する前は「ステージへ出す」はdisabled', () => {
+    renderAction();
+    expect(screen.getByRole('button', { name: 'ステージへ出す' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it('役者札・黒子札を選択後に「ステージへ出す」が有効になる', () => {
+    renderAction();
+    const cardButtons = screen.getAllByRole('button').filter(
+      (b) => b.getAttribute('aria-label') !== 'ステージへ出す',
+    );
+    // 役者札を選択
+    fireEvent.click(cardButtons[0]);
+    // 黒子札を選択（別のカード）
+    fireEvent.click(cardButtons[1]);
+    expect(screen.getByRole('button', { name: 'ステージへ出す' }).hasAttribute('disabled')).toBe(false);
+  });
+
+  it('同一カードを役者・黒子の両方に選択できない', () => {
+    renderAction();
+    const cardButtons = screen.getAllByRole('button').filter(
+      (b) => b.getAttribute('aria-label') !== 'ステージへ出す',
+    );
+    // 役者札を選択
+    fireEvent.click(cardButtons[0]);
+    // 同じカードをもう一度クリック → 無視されるはず
+    fireEvent.click(cardButtons[0]);
+    // 確定ボタンはまだdisabled
+    expect(screen.getByRole('button', { name: 'ステージへ出す' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it('「ステージへ出す」でPassDevice画面に遷移する', () => {
+    renderAction();
+    const cardButtons = screen.getAllByRole('button').filter(
+      (b) => b.getAttribute('aria-label') !== 'ステージへ出す',
+    );
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'ステージへ出す' }));
+    expect(screen.getByText('さんに渡してください')).toBeDefined();
+  });
+
+  it('PassDevice完了後にwatchフェーズへ遷移する（長押しボタンが表示される）', () => {
+    renderAction();
+    const cardButtons = screen.getAllByRole('button').filter(
+      (b) => b.getAttribute('aria-label') !== 'ステージへ出す',
+    );
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'ステージへ出す' }));
+    expect(screen.getByRole('button', { name: '長押しで進む' })).toBeDefined();
+  });
+});

--- a/src/screens/ActionScreen.tsx
+++ b/src/screens/ActionScreen.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useGameDispatch, useGameState } from '@/game/context';
+import Card from '@/components/Card';
+import PassDevice from '@/components/PassDevice';
+import styles from './ActionScreen.module.css';
+
+type SelectionStep = 'selectingActor' | 'selectingKuroko' | 'confirmed';
+
+export default function ActionScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+  const [step, setStep] = useState<SelectionStep>('selectingActor');
+  const [kamiIndex, setKamiIndex] = useState<number | null>(null);
+  const [shimoIndex, setShimoIndex] = useState<number | null>(null);
+  const [showPassDevice, setShowPassDevice] = useState(false);
+
+  const hand = state.players[0].hand;
+  const actionPlayer = state.players[0];
+
+  const handleCardClick = (index: number) => {
+    if (step === 'selectingActor') {
+      setKamiIndex(index);
+      setStep('selectingKuroko');
+    } else if (step === 'selectingKuroko') {
+      if (index === kamiIndex) return; // 同一カード不可
+      setShimoIndex(index);
+      setStep('confirmed');
+    }
+  };
+
+  const handleConfirm = () => {
+    if (kamiIndex === null || shimoIndex === null) return;
+    setShowPassDevice(true);
+  };
+
+  if (showPassDevice && kamiIndex !== null && shimoIndex !== null) {
+    return (
+      <PassDevice
+        playerName={actionPlayer.name}
+        onComplete={() => dispatch({ type: 'ACTION_PLAY', kamiIndex, shimoIndex })}
+      />
+    );
+  }
+
+  const kamiCard = kamiIndex !== null ? hand[kamiIndex] : null;
+  const shimoCard = shimoIndex !== null ? hand[shimoIndex] : null;
+
+  const getInstruction = () => {
+    if (step === 'selectingActor') return '役者札（カミ）を選んでください';
+    if (step === 'selectingKuroko') return '黒子札（シモ）を選んでください';
+    return '「ステージへ出す」で確定します';
+  };
+
+  const getCardOnClick = (index: number): (() => void) | undefined => {
+    if (step === 'selectingActor') return () => handleCardClick(index);
+    if (step === 'selectingKuroko' && index !== kamiIndex) return () => handleCardClick(index);
+    return undefined;
+  };
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>アクション</h1>
+      <p className={styles.sub}>{getInstruction()}</p>
+
+      <div className={styles.preview}>
+        <div className={styles.previewSlot}>
+          <span className={styles.slotLabel}>役者（カミ）</span>
+          {kamiCard ? (
+            <Card card={{ ...kamiCard, isFaceUp: true }} isSelected />
+          ) : (
+            <div className={styles.emptySlot} />
+          )}
+        </div>
+        <div className={styles.previewSlot}>
+          <span className={styles.slotLabel}>黒子（シモ）</span>
+          {shimoCard ? (
+            <Card card={{ ...shimoCard, isFaceUp: false }} isSelectedShimo />
+          ) : (
+            <div className={styles.emptySlot} />
+          )}
+        </div>
+      </div>
+
+      <div className={styles.grid}>
+        {hand.map((card, i) => (
+          <Card
+            key={i}
+            card={{ ...card, isFaceUp: true }}
+            isSelected={i === kamiIndex}
+            isSelectedShimo={i === shimoIndex}
+            onClick={getCardOnClick(i)}
+          />
+        ))}
+      </div>
+
+      <button
+        className={styles.confirmBtn}
+        onClick={handleConfirm}
+        disabled={step !== 'confirmed'}
+      >
+        ステージへ出す
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `ActionScreen` コンポーネント実装（役者札→黒子札の順序強制選択UI）
- プレビューエリアで選択カードを確認（役者=表向き・黒子=裏向き）
- 同一カード二重選択防止（UI + reducer 両方でガード）
- 確定後に PassDevice → `ACTION_PLAY` dispatch → watch フェーズへ遷移

Closes #23

## Test plan
- [ ] `npx vitest run` で 105 テスト全通過確認
- [ ] `npx eslint .` で lint クリーン確認
- [ ] 役者札選択前は黒子札選択不可（UI 無効化）
- [ ] 同一カードを役者・黒子に選択できない
- [ ] 「ステージへ出す」確定後に PassDevice 画面へ遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)