### PR TITLE
[Bug] ルートページが空でゲームUIに到達できない修正（Issue #79）

### DIFF
--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -1,0 +1,46 @@
+import { useGameState } from '@/game/context';
+import ActionScreen from '@/screens/ActionScreen';
+import BackstageScreen from '@/screens/BackstageScreen';
+import IntermissionScreen from '@/screens/IntermissionScreen';
+import ResultScreen from '@/screens/ResultScreen';
+import ScoutScreen from '@/screens/ScoutScreen';
+import SpotlightBonusScreen from '@/screens/SpotlightBonusScreen';
+import SpotlightRevealScreen from '@/screens/SpotlightRevealScreen';
+import StandbyScreen from '@/screens/StandbyScreen';
+import TitleScreen from '@/screens/TitleScreen';
+import WatchScreen from '@/screens/WatchScreen';
+
+export default function GameRouter() {
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return <TitleScreen />;
+  }
+
+  switch (state.phase) {
+    case 'standby':
+      return <StandbyScreen />;
+    case 'scout':
+      return <ScoutScreen />;
+    case 'action':
+      return <ActionScreen />;
+    case 'watch':
+      return <WatchScreen />;
+    case 'spotlight':
+      return <SpotlightRevealScreen />;
+    case 'spotlight-bonus':
+      return <SpotlightBonusScreen />;
+    case 'backstage':
+    case 'backstage-result':
+      return <BackstageScreen />;
+    case 'intermission':
+      return <IntermissionScreen />;
+    case 'curtain-call':
+    case 'result':
+      return <ResultScreen />;
+    default: {
+      const _exhaustive: never = state.phase;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/home.test.tsx
+++ b/src/home.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Home from '@/pages/index';
+
+describe('Home', () => {
+  it('初期表示でタイトル画面が描画される', () => {
+    render(<Home />);
+
+    expect(screen.getByRole('heading', { name: 'CurtainCall' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'ゲームスタート' })).toBeDefined();
+  });
+
+  it('ゲーム開始後にスタンバイ画面へ遷移する', () => {
+    render(<Home />);
+
+    fireEvent.change(screen.getByLabelText('プレイヤーA'), { target: { value: 'アリス' } });
+    fireEvent.change(screen.getByLabelText('プレイヤーB'), { target: { value: 'ボブ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'ゲームスタート' }));
+
+    expect(screen.getByRole('heading', { name: 'カード配布完了' })).toBeDefined();
+    expect(screen.getByText('アリス の手札')).toBeDefined();
+    expect(screen.getByText('ボブ の手札')).toBeDefined();
+  });
+});

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,10 @@
+import GameRouter from '@/components/GameRouter';
+import { GameProvider } from '@/game/context';
+
 export default function Home() {
-  return <></>;
+  return (
+    <GameProvider>
+      <GameRouter />
+    </GameProvider>
+  );
 }


### PR DESCRIPTION
## 概要

`/` にアクセスしてもゲーム画面が描画されなかった問題を修正。

## 変更内容

- `src/pages/index.tsx`: 空実装（`<></>`）を `GameProvider + GameRouter` 構成に変更
- `src/components/GameRouter.tsx`: フェーズに応じた Screen コンポーネントを切り替えるルーターを新規追加
- `src/home.test.tsx`: `/` の初期表示・ゲーム開始後遷移のレンダリングテストを追加

## テスト計画

- [x] `npx vitest run` — 213件すべて通過
- [x] `npx eslint .` — エラーなし
- [x] `npx tsc --noEmit` — 型エラーなし
- [ ] `/` を開きタイトル画面が表示されることを手動確認
- [ ] プレイヤー名入力 → ゲームスタートでスタンバイ画面へ遷移することを手動確認

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)