### PR TITLE
[Feature] Spotlight Reveal（黒子札開示・結果判定）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,11 +1,11 @@
 # .ai-context.md
 
 ## Status
-Phase 4 レビュー（Issue #25）進行中。PR #57 マージ済み。WATCH_BOO reducer バグ（Issue #58）を検出。
+Issue #26（Spotlight Reveal）実装完了。PR 作成待ち。Issue #58（WATCH_BOO バグ）は未修正。
 
 ## Active Issues
-- **#25: Phase 4 レビュー・Sign-off** ← 現在対応中（PR作成中）
-- **#58: WATCH_BOO バグ修正** ← レビューで発見したバグ
+- **#26: Spotlight Reveal** ← feature/issue-26 ブランチで実装完了、PR 未作成
+- **#58: WATCH_BOO バグ修正** ← レビューで発見したバグ（未対応）
 
 ## In-Progress PRs
 - （なし）
@@ -30,6 +30,7 @@ Phase 4 レビュー（Issue #25）進行中。PR #57 マージ済み。WATCH_BO
 - Issue #22: Scout フェーズ（PR#55 マージ済み）
 - Issue #23: Action フェーズ（PR#56 マージ済み）
 - Issue #24: Watch フェーズ（PR#57 マージ済み）
+- Issue #25: Phase 4 レビュー・Sign-off（完了）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -48,8 +49,9 @@ Phase 4 レビュー（Issue #25）進行中。PR #57 マージ済み。WATCH_BO
 - GameState.backstage: Card[] 追加（INIT_GAME 時に deal[2] = 10枚 を格納）
 
 ## Next actions
-1. PR #59（Issue #25 Phase 4 sign-off）マージ確認後、Issue #58（WATCH_BOO バグ修正）へ
-2. Issue #58 修正後、Issue #26 以降（Spotlight フェーズ等）へ
+1. Issue #26 の PR を作成して main へマージ
+2. Issue #58（WATCH_BOO バグ修正）対応
+3. Issue #27 以降（Backstage フェーズ等）へ
 
 ## Known pitfalls
 - WATCH_BOO reducer（reducer.ts:129）: `playerABooCnt` のコピペバグあり → Issue #58 で追跡中

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -161,6 +161,37 @@ describe('gameReducer', () => {
     });
   });
 
+  describe('SPOTLIGHT_REVEAL', () => {
+    let spotlightState: GameState;
+    beforeEach(() => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      spotlightState = gameReducer(s4, { type: 'WATCH_BOO' });
+    });
+
+    it('shimo が表向きになる', () => {
+      const result = gameReducer(spotlightState, { type: 'SPOTLIGHT_REVEAL' });
+      expect(result.stage.shimo?.isFaceUp).toBe(true);
+    });
+
+    it('phase が spotlight のまま', () => {
+      const result = gameReducer(spotlightState, { type: 'SPOTLIGHT_REVEAL' });
+      expect(result.phase).toBe('spotlight');
+    });
+
+    it('kami は変化しない', () => {
+      const result = gameReducer(spotlightState, { type: 'SPOTLIGHT_REVEAL' });
+      expect(result.stage.kami).toEqual(spotlightState.stage.kami);
+    });
+
+    it('spotlight 以外のフェーズでは SPOTLIGHT_REVEAL が無効', () => {
+      const result = gameReducer(initialState, { type: 'SPOTLIGHT_REVEAL' });
+      expect(result).toBe(initialState);
+    });
+  });
+
   describe('RESET_GAME', () => {
     it('phase が standby に戻る', () => {
       const afterInit = gameReducer(initialState, {

--- a/src/screens/SpotlightRevealScreen.module.css
+++ b/src/screens/SpotlightRevealScreen.module.css
@@ -1,0 +1,115 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  padding: 40px 16px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.stage {
+  display: flex;
+  gap: 32px;
+  justify-content: center;
+}
+
+.stageSlot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.slotLabel {
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+  letter-spacing: 0.05em;
+}
+
+.emptySlot {
+  width: 56px;
+  height: 80px;
+  border: 1px dashed var(--muted, #7a8aaa);
+  border-radius: 8px;
+  opacity: 0.4;
+}
+
+.revealBtn {
+  padding: 14px 40px;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  border: 2px solid var(--gold, #f0c060);
+  background: transparent;
+  color: var(--gold, #f0c060);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.revealBtn:active {
+  background: rgba(240, 192, 96, 0.12);
+}
+
+.result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.resultText {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+  margin: 0;
+}
+
+.moveText {
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 16px;
+}
+
+.openSetBtn,
+.skipBtn {
+  padding: 12px 28px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.openSetBtn {
+  border: 2px solid var(--gold, #f0c060);
+  background: transparent;
+  color: var(--gold, #f0c060);
+}
+
+.openSetBtn:active {
+  background: rgba(240, 192, 96, 0.12);
+}
+
+.skipBtn {
+  border: 2px solid var(--muted, #7a8aaa);
+  background: transparent;
+  color: var(--muted, #7a8aaa);
+}
+
+.skipBtn:active {
+  background: rgba(122, 138, 170, 0.12);
+}

--- a/src/screens/SpotlightRevealScreen.test.tsx
+++ b/src/screens/SpotlightRevealScreen.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
+import SpotlightRevealScreen from './SpotlightRevealScreen';
+
+// INIT_GAME → START_SCOUT → SCOUT_CARD → ACTION_PLAY → WATCH_BOO → spotlight フェーズまで進めるラッパー
+function SpotlightWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return (
+      <button
+        onClick={() =>
+          dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })
+        }
+      >
+        init
+      </button>
+    );
+  }
+  if (state.phase === 'standby') {
+    return <button onClick={() => dispatch({ type: 'START_SCOUT' })}>start</button>;
+  }
+  if (state.phase === 'scout') {
+    return (
+      <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
+    );
+  }
+  if (state.phase === 'action') {
+    return (
+      <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>
+        action
+      </button>
+    );
+  }
+  if (state.phase === 'watch') {
+    return <button onClick={() => dispatch({ type: 'WATCH_BOO' })}>boo</button>;
+  }
+  if (state.phase === 'spotlight') {
+    return <SpotlightRevealScreen />;
+  }
+  return <div data-testid="after-spotlight">phase: {state.phase}</div>;
+}
+
+function renderSpotlight() {
+  render(
+    <GameProvider>
+      <SpotlightWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+  fireEvent.click(screen.getByRole('button', { name: 'start' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action' }));
+  fireEvent.click(screen.getByRole('button', { name: 'boo' }));
+}
+
+describe('SpotlightRevealScreen', () => {
+  it('スポットライト画面が表示される', () => {
+    renderSpotlight();
+    expect(screen.getByText('スポットライト')).toBeDefined();
+  });
+
+  it('役者（カミ）と黒子（シモ）のスロットが表示される', () => {
+    renderSpotlight();
+    expect(screen.getByText('役者（カミ）')).toBeDefined();
+    expect(screen.getByText('黒子（シモ）')).toBeDefined();
+  });
+
+  it('開示前: 「黒子札を開示」ボタンが表示される', () => {
+    renderSpotlight();
+    expect(screen.getByRole('button', { name: '黒子札を開示' })).toBeDefined();
+  });
+
+  it('開示後: 「黒子札を開示」ボタンが消える', () => {
+    renderSpotlight();
+    fireEvent.click(screen.getByRole('button', { name: '黒子札を開示' }));
+    expect(screen.queryByRole('button', { name: '黒子札を開示' })).toBeNull();
+  });
+
+  it('開示後: ブーイング正解またはブーイング不正解が表示される', () => {
+    renderSpotlight();
+    fireEvent.click(screen.getByRole('button', { name: '黒子札を開示' }));
+    const correct = screen.queryByText('ブーイング正解！');
+    const incorrect = screen.queryByText('ブーイング不正解！');
+    expect(correct !== null || incorrect !== null).toBe(true);
+  });
+
+  it('開示後: セットを開くまたはスキップボタンが表示される', () => {
+    renderSpotlight();
+    fireEvent.click(screen.getByRole('button', { name: '黒子札を開示' }));
+    expect(screen.getByRole('button', { name: 'セットを開く' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'スキップ' })).toBeDefined();
+  });
+
+  it('スキップで backstage フェーズに遷移する', () => {
+    renderSpotlight();
+    fireEvent.click(screen.getByRole('button', { name: '黒子札を開示' }));
+    fireEvent.click(screen.getByRole('button', { name: 'スキップ' }));
+    expect(screen.getByTestId('after-spotlight').textContent).toBe('phase: backstage');
+  });
+});

--- a/src/screens/SpotlightRevealScreen.tsx
+++ b/src/screens/SpotlightRevealScreen.tsx
@@ -1,0 +1,82 @@
+import { useGameDispatch, useGameState } from '@/game/context';
+import Card from '@/components/Card';
+import styles from './SpotlightRevealScreen.module.css';
+
+export default function SpotlightRevealScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+
+  const { kami, shimo } = state.stage;
+  const isRevealed = shimo?.isFaceUp ?? false;
+  const isMatch =
+    isRevealed && kami !== null && shimo !== null && kami.rank === shimo.rank;
+  const isNoMatch =
+    isRevealed && kami !== null && shimo !== null && kami.rank !== shimo.rank;
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>スポットライト</h1>
+
+      <div className={styles.stage}>
+        <div className={styles.stageSlot}>
+          <span className={styles.slotLabel}>役者（カミ）</span>
+          {kami ? <Card card={kami} /> : <div className={styles.emptySlot} />}
+        </div>
+        <div className={styles.stageSlot}>
+          <span className={styles.slotLabel}>黒子（シモ）</span>
+          {shimo ? <Card card={shimo} /> : <div className={styles.emptySlot} />}
+        </div>
+      </div>
+
+      {!isRevealed && (
+        <button
+          className={styles.revealBtn}
+          onClick={() => dispatch({ type: 'SPOTLIGHT_REVEAL' })}
+        >
+          黒子札を開示
+        </button>
+      )}
+
+      {isMatch && (
+        <div className={styles.result}>
+          <p className={styles.resultText}>ブーイング不正解！</p>
+          <div className={styles.actions}>
+            <button
+              className={styles.openSetBtn}
+              onClick={() => dispatch({ type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 })}
+            >
+              セットを開く
+            </button>
+            <button
+              className={styles.skipBtn}
+              onClick={() => dispatch({ type: 'SPOTLIGHT_SKIP_SET' })}
+            >
+              スキップ
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isNoMatch && (
+        <div className={styles.result}>
+          <p className={styles.resultText}>ブーイング正解！</p>
+          <p className={styles.moveText}>カードがBのステージへ移動します</p>
+          <div className={styles.actions}>
+            <button
+              className={styles.openSetBtn}
+              onClick={() => dispatch({ type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 })}
+            >
+              セットを開く
+            </button>
+            <button
+              className={styles.skipBtn}
+              onClick={() => dispatch({ type: 'SPOTLIGHT_SKIP_SET' })}
+            >
+              スキップ
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- `SpotlightRevealScreen` コンポーネントを実装（黒子札開示・役者札との数値比較判定）
- 一致時（ブーイング不正解）：「ブーイング不正解！」＋セットオープン選択肢を表示
- 不一致時（ブーイング正解）：「ブーイング正解！」＋Bステージ移動メッセージ＋セットオープン選択肢を表示
- `SPOTLIGHT_REVEAL` reducer テストを追加

Closes #26

## Test plan

- [x] `npx vitest run` — 122テスト全通過
- [x] `npx eslint .` — 警告・エラーなし
- [x] `npx tsc --noEmit` — 新規コードに型エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)