### PR TITLE
[Feature] カーテンコール条件検出（3つの終了条件）

### DIFF
--- a/src/lib/curtainCall.test.ts
+++ b/src/lib/curtainCall.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { checkCurtainCall } from './curtainCall';
+import type { Card, GameState, Player } from '@/types/game';
+
+function makeCard(rank: number, isJoker = false, isFaceUp = false): Card {
+  return { suit: 'spades', rank, isJoker, isFaceUp };
+}
+
+function makePlayer(id: string, handSize: number): Player {
+  return {
+    id,
+    name: id,
+    hand: Array.from({ length: handSize }, (_, i) => makeCard(i + 1)),
+  };
+}
+
+const baseState: GameState = {
+  phase: 'intermission',
+  players: [makePlayer('A', 5), makePlayer('B', 5)],
+  stage: { kami: null, shimo: null },
+  deck: [makeCard(1), makeCard(2), makeCard(3)],
+  backstage: [],
+  setRemainingCount: 3,
+  publicInfos: [],
+  playerABooCnt: 0,
+  playerBBooCnt: 0,
+  round: 1,
+  curtainCallReason: null,
+  spotlightCard: null,
+  backstageRevealedCards: [],
+  backstageResult: null,
+};
+
+describe('checkCurtainCall', () => {
+  describe('条件①: ジョーカーがセットからオープンされた', () => {
+    it('face-up のジョーカーがデッキにある場合 joker を返す', () => {
+      const state: GameState = {
+        ...baseState,
+        deck: [makeCard(0, true, true), makeCard(1), makeCard(2)],
+        setRemainingCount: 2,
+      };
+      expect(checkCurtainCall(state)).toBe('joker');
+    });
+
+    it('ジョーカーが裏向きの場合は joker を返さない', () => {
+      const state: GameState = {
+        ...baseState,
+        deck: [makeCard(0, true, false), makeCard(1), makeCard(2)],
+        setRemainingCount: 3,
+      };
+      expect(checkCurtainCall(state)).toBeNull();
+    });
+  });
+
+  describe('条件②: セットの裏向きカードが残り1枚以下', () => {
+    it('setRemainingCount が 1 のとき set-last-1 を返す', () => {
+      const state: GameState = {
+        ...baseState,
+        deck: [makeCard(1, false, true), makeCard(2, false, true), makeCard(3)],
+        setRemainingCount: 1,
+      };
+      expect(checkCurtainCall(state)).toBe('set-last-1');
+    });
+
+    it('setRemainingCount が 0 のとき set-last-1 を返す', () => {
+      const state: GameState = {
+        ...baseState,
+        deck: [makeCard(1, false, true), makeCard(2, false, true)],
+        setRemainingCount: 0,
+      };
+      // deck.length > 0 かつ setRemainingCount <= 1 → set-last-1
+      expect(checkCurtainCall(state)).toBe('set-last-1');
+    });
+
+    it('ゲーム未開始（deck が空）のとき set-last-1 を返さない', () => {
+      const state: GameState = {
+        ...baseState,
+        deck: [],
+        setRemainingCount: 0,
+      };
+      expect(checkCurtainCall(state)).toBeNull();
+    });
+
+    it('setRemainingCount が 2 以上のとき set-last-1 を返さない', () => {
+      const state: GameState = {
+        ...baseState,
+        setRemainingCount: 2,
+      };
+      expect(checkCurtainCall(state)).toBeNull();
+    });
+  });
+
+  describe('条件③: 手札不足', () => {
+    it('次スカウト担当の手札が 0 枚のとき hand-shortage を返す', () => {
+      // round=1: players[0] がスカウト → 次は players[1]（round 偶数でA）
+      // round=1 → nextScoutIsA = (1 % 2 === 0) = false → nextScout = players[1]
+      const state: GameState = {
+        ...baseState,
+        round: 1,
+        players: [makePlayer('A', 3), makePlayer('B', 0)],
+      };
+      expect(checkCurtainCall(state)).toBe('hand-shortage');
+    });
+
+    it('次スカウト担当が 1 枚かつ相手が 0 枚のとき hand-shortage を返す', () => {
+      const state: GameState = {
+        ...baseState,
+        round: 1,
+        players: [makePlayer('A', 0), makePlayer('B', 1)],
+      };
+      expect(checkCurtainCall(state)).toBe('hand-shortage');
+    });
+
+    it('次スカウト担当が 2 枚以上のとき hand-shortage を返さない', () => {
+      const state: GameState = {
+        ...baseState,
+        round: 1,
+        players: [makePlayer('A', 3), makePlayer('B', 2)],
+      };
+      expect(checkCurtainCall(state)).toBeNull();
+    });
+
+    it('ラウンド偶数時は players[0] が次スカウトとして判定される', () => {
+      // round=2 → nextScoutIsA = (2 % 2 === 0) = true → nextScout = players[0]
+      const state: GameState = {
+        ...baseState,
+        round: 2,
+        players: [makePlayer('A', 0), makePlayer('B', 5)],
+      };
+      expect(checkCurtainCall(state)).toBe('hand-shortage');
+    });
+  });
+
+  describe('条件に該当しない場合', () => {
+    it('全条件を満たさない場合は null を返す', () => {
+      expect(checkCurtainCall(baseState)).toBeNull();
+    });
+  });
+});

--- a/src/lib/curtainCall.ts
+++ b/src/lib/curtainCall.ts
@@ -1,0 +1,29 @@
+import type { CurtainCallReason, GameState } from '@/types/game';
+
+/**
+ * 現在の GameState からカーテンコール条件を検出する。
+ *
+ * 条件①: ジョーカーがセットからオープンされた
+ * 条件②: セットの裏向きカードが残り1枚以下
+ * 条件③: 手札不足（次のスカウト担当が続行不可）
+ *
+ * 条件に該当しない場合は null を返す。
+ */
+export function checkCurtainCall(state: GameState): CurtainCallReason | null {
+  // 条件①: ジョーカーがセットからオープンされた
+  if (state.deck.some((c) => c.isJoker && c.isFaceUp)) return 'joker';
+
+  // 条件②: セットの裏向きカードが残り1枚以下（ゲーム開始後のみ判定）
+  if (state.setRemainingCount <= 1 && state.deck.length > 0) return 'set-last-1';
+
+  // 条件③: 手札不足（次のスカウト担当の手札が続行不可）
+  // round が奇数: players[0] がスカウト担当 → 次は players[1]（= round 偶数で A）
+  const nextScoutIsA = state.round % 2 === 0;
+  const nextScoutHand = nextScoutIsA ? state.players[0].hand : state.players[1].hand;
+  const otherHand = nextScoutIsA ? state.players[1].hand : state.players[0].hand;
+  if (nextScoutHand.length === 0 || (nextScoutHand.length === 1 && otherHand.length === 0)) {
+    return 'hand-shortage';
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- `src/lib/curtainCall.ts` に `checkCurtainCall(state: GameState): CurtainCallReason | null` を実装
- 条件①: ジョーカーがセットからオープンされた（`joker`）
- 条件②: セットの裏向きカードが残り1枚以下（`set-last-1`）
- 条件③: 手札不足（`hand-shortage`）
- 11ケースのユニットテストで全条件・非該当ケースをカバー

Closes #31

## Test plan

- [ ] `npx vitest run src/lib/curtainCall.test.ts` → 11 passed
- [ ] `npx vitest run` → 169 passed（全体）

🤖 Generated with [Claude Code](https://claude.com/claude-code)