### PR TITLE
[Feature] インターミッション（役割交代・手札枚数チェック）

### DIFF
--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -421,6 +421,68 @@ describe('gameReducer', () => {
     });
   });
 
+  describe('INTERMISSION', () => {
+    // intermission フェーズに到達するベース状態を構築（WATCH_CLAP 経由）
+    function buildIntermissionState() {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      return gameReducer(s4, { type: 'WATCH_CLAP' });
+    }
+
+    it('通常継続時に scout フェーズへ遷移する', () => {
+      const intermissionState = buildIntermissionState();
+      const result = gameReducer(intermissionState, { type: 'INTERMISSION' });
+      expect(result.phase).toBe('scout');
+    });
+
+    it('通常継続時に round が +1 される', () => {
+      const intermissionState = buildIntermissionState();
+      const result = gameReducer(intermissionState, { type: 'INTERMISSION' });
+      expect(result.round).toBe(intermissionState.round + 1);
+    });
+
+    it('通常継続時にプレイヤーが入れ替わる', () => {
+      const intermissionState = buildIntermissionState();
+      const prevScoutId = intermissionState.players[0].id;
+      const result = gameReducer(intermissionState, { type: 'INTERMISSION' });
+      expect(result.players[0].id).not.toBe(prevScoutId);
+    });
+
+    it('次スカウト担当の手札が0枚のとき curtain-call に遷移する', () => {
+      const base = buildIntermissionState();
+      // players[1] が次スカウト（round=1 の場合 nextScoutIsA=false → players[1] を参照）
+      const stateWithEmptyHand = {
+        ...base,
+        players: [base.players[0], { ...base.players[1], hand: [] }] as typeof base.players,
+      };
+      const result = gameReducer(stateWithEmptyHand, { type: 'INTERMISSION' });
+      expect(result.phase).toBe('curtain-call');
+      expect(result.curtainCallReason).toBe('hand-shortage');
+    });
+
+    it('次スカウト担当が1枚かつ相手が0枚のとき curtain-call に遷移する', () => {
+      const base = buildIntermissionState();
+      const oneCard = [base.players[1].hand[0]];
+      const stateWith1And0 = {
+        ...base,
+        players: [
+          { ...base.players[0], hand: [] },
+          { ...base.players[1], hand: oneCard },
+        ] as typeof base.players,
+      };
+      const result = gameReducer(stateWith1And0, { type: 'INTERMISSION' });
+      expect(result.phase).toBe('curtain-call');
+      expect(result.curtainCallReason).toBe('hand-shortage');
+    });
+
+    it('intermission 以外のフェーズでは INTERMISSION が無効', () => {
+      const result = gameReducer(initialState, { type: 'INTERMISSION' });
+      expect(result).toBe(initialState);
+    });
+  });
+
   describe('RESET_GAME', () => {
     it('phase が standby に戻る', () => {
       const afterInit = gameReducer(initialState, {

--- a/src/screens/IntermissionScreen.module.css
+++ b/src/screens/IntermissionScreen.module.css
@@ -1,0 +1,64 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 40px 16px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--accent, #60a5fa);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.roundInfo {
+  font-size: 14px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+}
+
+.swapInfo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.swapLabel {
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+}
+
+.swapArrow {
+  font-size: 20px;
+  color: var(--accent, #60a5fa);
+}
+
+.nextScout {
+  font-size: 18px;
+  font-weight: bold;
+  color: #fff;
+  margin: 0;
+}
+
+.proceedBtn {
+  padding: 12px 28px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+  border: 2px solid var(--accent, #60a5fa);
+  background: transparent;
+  color: var(--accent, #60a5fa);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.proceedBtn:active {
+  background: rgba(96, 165, 250, 0.12);
+}

--- a/src/screens/IntermissionScreen.tsx
+++ b/src/screens/IntermissionScreen.tsx
@@ -1,0 +1,30 @@
+import { useGameDispatch, useGameState } from '@/game/context';
+import styles from './IntermissionScreen.module.css';
+
+export default function IntermissionScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+
+  const currentScout = state.players[0];
+  const nextScout = state.players[1];
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>インターミッション</h1>
+      <p className={styles.roundInfo}>ラウンド {state.round} 終了</p>
+
+      <div className={styles.swapInfo}>
+        <p className={styles.swapLabel}>次のスカウト担当</p>
+        <p className={styles.swapArrow}>{currentScout.name} → {nextScout.name}</p>
+        <p className={styles.nextScout}>{nextScout.name}</p>
+      </div>
+
+      <button
+        className={styles.proceedBtn}
+        onClick={() => dispatch({ type: 'INTERMISSION' })}
+      >
+        次のラウンドへ
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #30 の実装。インターミッションフェーズでの役割交代と手札不足によるカーテンコール判定を追加する。

## 変更内容

- `src/screens/IntermissionScreen.tsx` — 役割交代表示と「次のラウンドへ」ボタン
- `src/screens/IntermissionScreen.module.css` — 画面スタイル
- `src/game/reducer.test.ts` — INTERMISSION カーテンコール条件テスト追加（6ケース）

## テスト

- 通常継続: scout フェーズへ遷移 / round+1 / プレイヤー入れ替わり
- 次スカウト手札0枚 → curtain-call（hand-shortage）
- 次スカウト1枚・相手0枚 → curtain-call（hand-shortage）
- 不正フェーズガード

全 158 テスト pass 確認済み。

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)