### PR TITLE
feat: Result画面（スコアテーブル・勝者表示・もう一度）

### DIFF
--- a/src/screens/ResultScreen.module.css
+++ b/src/screens/ResultScreen.module.css
@@ -1,0 +1,98 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 40px 16px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--accent, #60a5fa);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.winnerText {
+  font-size: 20px;
+  font-weight: bold;
+  color: #facc15;
+  margin: 0;
+}
+
+.draw {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 360px;
+}
+
+.th {
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  text-align: center;
+  border-bottom: 1px solid #1e2d42;
+}
+
+.th.winnerCol {
+  color: #facc15;
+}
+
+.label {
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  text-align: left;
+}
+
+.td {
+  padding: 8px 12px;
+  font-size: 15px;
+  color: #fff;
+  text-align: center;
+}
+
+.total {
+  padding: 8px 12px;
+  font-size: 18px;
+  font-weight: bold;
+  color: #fff;
+  text-align: center;
+  border-top: 1px solid #1e2d42;
+}
+
+.winTotal {
+  color: #facc15;
+}
+
+.resetBtn {
+  padding: 12px 28px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+  border: 2px solid var(--accent, #60a5fa);
+  background: transparent;
+  color: var(--accent, #60a5fa);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.resetBtn:active {
+  background: rgba(96, 165, 250, 0.12);
+}

--- a/src/screens/ResultScreen.test.tsx
+++ b/src/screens/ResultScreen.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
+import ResultScreen from './ResultScreen';
+
+// INIT_GAME → CURTAIN_CALL まで進めるラッパー（プレイヤー名あり）
+function ResultWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return (
+      <button
+        onClick={() =>
+          dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })
+        }
+      >
+        init
+      </button>
+    );
+  }
+  if (state.phase !== 'curtain-call') {
+    return (
+      <button onClick={() => dispatch({ type: 'CURTAIN_CALL', reason: 'joker' })}>
+        curtain-call
+      </button>
+    );
+  }
+  return <ResultScreen />;
+}
+
+// CURTAIN_CALL を initialState から直接発火（両プレイヤーの手札空 → 引き分け確定）
+function DrawWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase !== 'curtain-call') {
+    return (
+      <button onClick={() => dispatch({ type: 'CURTAIN_CALL', reason: 'joker' })}>
+        curtain-call
+      </button>
+    );
+  }
+  return <ResultScreen />;
+}
+
+function renderResult() {
+  render(
+    <GameProvider>
+      <ResultWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+  fireEvent.click(screen.getByRole('button', { name: 'curtain-call' }));
+}
+
+function renderDraw() {
+  render(
+    <GameProvider>
+      <DrawWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'curtain-call' }));
+}
+
+describe('ResultScreen', () => {
+  it('カーテンコール見出しが表示される', () => {
+    renderResult();
+    expect(screen.getByText('カーテンコール')).toBeDefined();
+  });
+
+  it('両プレイヤー名が表示される', () => {
+    renderResult();
+    expect(screen.getAllByText('アリス').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('ボブ').length).toBeGreaterThan(0);
+  });
+
+  it('スコアテーブルのラベルが表示される', () => {
+    renderResult();
+    expect(screen.getByText('カミ合計')).toBeDefined();
+    expect(screen.getByText('手札合計')).toBeDefined();
+    expect(screen.getByText('ペナルティ')).toBeDefined();
+    expect(screen.getByText('最終ポイント')).toBeDefined();
+  });
+
+  it('勝者またはドローが表示される', () => {
+    renderResult();
+    const winner = screen.queryByText(/の勝利！/);
+    const draw = screen.queryByText('引き分け');
+    expect(winner !== null || draw !== null).toBe(true);
+  });
+
+  it('引き分けの場合「引き分け」が表示される', () => {
+    // 手札・stage.kami ともに初期値（空・null）→ 両者 total=0 → 引き分け
+    renderDraw();
+    expect(screen.getByText('引き分け')).toBeDefined();
+  });
+
+  it('「もう一度」ボタンが表示される', () => {
+    renderResult();
+    expect(screen.getByRole('button', { name: 'もう一度' })).toBeDefined();
+  });
+
+  it('「もう一度」でRESET_GAMEがdispatchされカーテンコール画面が非表示になる', () => {
+    renderResult();
+    fireEvent.click(screen.getByRole('button', { name: 'もう一度' }));
+    // RESET_GAME後はstandbyフェーズ → ResultScreenが非表示
+    expect(screen.queryByText('カーテンコール')).toBeNull();
+  });
+});

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -1,0 +1,80 @@
+import { useGameDispatch, useGameState } from '@/game/context';
+import { calculateScore } from '@/lib/scoring';
+import styles from './ResultScreen.module.css';
+
+export default function ResultScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+
+  const playerA = state.players.find((p) => p.id === 'A');
+  const playerB = state.players.find((p) => p.id === 'B');
+
+  const scoreA = calculateScore(state, 'A');
+  const scoreB = calculateScore(state, 'B');
+
+  const winner =
+    scoreA.total > scoreB.total ? 'A' : scoreB.total > scoreA.total ? 'B' : 'draw';
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>カーテンコール</h1>
+
+      <div className={styles.result}>
+        {winner === 'draw' ? (
+          <p className={styles.draw}>引き分け</p>
+        ) : (
+          <p className={styles.winnerText}>
+            {winner === 'A' ? playerA?.name : playerB?.name} の勝利！
+          </p>
+        )}
+      </div>
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.th}></th>
+            <th className={`${styles.th} ${winner === 'A' ? styles.winnerCol : ''}`}>
+              {playerA?.name ?? 'A'}
+            </th>
+            <th className={`${styles.th} ${winner === 'B' ? styles.winnerCol : ''}`}>
+              {playerB?.name ?? 'B'}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className={styles.label}>カミ合計</td>
+            <td className={styles.td}>{scoreA.kamiTotal}</td>
+            <td className={styles.td}>{scoreB.kamiTotal}</td>
+          </tr>
+          <tr>
+            <td className={styles.label}>手札合計</td>
+            <td className={styles.td}>-{scoreA.handTotal}</td>
+            <td className={styles.td}>-{scoreB.handTotal}</td>
+          </tr>
+          <tr>
+            <td className={styles.label}>ペナルティ</td>
+            <td className={styles.td}>-{scoreA.penalty}</td>
+            <td className={styles.td}>-{scoreB.penalty}</td>
+          </tr>
+          <tr>
+            <td className={styles.label}>最終ポイント</td>
+            <td className={`${styles.total} ${winner === 'A' ? styles.winTotal : ''}`}>
+              {scoreA.total}
+            </td>
+            <td className={`${styles.total} ${winner === 'B' ? styles.winTotal : ''}`}>
+              {scoreB.total}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <button
+        className={styles.resetBtn}
+        onClick={() => dispatch({ type: 'RESET_GAME' })}
+      >
+        もう一度
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `src/screens/ResultScreen.tsx` を新規実装
- `calculateScore` で両プレイヤーのカミ合計・手札合計・ペナルティ・最終ポイントを算出してテーブル表示
- 高スコアプレイヤーを勝者として強調表示（同点は「引き分け」）
- 「もう一度」ボタンで `RESET_GAME` → Title画面へ

## Test plan
- [ ] カーテンコール見出し・プレイヤー名・スコアラベル表示
- [ ] 引き分けケース（両手札空 → total=0同士）で「引き分け」表示
- [ ] 勝者またはドローが表示される
- [ ] 「もう一度」でRESET_GAME・ResultScreen非表示（7テスト追加、全198テストパス）

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)