### PR TITLE
review: Phase 4 レビュー・Sign-off（Issue #25）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,13 +1,14 @@
 # .ai-context.md
 
 ## Status
-Phase 4（メインターンフェーズ）進行中。Issue #24 Watch フェーズ実装完了・PR #57 レビュー待ち。
+Phase 4 レビュー（Issue #25）進行中。PR #57 マージ済み。WATCH_BOO reducer バグ（Issue #58）を検出。
 
 ## Active Issues
-- **#25〜38: 後続フェーズ実装等** ← 次のターゲット
+- **#25: Phase 4 レビュー・Sign-off** ← 現在対応中（PR作成中）
+- **#58: WATCH_BOO バグ修正** ← レビューで発見したバグ
 
 ## In-Progress PRs
-- PR #57: Issue #24 Watch フェーズ（レビュー待ち）
+- （なし）
 
 ## Completed
 - Issue #1: Next.js + TypeScript 初期化（main push）
@@ -28,7 +29,7 @@ Phase 4（メインターンフェーズ）進行中。Issue #24 Watch フェー
 - Issue #21: Phase 3 レビュー・Sign-off（PR#54 マージ済み）
 - Issue #22: Scout フェーズ（PR#55 マージ済み）
 - Issue #23: Action フェーズ（PR#56 マージ済み）
-- Issue #24: Watch フェーズ（PR#57 レビュー待ち）
+- Issue #24: Watch フェーズ（PR#57 マージ済み）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -47,9 +48,14 @@ Phase 4（メインターンフェーズ）進行中。Issue #24 Watch フェー
 - GameState.backstage: Card[] 追加（INIT_GAME 時に deal[2] = 10枚 を格納）
 
 ## Next actions
-1. PR #57（Issue #24 Watch フェーズ）マージ確認後、Issue #25 以降へ
+1. PR #59（Issue #25 Phase 4 sign-off）マージ確認後、Issue #58（WATCH_BOO バグ修正）へ
+2. Issue #58 修正後、Issue #26 以降（Spotlight フェーズ等）へ
 
 ## Known pitfalls
+- WATCH_BOO reducer（reducer.ts:129）: `playerABooCnt` のコピペバグあり → Issue #58 で追跡中
+  - ラウンド偶数時（Aがウォッチャー）に playerABooCnt が加算されない
+
+
 - `create-next-app` はディレクトリ名を npm package name に使う。大文字NG → `/tmp` 等で生成して移動する
 - ESLint v9 は `.eslintrc.*` 非対応。フラットコンフィグ（`eslint.config.mjs`）を使うこと
 - Vitest は tsconfig の `paths` を自動解決しない。`vitest.config.ts` に `resolve.alias` を明示すること


### PR DESCRIPTION
## レビューサマリー

Issue #22・#23・#24（スカウト→アクション→ウォッチ）の成果物レビュー。

### Issue #22 Scout フェーズ — 全AC達成 ✅
- 裏向きグリッド表示・引き直し不可・SCOUT_CARD dispatch・PassDevice 経由遷移

### Issue #23 Action フェーズ — 全AC達成 ✅
- 役者→黒子の順序強制・同一カード不可・プレビュー・ACTION_PLAY dispatch

### Issue #24 Watch フェーズ — 主要AC達成 ✅（バグあり ⚠️）
- クラップ/ブーイングボタン・フェーズ遷移は正常
- `WATCH_BOO` reducer にコピペバグあり → Issue #58 として起票済み
  - ラウンド偶数時に `playerABooCnt` が加算されない（`playerABooCnt: isPlayerA ? state.playerABooCnt : state.playerABooCnt` 両辺同じ）

### CI
- PR#57: ci/dependency-scan/guardrail/lcg/secret-scan すべて SUCCESS ✅

## Test plan
- [ ] CI グリーン確認
- [ ] Issue #58（WATCH_BOO バグ）は別PRで修正予定

Closes #25