### PR TITLE
feat: Spotlight ボーナス（セットオープン・ペア成立処理）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,10 +1,10 @@
 # .ai-context.md
 
 ## Status
-Issue #26（Spotlight Reveal）実装完了。PR 作成待ち。Issue #58（WATCH_BOO バグ）は未修正。
+Issue #27（Spotlight ボーナス）実装完了。PR 作成待ち。Issue #58（WATCH_BOO バグ）は未修正。
 
 ## Active Issues
-- **#26: Spotlight Reveal** ← feature/issue-26 ブランチで実装完了、PR 未作成
+- **#27: Spotlight ボーナス** ← feature/issue-27 ブランチで実装完了、PR 未作成
 - **#58: WATCH_BOO バグ修正** ← レビューで発見したバグ（未対応）
 
 ## In-Progress PRs
@@ -31,6 +31,7 @@ Issue #26（Spotlight Reveal）実装完了。PR 作成待ち。Issue #58（WATC
 - Issue #23: Action フェーズ（PR#56 マージ済み）
 - Issue #24: Watch フェーズ（PR#57 マージ済み）
 - Issue #25: Phase 4 レビュー・Sign-off（完了）
+- Issue #26: Spotlight Reveal（PR#60 マージ済み）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -47,11 +48,14 @@ Issue #26（Spotlight Reveal）実装完了。PR 作成待ち。Issue #58（WATC
 - INIT_GAME は standby フェーズ維持（カード配布完了後も standby）。START_SCOUT で scout へ遷移
   - 理由: StandbyScreen（配布サマリー）を INIT_GAME 後に表示するため
 - GameState.backstage: Card[] 追加（INIT_GAME 時に deal[2] = 10枚 を格納）
+- spotlight-bonus フェーズを追加（spotlight → spotlight-bonus → 各分岐）
+  - SPOTLIGHT_ENTER_BONUS で spotlight-bonus へ遷移
+  - SPOTLIGHT_OPEN_SET は spotlight-bonus フェーズで処理（ペア判定含む）
 
 ## Next actions
-1. Issue #26 の PR を作成して main へマージ
+1. Issue #27 の PR を作成して main へマージ
 2. Issue #58（WATCH_BOO バグ修正）対応
-3. Issue #27 以降（Backstage フェーズ等）へ
+3. Issue #28 以降へ
 
 ## Known pitfalls
 - WATCH_BOO reducer（reducer.ts:129）: `playerABooCnt` のコピペバグあり → Issue #58 で追跡中

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -192,6 +192,107 @@ describe('gameReducer', () => {
     });
   });
 
+  describe('SPOTLIGHT_ENTER_BONUS', () => {
+    let spotlightState: GameState;
+    beforeEach(() => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
+      spotlightState = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
+    });
+
+    it('spotlight → spotlight-bonus に遷移する', () => {
+      const result = gameReducer(spotlightState, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      expect(result.phase).toBe('spotlight-bonus');
+    });
+
+    it('spotlight 以外では無効', () => {
+      const result = gameReducer(initialState, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      expect(result).toBe(initialState);
+    });
+  });
+
+  describe('SPOTLIGHT_OPEN_SET', () => {
+    let bonusState: GameState;
+    beforeEach(() => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
+      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
+      bonusState = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+    });
+
+    it('spotlight-bonus 以外では無効', () => {
+      const result = gameReducer(initialState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
+      expect(result).toBe(initialState);
+    });
+
+    it('ジョーカーを開いたとき curtain-call に遷移する', () => {
+      const jokerIndex = bonusState.deck.findIndex((c) => c.isJoker);
+      if (jokerIndex === -1) return; // jokerがない場合はスキップ
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: jokerIndex });
+      expect(result.phase).toBe('curtain-call');
+      expect(result.curtainCallReason).toBe('joker');
+    });
+
+    it('setRemainingCount が減少する', () => {
+      const nonJokerIndex = bonusState.deck.findIndex((c) => !c.isJoker);
+      if (nonJokerIndex === -1) return;
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: nonJokerIndex });
+      expect(result.setRemainingCount).toBe(bonusState.setRemainingCount - 1);
+    });
+
+    it('ペア成立時に intermission へ遷移する', () => {
+      // 手札に同じrankのカードがあるsetカードを探す
+      const playerAHand = bonusState.players[0].hand;
+      const pairableSetIndex = bonusState.deck.findIndex(
+        (sc) => !sc.isJoker && playerAHand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
+      );
+      if (pairableSetIndex === -1) return; // ペアなし状態ではスキップ
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: pairableSetIndex });
+      expect(result.phase).toBe('intermission');
+    });
+
+    it('ペア成立時に手札が1枚減る', () => {
+      const playerAHand = bonusState.players[0].hand;
+      const pairableSetIndex = bonusState.deck.findIndex(
+        (sc) => !sc.isJoker && playerAHand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
+      );
+      if (pairableSetIndex === -1) return;
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: pairableSetIndex });
+      expect(result.players[0].hand).toHaveLength(playerAHand.length - 1);
+    });
+
+    it('ペア不成立時に backstage へ遷移する', () => {
+      // 手札にないrankのsetカードを探す
+      const playerAHand = bonusState.players[0].hand;
+      const noPairSetIndex = bonusState.deck.findIndex(
+        (sc) => !sc.isJoker && !playerAHand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
+      );
+      if (noPairSetIndex === -1) return;
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
+      expect(result.phase).toBe('backstage');
+    });
+  });
+
+  describe('SPOTLIGHT_SKIP_SET（spotlight-bonus フェーズ）', () => {
+    it('spotlight-bonus → backstage に遷移する', () => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
+      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
+      const bonusState = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_SKIP_SET' });
+      expect(result.phase).toBe('backstage');
+    });
+  });
+
   describe('RESET_GAME', () => {
     it('phase が standby に戻る', () => {
       const afterInit = gameReducer(initialState, {

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -9,6 +9,7 @@ export type GameAction =
   | { type: 'WATCH_CLAP' }
   | { type: 'WATCH_BOO' }
   | { type: 'SPOTLIGHT_REVEAL' }
+  | { type: 'SPOTLIGHT_ENTER_BONUS' }
   | { type: 'SPOTLIGHT_OPEN_SET'; setCardIndex: number }
   | { type: 'SPOTLIGHT_SKIP_SET' }
   | { type: 'BACKSTAGE_OPEN' }
@@ -138,8 +139,13 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return { ...state, stage: { ...state.stage, shimo: revealedShimo } };
     }
 
-    case 'SPOTLIGHT_OPEN_SET': {
+    case 'SPOTLIGHT_ENTER_BONUS': {
       if (state.phase !== 'spotlight') return state;
+      return { ...state, phase: 'spotlight-bonus' };
+    }
+
+    case 'SPOTLIGHT_OPEN_SET': {
+      if (state.phase !== 'spotlight-bonus') return state;
       const setCard = state.deck[action.setCardIndex];
       if (setCard === undefined) return state;
 
@@ -167,7 +173,24 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         };
       }
 
-      // ペア判定などの詳細ロジックは後続Issueで実装
+      // ペア判定: 手札に同数字があるか
+      const playerAHand = state.players[0].hand;
+      const pairCardIndex = playerAHand.findIndex((c) => !c.isJoker && c.rank === openedCard.rank);
+      if (pairCardIndex !== -1) {
+        const pairCard = playerAHand[pairCardIndex];
+        const newHandA = removeCardAt(playerAHand, pairCardIndex);
+        const newPlayerA: Player = { ...state.players[0], hand: newHandA };
+        const players: [Player, Player] = [newPlayerA, state.players[1]];
+        return {
+          ...state,
+          deck: newDeck,
+          setRemainingCount: newSetRemainingCount,
+          stage: { kami: { ...openedCard }, shimo: { ...pairCard, isFaceUp: true } },
+          players,
+          phase: 'intermission',
+        };
+      }
+
       return {
         ...state,
         deck: newDeck,
@@ -177,7 +200,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     }
 
     case 'SPOTLIGHT_SKIP_SET': {
-      if (state.phase !== 'spotlight') return state;
+      if (state.phase !== 'spotlight' && state.phase !== 'spotlight-bonus') return state;
       return { ...state, phase: 'backstage' };
     }
 

--- a/src/screens/SpotlightBonusScreen.module.css
+++ b/src/screens/SpotlightBonusScreen.module.css
@@ -1,0 +1,47 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  padding: 40px 16px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.instruction {
+  font-size: 14px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+}
+
+.cardGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  max-width: 360px;
+}
+
+.cancelBtn {
+  padding: 12px 28px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+  border: 2px solid var(--muted, #7a8aaa);
+  background: transparent;
+  color: var(--muted, #7a8aaa);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.cancelBtn:active {
+  background: rgba(122, 138, 170, 0.12);
+}

--- a/src/screens/SpotlightBonusScreen.test.tsx
+++ b/src/screens/SpotlightBonusScreen.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
+import SpotlightBonusScreen from './SpotlightBonusScreen';
+
+// INIT_GAME → START_SCOUT → SCOUT_CARD → ACTION_PLAY → WATCH_BOO → SPOTLIGHT_REVEAL → SPOTLIGHT_ENTER_BONUS まで進めるラッパー
+function BonusWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return (
+      <button
+        onClick={() =>
+          dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })
+        }
+      >
+        init
+      </button>
+    );
+  }
+  if (state.phase === 'standby') {
+    return <button onClick={() => dispatch({ type: 'START_SCOUT' })}>start</button>;
+  }
+  if (state.phase === 'scout') {
+    return (
+      <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
+    );
+  }
+  if (state.phase === 'action') {
+    return (
+      <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>
+        action
+      </button>
+    );
+  }
+  if (state.phase === 'watch') {
+    return <button onClick={() => dispatch({ type: 'WATCH_BOO' })}>boo</button>;
+  }
+  if (state.phase === 'spotlight') {
+    return (
+      <>
+        <button onClick={() => dispatch({ type: 'SPOTLIGHT_REVEAL' })}>reveal</button>
+        <button onClick={() => dispatch({ type: 'SPOTLIGHT_ENTER_BONUS' })}>enter-bonus</button>
+      </>
+    );
+  }
+  if (state.phase === 'spotlight-bonus') {
+    return <SpotlightBonusScreen />;
+  }
+  return <div data-testid="after-bonus">phase: {state.phase}</div>;
+}
+
+function renderBonus() {
+  render(
+    <GameProvider>
+      <BonusWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+  fireEvent.click(screen.getByRole('button', { name: 'start' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action' }));
+  fireEvent.click(screen.getByRole('button', { name: 'boo' }));
+  fireEvent.click(screen.getByRole('button', { name: 'reveal' }));
+  fireEvent.click(screen.getByRole('button', { name: 'enter-bonus' }));
+}
+
+describe('SpotlightBonusScreen', () => {
+  it('ボーナス画面が表示される', () => {
+    renderBonus();
+    expect(screen.getByText('セットを開く')).toBeDefined();
+  });
+
+  it('裏向きカードが表示される', () => {
+    renderBonus();
+    expect(screen.getByText('裏向きのカードを1枚選んでください')).toBeDefined();
+  });
+
+  it('「開かない」ボタンが表示される', () => {
+    renderBonus();
+    expect(screen.getByRole('button', { name: '開かない' })).toBeDefined();
+  });
+
+  it('「開かない」で backstage フェーズに遷移する', () => {
+    renderBonus();
+    fireEvent.click(screen.getByRole('button', { name: '開かない' }));
+    expect(screen.getByTestId('after-bonus').textContent).toBe('phase: backstage');
+  });
+
+  it('セットカードをクリックすると curtain-call か backstage か intermission に遷移する', () => {
+    renderBonus();
+    const cardButtons = screen.getAllByRole('button').filter((btn) => btn.className !== '');
+    // 裏向きカード（Card コンポーネントの button role）が存在する
+    expect(cardButtons.length).toBeGreaterThan(0);
+    fireEvent.click(cardButtons[0]);
+    const afterDiv = screen.queryByTestId('after-bonus');
+    const stillBonus = screen.queryByText('セットを開く');
+    // ボーナス画面から離れているか、カーテンコール等に遷移している
+    expect(afterDiv !== null || stillBonus === null).toBe(true);
+  });
+});

--- a/src/screens/SpotlightBonusScreen.tsx
+++ b/src/screens/SpotlightBonusScreen.tsx
@@ -1,0 +1,36 @@
+import { useGameDispatch, useGameState } from '@/game/context';
+import Card from '@/components/Card';
+import styles from './SpotlightBonusScreen.module.css';
+
+export default function SpotlightBonusScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+
+  const faceDownCards = state.deck
+    .map((card, index) => ({ card, index }))
+    .filter(({ card }) => !card.isFaceUp);
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>セットを開く</h1>
+      <p className={styles.instruction}>裏向きのカードを1枚選んでください</p>
+
+      <div className={styles.cardGrid}>
+        {faceDownCards.map(({ card, index }) => (
+          <Card
+            key={index}
+            card={card}
+            onClick={() => dispatch({ type: 'SPOTLIGHT_OPEN_SET', setCardIndex: index })}
+          />
+        ))}
+      </div>
+
+      <button
+        className={styles.cancelBtn}
+        onClick={() => dispatch({ type: 'SPOTLIGHT_SKIP_SET' })}
+      >
+        開かない
+      </button>
+    </div>
+  );
+}

--- a/src/screens/SpotlightRevealScreen.tsx
+++ b/src/screens/SpotlightRevealScreen.tsx
@@ -43,7 +43,7 @@ export default function SpotlightRevealScreen() {
           <div className={styles.actions}>
             <button
               className={styles.openSetBtn}
-              onClick={() => dispatch({ type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 })}
+              onClick={() => dispatch({ type: 'SPOTLIGHT_ENTER_BONUS' })}
             >
               セットを開く
             </button>
@@ -64,7 +64,7 @@ export default function SpotlightRevealScreen() {
           <div className={styles.actions}>
             <button
               className={styles.openSetBtn}
-              onClick={() => dispatch({ type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 })}
+              onClick={() => dispatch({ type: 'SPOTLIGHT_ENTER_BONUS' })}
             >
               セットを開く
             </button>

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -24,6 +24,7 @@ export type GamePhase =
   | 'action'
   | 'watch'
   | 'spotlight'
+  | 'spotlight-bonus'
   | 'backstage'
   | 'intermission'
   | 'curtain-call'


### PR DESCRIPTION
## Summary
- `GamePhase` に `'spotlight-bonus'` を追加
- `SPOTLIGHT_ENTER_BONUS` アクションを追加（spotlight → spotlight-bonus）
- `SPOTLIGHT_OPEN_SET` にペア判定ロジックを実装（ジョーカー→curtain-call / セット残1枚→curtain-call / ペア成立→intermission / ペア不成立→backstage）
- `SpotlightBonusScreen` を新規作成（セット裏向きカード選択UI・「開かない」ボタン）
- `SpotlightRevealScreen` の「セットを開く」を `SPOTLIGHT_ENTER_BONUS` に変更

## Test plan
- [ ] `SPOTLIGHT_ENTER_BONUS`（spotlight → spotlight-bonus、不正フェーズ無効）
- [ ] `SPOTLIGHT_OPEN_SET`（ジョーカー・セット残1枚・ペア成立・ペア不成立・不正フェーズ無効）
- [ ] `SPOTLIGHT_SKIP_SET`（spotlight-bonus → backstage）
- [ ] `SpotlightBonusScreen` 画面表示・「開かない」→backstage・カード選択後の遷移

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)