### PR TITLE
[Fix] WATCH_BOO コピペバグ（#58）・SPOTLIGHT_OPEN_SET hand参照バグ（#64）

### DIFF
--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -18,6 +18,7 @@ const baseState: GameState = {
   playerBBooCnt: 2,
   round: 1,
   curtainCallReason: null,
+  booResult: null,
   spotlightCard: null,
   backstageRevealedCards: [],
   backstageResult: null,

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { gameReducer, initialState } from './reducer';
-import type { GameState } from '@/types/game';
+import type { Card, GameState } from '@/types/game';
 
 describe('gameReducer', () => {
   describe('INIT_GAME', () => {
@@ -230,7 +230,9 @@ describe('gameReducer', () => {
       const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
       const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
       const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      bonusState = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s7 = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      // 既存テストは boo 不正解（actor の手札参照）パスを検証するため明示的に設定
+      bonusState = { ...s7, booResult: 'incorrect' as const };
     });
 
     it('spotlight-bonus 以外では無効', () => {
@@ -284,6 +286,62 @@ describe('gameReducer', () => {
       const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
       expect(result.phase).toBe('backstage');
     });
+
+    describe('boo 正解時（booResult=correct）の手札参照（Issue #64）', () => {
+      const mk = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+
+      it('boo 正解時に players[1].hand でペア判定し intermission へ遷移する', () => {
+        const booCorrectState: GameState = {
+          phase: 'spotlight-bonus',
+          booResult: 'correct',
+          players: [
+            { id: 'A', name: 'A', hand: [mk(3), mk(7)] },  // actor: rank-5 なし
+            { id: 'B', name: 'B', hand: [mk(5), mk(9)] },  // watcher: rank-5 あり
+          ],
+          stage: { kami: { ...mk(4), isFaceUp: true }, shimo: { ...mk(6), isFaceUp: true } },
+          deck: [mk(5), mk(11), mk(8)],
+          backstage: [],
+          setRemainingCount: 3,
+          publicInfos: [],
+          playerABooCnt: 0,
+          playerBBooCnt: 0,
+          round: 1,
+          curtainCallReason: null,
+          spotlightCard: null,
+          backstageRevealedCards: [],
+          backstageResult: null,
+        };
+        const result = gameReducer(booCorrectState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
+        expect(result.phase).toBe('intermission');
+        expect(result.players[1].hand).toHaveLength(1);
+        expect(result.players[0].hand).toHaveLength(2);
+      });
+
+      it('boo 正解時は players[0].hand にペアがあっても players[1].hand を使う', () => {
+        const booCorrectState: GameState = {
+          phase: 'spotlight-bonus',
+          booResult: 'correct',
+          players: [
+            { id: 'A', name: 'A', hand: [mk(5), mk(7)] },  // actor: rank-5 あり（だが参照されない）
+            { id: 'B', name: 'B', hand: [mk(9), mk(11)] }, // watcher: rank-5 なし → ペア不成立
+          ],
+          stage: { kami: { ...mk(4), isFaceUp: true }, shimo: { ...mk(6), isFaceUp: true } },
+          deck: [mk(5), mk(11), mk(8)],
+          backstage: [],
+          setRemainingCount: 3,
+          publicInfos: [],
+          playerABooCnt: 0,
+          playerBBooCnt: 0,
+          round: 1,
+          curtainCallReason: null,
+          spotlightCard: null,
+          backstageRevealedCards: [],
+          backstageResult: null,
+        };
+        const result = gameReducer(booCorrectState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
+        expect(result.phase).toBe('backstage');
+      });
+    });
   });
 
   describe('SPOTLIGHT_SKIP_SET（spotlight-bonus フェーズ）', () => {
@@ -309,7 +367,9 @@ describe('gameReducer', () => {
       const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
       const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
       const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const s7 = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s7raw = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      // boo 不正解パスを確定させて既存テストを安定化
+      const s7 = { ...s7raw, booResult: 'incorrect' as const };
 
       // ペア不成立のセットカードを探す
       const playerAHand = s7.players[0].hand;
@@ -354,7 +414,8 @@ describe('gameReducer', () => {
       const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
       const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
       const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const s7 = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s7raw = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s7 = { ...s7raw, booResult: 'incorrect' as const };
       const noPairSetIndex = s7.deck.findIndex(
         (sc) => !sc.isJoker && !s7.players[0].hand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
       );

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -159,6 +159,13 @@ describe('gameReducer', () => {
       const result = gameReducer(watchState, { type: 'WATCH_BOO' });
       expect(result.playerBBooCnt).toBe(1);
     });
+
+    it('ラウンド偶数時（round=2）に WATCH_BOO で playerABooCnt が増える', () => {
+      const round2WatchState = { ...watchState, round: 2 };
+      const result = gameReducer(round2WatchState, { type: 'WATCH_BOO' });
+      expect(result.playerABooCnt).toBe(1);
+      expect(result.playerBBooCnt).toBe(0);
+    });
   });
 
   describe('SPOTLIGHT_REVEAL', () => {

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -132,7 +132,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return {
         ...state,
         phase: 'spotlight',
-        playerABooCnt: isPlayerA ? state.playerABooCnt : state.playerABooCnt,
+        playerABooCnt: isPlayerA ? state.playerABooCnt : state.playerABooCnt + 1,
         playerBBooCnt: isPlayerA ? state.playerBBooCnt + 1 : state.playerBBooCnt,
       };
     }

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -140,9 +140,10 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
     case 'SPOTLIGHT_REVEAL': {
       if (state.phase !== 'spotlight') return state;
-      if (state.stage.shimo === null) return state;
+      if (state.stage.shimo === null || state.stage.kami === null) return state;
       const revealedShimo: Card = { ...state.stage.shimo, isFaceUp: true };
-      return { ...state, stage: { ...state.stage, shimo: revealedShimo } };
+      const booResult = state.stage.kami.rank !== state.stage.shimo.rank ? 'correct' : 'incorrect';
+      return { ...state, stage: { ...state.stage, shimo: revealedShimo }, booResult };
     }
 
     case 'SPOTLIGHT_ENTER_BONUS': {
@@ -179,14 +180,18 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         };
       }
 
-      // ペア判定: 手札に同数字があるか
-      const playerAHand = state.players[0].hand;
-      const pairCardIndex = playerAHand.findIndex((c) => !c.isJoker && c.rank === openedCard.rank);
+      // ペア判定: boo 正解時は watcher(players[1])、不正解時は actor(players[0])の手札を使う
+      const booCorrect = state.booResult === 'correct';
+      const pairingPlayer = booCorrect ? state.players[1] : state.players[0];
+      const pairingHand = pairingPlayer.hand;
+      const pairCardIndex = pairingHand.findIndex((c) => !c.isJoker && c.rank === openedCard.rank);
       if (pairCardIndex !== -1) {
-        const pairCard = playerAHand[pairCardIndex];
-        const newHandA = removeCardAt(playerAHand, pairCardIndex);
-        const newPlayerA: Player = { ...state.players[0], hand: newHandA };
-        const players: [Player, Player] = [newPlayerA, state.players[1]];
+        const pairCard = pairingHand[pairCardIndex];
+        const newHand = removeCardAt(pairingHand, pairCardIndex);
+        const newPairingPlayer: Player = { ...pairingPlayer, hand: newHand };
+        const players: [Player, Player] = booCorrect
+          ? [state.players[0], newPairingPlayer]
+          : [newPairingPlayer, state.players[1]];
         return {
           ...state,
           deck: newDeck,

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -34,6 +34,7 @@ export const initialState: GameState = {
   playerBBooCnt: 0,
   round: 0,
   curtainCallReason: null,
+  booResult: null,
   spotlightCard: null,
   backstageRevealedCards: [],
   backstageResult: null,

--- a/src/lib/curtainCall.test.ts
+++ b/src/lib/curtainCall.test.ts
@@ -26,6 +26,7 @@ const baseState: GameState = {
   playerBBooCnt: 0,
   round: 1,
   curtainCallReason: null,
+  booResult: null,
   spotlightCard: null,
   backstageRevealedCards: [],
   backstageResult: null,

--- a/src/screens/BackstageScreen.test.tsx
+++ b/src/screens/BackstageScreen.test.tsx
@@ -42,9 +42,10 @@ function BackstageWrapper() {
   }
   if (state.phase === 'spotlight-bonus') {
     // ペア不成立のセットカードを探してクリック → backstage へ
-    const playerAHand = state.players[0].hand;
+    // boo 正解時は watcher(players[1])、不正解時は actor(players[0])の手札でペア判定
+    const pairingHand = state.booResult === 'correct' ? state.players[1].hand : state.players[0].hand;
     const noPairSetIndex = state.deck.findIndex(
-      (sc) => !sc.isJoker && !playerAHand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
+      (sc) => !sc.isJoker && !pairingHand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
     );
     if (noPairSetIndex === -1) {
       return <div data-testid="skip">no-pair-card-not-found</div>;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -53,6 +53,7 @@ export type GameState = {
   playerBBooCnt: number;
   round: number;
   curtainCallReason: CurtainCallReason | null;
+  booResult: 'correct' | 'incorrect' | null;
   spotlightCard: Card | null;
   backstageRevealedCards: Card[];
   backstageResult: BackstageResult | null;


### PR DESCRIPTION
## Summary

- **Issue #58**: `WATCH_BOO` でラウンド偶数時に `playerABooCnt` が加算されないコピペバグを修正
- **Issue #64**: `SPOTLIGHT_OPEN_SET` が boo 正解時も `players[0].hand` でペア判定していたバグを修正

## 変更内容

### Issue #58 修正
- `reducer.ts:WATCH_BOO`: `playerABooCnt: isPlayerA ? ... : state.playerABooCnt` → `state.playerABooCnt + 1`
- リグレッションテスト追加（round=2 WATCH_BOO → playerABooCnt +1）

### Issue #64 修正
- `GameState` に `booResult: 'correct' | 'incorrect' | null` フィールドを追加
- `SPOTLIGHT_REVEAL`: kami.rank ≠ shimo.rank → `booResult: 'correct'`、等しければ `'incorrect'` をセット
- `SPOTLIGHT_OPEN_SET`: `booResult === 'correct'` のとき `players[1].hand`（watcher）でペア判定
- リグレッションテスト2件追加（boo正解ペア成立 / boo正解でもA手札参照しない）

## Test plan

- [x] `npx vitest run` → 172 passed
- [x] Issue #58 round=2 WATCH_BOO playerABooCnt +1 確認
- [x] Issue #64 boo 正解時 players[1].hand でペア判定確認

Closes #58
Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)