### PR TITLE
feat: 公開情報トラッキング（Issue #36）

### DIFF
--- a/src/game/publicInfo.ts
+++ b/src/game/publicInfo.ts
@@ -1,0 +1,13 @@
+import type { Card, PublicInfo } from '@/types/game';
+
+export function buildPublicInfos(
+  existing: PublicInfo[],
+  cards: Card[],
+  playerId: string,
+  round: number,
+): PublicInfo[] {
+  return [
+    ...existing,
+    ...cards.map((card) => ({ playerId, card, round })),
+  ];
+}

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -474,6 +474,47 @@ describe('gameReducer', () => {
       expect(final.backstage).toHaveLength(backstageBefore - 1);
     });
 
+    it('BACKSTAGE_OPEN でペア成立時も publicInfos に3件記録される', () => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
+      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
+      const s7raw = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s7 = { ...s7raw, booResult: 'incorrect' as const };
+      const noPairSetIndex = s7.deck.findIndex(
+        (sc) => !sc.isJoker && !s7.players[0].hand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
+      );
+      if (noPairSetIndex === -1) return;
+      const backstageState = gameReducer(s7, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
+      if (backstageState.spotlightCard === null) return;
+
+      const { spotlightCard, backstage } = backstageState;
+      const pairIdx = backstage.findIndex((c) => !c.isJoker && c.rank === spotlightCard.rank);
+      if (pairIdx === -1) return;
+
+      const others = backstage.map((_, i) => i).filter((i) => i !== pairIdx).slice(0, 2);
+      const before = backstageState.publicInfos.length;
+      const result = gameReducer(backstageState, {
+        type: 'BACKSTAGE_OPEN',
+        cardIndices: [pairIdx, others[0], others[1]],
+      });
+      expect(result.backstageResult).toBe('match');
+      expect(result.publicInfos.length).toBe(before + 3);
+    });
+
+    it('BACKSTAGE_TAKE_HAND で取得したカードは publicInfos に含まれない', () => {
+      const state = buildBackstageState();
+      if (!state) return;
+      const resultState = gameReducer(state, { type: 'BACKSTAGE_OPEN', cardIndices: [0, 1, 2] });
+      if (resultState.backstageResult !== 'no-match') return;
+      const countBefore = resultState.publicInfos.length;
+      const final = gameReducer(resultState, { type: 'BACKSTAGE_TAKE_HAND', cardIndex: 0 });
+      // 手札に加えたカードで publicInfos は増えない
+      expect(final.publicInfos.length).toBe(countBefore);
+    });
+
     it('BACKSTAGE_PROCEED で backstage（スキップ経由）→ intermission', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -1,5 +1,6 @@
-import type { Card, CurtainCallReason, GamePhase, GameState, Player, PublicInfo, Stage } from '@/types/game';
+import type { Card, CurtainCallReason, GamePhase, GameState, Player, Stage } from '@/types/game';
 import { createDeck, createDeckWithJoker, deal, shuffle } from '@/lib/deck';
+import { buildPublicInfos } from './publicInfo';
 
 export type GameAction =
   | { type: 'INIT_GAME'; playerAName: string; playerBName: string }
@@ -224,10 +225,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
       const selectedCards = cardIndices.map((i) => state.backstage[i]) as [Card, Card, Card];
 
-      const newPublicInfos: PublicInfo[] = [
-        ...state.publicInfos,
-        ...selectedCards.map((c) => ({ playerId: state.players[0].id, card: c, round: state.round })),
-      ];
+      const newPublicInfos = buildPublicInfos(
+        state.publicInfos,
+        selectedCards,
+        state.players[0].id,
+        state.round,
+      );
 
       const spotlightCard = state.spotlightCard;
       const matchLocalIndex =


### PR DESCRIPTION
## 概要

Issue #36「公開情報トラッキング」の実装。

publicInfos の記録ロジックと InfoOverlay 表示は既に main に実装済みのため、
本 PR では Scope に明記された `publicInfo.ts` ヘルパー関数の実装と不足テストの追加を行う。

## 変更内容

- `src/game/publicInfo.ts` 新規作成：`buildPublicInfos` ヘルパー関数を実装
- `src/game/reducer.ts`：BACKSTAGE_OPEN でヘルパーを使用するようリファクタリング
- `src/game/reducer.test.ts`：以下のテストを追加
  - ペア成立時も publicInfos に3件記録される
  - BACKSTAGE_TAKE_HAND で取得したカードは publicInfos に含まれない

## AC チェック

- [x] バックステージ後に公開情報がGameStateに記録される
- [x] ペア成立・不成立両方で記録される（テスト追加）
- [x] InfoOverlayに公開情報（数字・スート）が表示される
- [x] 手札に加えた非公開カードは含まれない（テスト追加）
- [x] publicInfo更新のユニットテストが通る（200件全通過）

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)