### PR TITLE
feat: スコアリング計算（カミ合計・手札合計・ブーイングペナルティ）

### DIFF
--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { calculateScore } from './scoring';
+import type { Card, GameState } from '@/types/game';
+
+function makeCard(rank: number, isJoker = false): Card {
+  return { suit: 'spades', rank, isJoker, isFaceUp: false };
+}
+
+const baseState: GameState = {
+  phase: 'curtain-call',
+  players: [
+    { id: 'A', name: 'アリス', hand: [] },
+    { id: 'B', name: 'ボブ', hand: [] },
+  ],
+  stage: { kami: null, shimo: null },
+  deck: [],
+  backstage: [],
+  setRemainingCount: 0,
+  publicInfos: [],
+  playerABooCnt: 3,
+  playerBBooCnt: 3,
+  round: 1,
+  curtainCallReason: 'joker',
+  booResult: null,
+  spotlightCard: null,
+  backstageRevealedCards: [],
+  backstageResult: null,
+};
+
+describe('calculateScore', () => {
+  describe('カミ合計', () => {
+    it('stage.kami が null の場合は 0', () => {
+      const result = calculateScore({ ...baseState, stage: { kami: null, shimo: null } }, 'A');
+      expect(result.kamiTotal).toBe(0);
+    });
+
+    it('数字カードはランク値をそのまま使う（5 → 5）', () => {
+      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(5), isFaceUp: true }, shimo: null } };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(5);
+    });
+
+    it('A は 1', () => {
+      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(1), isFaceUp: true }, shimo: null } };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(1);
+    });
+
+    it('J は 11', () => {
+      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(11), isFaceUp: true }, shimo: null } };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(11);
+    });
+
+    it('Q は 12', () => {
+      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(12), isFaceUp: true }, shimo: null } };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(12);
+    });
+
+    it('K は 13', () => {
+      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(13), isFaceUp: true }, shimo: null } };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(13);
+    });
+
+    it('Joker は 0', () => {
+      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(0, true), isFaceUp: true }, shimo: null } };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(0);
+    });
+  });
+
+  describe('手札合計', () => {
+    it('手札が空の場合は 0', () => {
+      const result = calculateScore(baseState, 'A');
+      expect(result.handTotal).toBe(0);
+    });
+
+    it('手札の合計が正しい（3+7+10=20）', () => {
+      const state: GameState = {
+        ...baseState,
+        players: [
+          { id: 'A', name: 'A', hand: [makeCard(3), makeCard(7), makeCard(10)] },
+          { id: 'B', name: 'B', hand: [] },
+        ],
+      };
+      expect(calculateScore(state, 'A').handTotal).toBe(20);
+    });
+
+    it('プレイヤーが swap 後（players[0]=B の場合）でも id で正しく取得できる', () => {
+      const state: GameState = {
+        ...baseState,
+        players: [
+          { id: 'B', name: 'B', hand: [makeCard(5)] },
+          { id: 'A', name: 'A', hand: [makeCard(8)] },
+        ],
+      };
+      expect(calculateScore(state, 'A').handTotal).toBe(8);
+      expect(calculateScore(state, 'B').handTotal).toBe(5);
+    });
+  });
+
+  describe('ブーイングペナルティ', () => {
+    it('curtainCallReason が set-last-1 以外の場合はペナルティ 0', () => {
+      const state: GameState = { ...baseState, curtainCallReason: 'joker', playerABooCnt: 0 };
+      expect(calculateScore(state, 'A').penalty).toBe(0);
+    });
+
+    it('hand-shortage でもペナルティ 0', () => {
+      const state: GameState = { ...baseState, curtainCallReason: 'hand-shortage', playerABooCnt: 1 };
+      expect(calculateScore(state, 'A').penalty).toBe(0);
+    });
+
+    it('set-last-1 かつブーイング 3 回でペナルティ 0', () => {
+      const state: GameState = { ...baseState, curtainCallReason: 'set-last-1', playerABooCnt: 3 };
+      expect(calculateScore(state, 'A').penalty).toBe(0);
+    });
+
+    it('set-last-1 かつブーイング 2 回（不足 1 回）→ 15 マイナス', () => {
+      const state: GameState = { ...baseState, curtainCallReason: 'set-last-1', playerABooCnt: 2 };
+      expect(calculateScore(state, 'A').penalty).toBe(15);
+    });
+
+    it('set-last-1 かつブーイング 1 回（不足 2 回）→ 30 マイナス', () => {
+      const state: GameState = { ...baseState, curtainCallReason: 'set-last-1', playerABooCnt: 1 };
+      expect(calculateScore(state, 'A').penalty).toBe(30);
+    });
+
+    it('set-last-1 かつブーイング 0 回（不足 3 回）→ 45 マイナス', () => {
+      const state: GameState = { ...baseState, curtainCallReason: 'set-last-1', playerABooCnt: 0 };
+      expect(calculateScore(state, 'A').penalty).toBe(45);
+    });
+
+    it('プレイヤー B のペナルティも正しく計算される', () => {
+      const state: GameState = { ...baseState, curtainCallReason: 'set-last-1', playerBBooCnt: 1 };
+      expect(calculateScore(state, 'B').penalty).toBe(30);
+    });
+  });
+
+  describe('最終ポイント合計', () => {
+    it('カミ合計 - 手札合計 - ペナルティ の計算が正しい', () => {
+      const state: GameState = {
+        ...baseState,
+        stage: { kami: { ...makeCard(10), isFaceUp: true }, shimo: null },
+        players: [
+          { id: 'A', name: 'A', hand: [makeCard(3), makeCard(2)] }, // hand=5
+          { id: 'B', name: 'B', hand: [] },
+        ],
+        curtainCallReason: 'set-last-1',
+        playerABooCnt: 1, // 不足2回 → penalty=30
+      };
+      const result = calculateScore(state, 'A');
+      expect(result.kamiTotal).toBe(10);
+      expect(result.handTotal).toBe(5);
+      expect(result.penalty).toBe(30);
+      expect(result.total).toBe(-25); // 10 - 5 - 30
+    });
+
+    it('ペナルティなしの場合のトータル計算', () => {
+      const state: GameState = {
+        ...baseState,
+        stage: { kami: { ...makeCard(8), isFaceUp: true }, shimo: null },
+        players: [
+          { id: 'A', name: 'A', hand: [makeCard(3)] }, // hand=3
+          { id: 'B', name: 'B', hand: [] },
+        ],
+        curtainCallReason: 'joker',
+      };
+      const result = calculateScore(state, 'A');
+      expect(result.total).toBe(5); // 8 - 3 - 0
+    });
+  });
+});

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -1,0 +1,44 @@
+import type { Card, GameState } from '@/types/game';
+
+export type ScoreBreakdown = {
+  kamiTotal: number;
+  handTotal: number;
+  penalty: number;
+  total: number;
+};
+
+/** カードのポイント値を返す（A=1, 2-10=face value, J=11, Q=12, K=13, Joker=0） */
+function cardValue(card: Card): number {
+  return card.isJoker ? 0 : card.rank;
+}
+
+/**
+ * 指定プレイヤーのスコアを計算する。
+ *
+ * 計算式: 最終ポイント = カミ合計 - 手札合計 - ペナルティ
+ * - カミ合計: stage.kami のカード値
+ * - 手札合計: プレイヤーの残り手札のカード値合計
+ * - ペナルティ: curtainCallReason === 'set-last-1' の場合のみ適用
+ *   各プレイヤーのブーイング宣言が 3 回未満なら不足数 × 15 マイナス
+ */
+export function calculateScore(state: GameState, playerId: 'A' | 'B'): ScoreBreakdown {
+  const kamiTotal = state.stage.kami ? cardValue(state.stage.kami) : 0;
+
+  const player = state.players.find((p) => p.id === playerId);
+  const handTotal = player ? player.hand.reduce((sum, c) => sum + cardValue(c), 0) : 0;
+
+  let penalty = 0;
+  if (state.curtainCallReason === 'set-last-1') {
+    const booCount = playerId === 'A' ? state.playerABooCnt : state.playerBBooCnt;
+    if (booCount < 3) {
+      penalty = (3 - booCount) * 15;
+    }
+  }
+
+  return {
+    kamiTotal,
+    handTotal,
+    penalty,
+    total: kamiTotal - handTotal - penalty,
+  };
+}


### PR DESCRIPTION
## Summary
- `src/lib/scoring.ts` に `calculateScore(state, playerId)` 純関数を実装
- カミ合計（stage.kami のランク値）・手札合計・ブーイングペナルティを計算
- 最終ポイント = カミ合計 - 手札合計 - ペナルティ
- ペナルティは `curtainCallReason === 'set-last-1'` 時のみ適用（不足数×15）

## Test plan
- [ ] `src/lib/scoring.test.ts` 19テスト全通過確認済み
- [ ] 全テストスイート 191テスト通過確認済み
- [ ] TypeScript 型エラーなし

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)