### PR TITLE
[Bug] ステージ札累積とスコア計算を修正する（Issue #76）

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,17 +1,17 @@
 # .ai-context.md
 
 ## Status
-Issue #29（Phase 5 レビュー）実装完了、PR 作成待ち。Issue #58（WATCH_BOO バグ）は未修正。
+Issue #76（ステージ累積バグ修正）実装完了、PR 作成待ち。
 
 ## Active Issues
-- **#29: Phase 5 レビュー・Sign-off** ← feature/issue-29 ブランチ、PR 未作成
-- **#58: WATCH_BOO バグ修正** ← レビューで発見したバグ（未対応）
-- **#64: SPOTLIGHT_OPEN_SET hand参照バグ** ← Issue #29 レビューで発見。boo正解時にplayers[1].handを参照すべき
+- Issue #76: ステージ札累積・最終スコア修正 → feature/issue-76 にて実装済み・PR作成待ち
 
 ## In-Progress PRs
-- （なし）
+- なし
 
 ## Completed
+- Issue #79: ルートページ空バグ修正（PR #90 マージ済み）
+- Issue #38: Phase 8 レビュー（PR #75 マージ済み）
 - Issue #1: Next.js + TypeScript 初期化（main push）
 - Issue #2: ESLint + Vitest 設定（PR#39 マージ済み）
 - Issue #3: Phase 0 レビュー・Sign-off（クローズ済み）
@@ -35,6 +35,18 @@ Issue #29（Phase 5 レビュー）実装完了、PR 作成待ち。Issue #58（
 - Issue #26: Spotlight Reveal（PR#60 マージ済み）
 - Issue #27: Spotlight ボーナス（PR#61 マージ済み）
 - Issue #28: Backstage フェーズ（PR#62 マージ済み）
+- Issue #29: Phase 5 レビュー・Sign-off（PR#63/66 マージ済み）
+- Issue #30: IntermissionScreen（PR#65 マージ済み）
+- Issue #31: カーテンコール条件検出（PR#67 マージ済み）
+- Issue #32: Phase 6 レビュー・Sign-off（PR#68 マージ済み）
+- Issue #58: WATCH_BOO playerABooCnt コピペバグ修正（PR#69 マージ済み）
+- Issue #64: SPOTLIGHT_OPEN_SET hand参照バグ修正（PR#69 マージ済み）
+- Issue #33: スコアリング計算（PR#70 マージ済み）
+- Issue #34: Result画面（PR#71 マージ済み）
+- Issue #35: Phase 7 sign-off（PR#72 マージ済み）
+- Issue #36: 公開情報トラッキング（PR#73 マージ済み）
+- Issue #37: カードアニメーション（PR#74 マージ済み）
+- Issue #38: Phase 8 レビュー（PR#75 マージ待ち）
 
 ## Decisions
 - フレームワーク: Next.js 16.1.6 + TypeScript (Pages Router, App Router 不使用)
@@ -60,17 +72,10 @@ Issue #29（Phase 5 レビュー）実装完了、PR 作成待ち。Issue #58（
   - spotlightCard: SPOTLIGHT_OPEN_SET no-pair 時にセット、backstage 比較に使用
 
 ## Next actions
-1. Issue #29 の PR を作成して main へマージ
-2. Issue #58（WATCH_BOO バグ修正）対応
-3. Issue #30 以降へ
+1. Issue #76 PR 作成・マージ
+2. 次は Issue #78（偶数ラウンド次スカウト判定バグ）または Issue #80（バックステージ担当者バグ）
 
 ## Known pitfalls
-- WATCH_BOO reducer（reducer.ts:129）: `playerABooCnt` のコピペバグあり → Issue #58 で追跡中
-  - ラウンド偶数時（Aがウォッチャー）に playerABooCnt が加算されない
-- SPOTLIGHT_OPEN_SET（reducer.ts:183）: 常に `players[0].hand` 参照 → Issue #64 で追跡中
-  - boo 正解時は `players[1].hand`（watcher の手札）でペア判定すべき
-
-
 - `create-next-app` はディレクトリ名を npm package name に使う。大文字NG → `/tmp` 等で生成して移動する
 - ESLint v9 は `.eslintrc.*` 非対応。フラットコンフィグ（`eslint.config.mjs`）を使うこと
 - Vitest は tsconfig の `paths` を自動解決しない。`vitest.config.ts` に `resolve.alias` を明示すること

--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -16,6 +16,8 @@ const baseState: GameState = {
   publicInfos: [],
   playerABooCnt: 1,
   playerBBooCnt: 2,
+  playerAKami: [],
+  playerBKami: [],
   round: 1,
   curtainCallReason: null,
   booResult: null,

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -305,6 +305,8 @@ describe('gameReducer', () => {
           publicInfos: [],
           playerABooCnt: 0,
           playerBBooCnt: 0,
+          playerAKami: [],
+          playerBKami: [],
           round: 1,
           curtainCallReason: null,
           spotlightCard: null,
@@ -332,6 +334,8 @@ describe('gameReducer', () => {
           publicInfos: [],
           playerABooCnt: 0,
           playerBBooCnt: 0,
+          playerAKami: [],
+          playerBKami: [],
           round: 1,
           curtainCallReason: null,
           spotlightCard: null,
@@ -630,6 +634,203 @@ describe('gameReducer', () => {
     it('standby フェーズで WATCH_CLAP を dispatch しても state が変わらない', () => {
       const result = gameReducer(initialState, { type: 'WATCH_CLAP' });
       expect(result).toBe(initialState);
+    });
+  });
+
+  describe('ステージ累積（Issue #76）', () => {
+    const mk = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+
+    // watch フェーズまで進めるヘルパー（round=1: players[0]=A がアクター）
+    function buildWatchState(kamiRank: number, shimoRank: number): GameState {
+      const kamiCard = mk(kamiRank);
+      const shimoCard = mk(shimoRank);
+      return {
+        phase: 'watch',
+        players: [
+          { id: 'A', name: 'A', hand: [kamiCard, shimoCard] },
+          { id: 'B', name: 'B', hand: [mk(3), mk(7)] },
+        ],
+        stage: { kami: { ...kamiCard, isFaceUp: true }, shimo: { ...shimoCard, isFaceUp: false } },
+        deck: [mk(2), mk(4), mk(6), mk(8), mk(10)],
+        backstage: [mk(2), mk(4), mk(6), mk(8), mk(10)],
+        setRemainingCount: 5,
+        publicInfos: [],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        round: 1,
+        curtainCallReason: null,
+        booResult: null,
+        spotlightCard: null,
+        backstageRevealedCards: [],
+        backstageResult: null,
+      };
+    }
+
+    describe('WATCH_CLAP: アクターのカミが playerAKami に追加される', () => {
+      it('round=1 (players[0].id=A) の CLAP で playerAKami に stage.kami が追加される', () => {
+        const watchState = buildWatchState(5, 9);
+        const result = gameReducer(watchState, { type: 'WATCH_CLAP' });
+        expect(result.playerAKami).toHaveLength(1);
+        expect(result.playerAKami[0].rank).toBe(5);
+      });
+
+      it('players[0].id=B の CLAP で playerBKami に stage.kami が追加される', () => {
+        const watchState: GameState = {
+          ...buildWatchState(7, 3),
+          players: [
+            { id: 'B', name: 'B', hand: [mk(7), mk(3)] },
+            { id: 'A', name: 'A', hand: [mk(2), mk(8)] },
+          ],
+        };
+        const result = gameReducer(watchState, { type: 'WATCH_CLAP' });
+        expect(result.playerBKami).toHaveLength(1);
+        expect(result.playerBKami[0].rank).toBe(7);
+        expect(result.playerAKami).toHaveLength(0);
+      });
+
+      it('CLAP を複数回重ねても playerAKami が累積される', () => {
+        const watchState1 = buildWatchState(5, 9);
+        const afterClap1 = gameReducer(watchState1, { type: 'WATCH_CLAP' });
+        // 2ラウンド目: 手動でステージを設定して再度CLAP
+        const watchState2: GameState = {
+          ...afterClap1,
+          phase: 'watch',
+          stage: { kami: { ...mk(10), isFaceUp: true }, shimo: { ...mk(3), isFaceUp: false } },
+        };
+        const result = gameReducer(watchState2, { type: 'WATCH_CLAP' });
+        expect(result.playerAKami).toHaveLength(2);
+        expect(result.playerAKami[0].rank).toBe(5);
+        expect(result.playerAKami[1].rank).toBe(10);
+      });
+    });
+
+    describe('SPOTLIGHT_REVEAL: booResult に応じてカミが累積される', () => {
+      it('boo 正解（kami !== shimo）: watcher=players[1].id=B の playerBKami に追加される', () => {
+        // kami と shimo のランクが異なる → booResult='correct'
+        const spotlightState: GameState = {
+          ...buildWatchState(5, 9),
+          phase: 'spotlight',
+        };
+        const result = gameReducer(spotlightState, { type: 'SPOTLIGHT_REVEAL' });
+        expect(result.booResult).toBe('correct');
+        expect(result.playerBKami).toHaveLength(1);
+        expect(result.playerBKami[0].rank).toBe(5);
+        expect(result.playerAKami).toHaveLength(0);
+      });
+
+      it('boo 不正解（kami === shimo）: actor=players[0].id=A の playerAKami に追加される', () => {
+        // kami と shimo のランクが同じ → booResult='incorrect'
+        const spotlightState: GameState = {
+          ...buildWatchState(5, 5),
+          phase: 'spotlight',
+        };
+        const result = gameReducer(spotlightState, { type: 'SPOTLIGHT_REVEAL' });
+        expect(result.booResult).toBe('incorrect');
+        expect(result.playerAKami).toHaveLength(1);
+        expect(result.playerAKami[0].rank).toBe(5);
+        expect(result.playerBKami).toHaveLength(0);
+      });
+    });
+
+    describe('SPOTLIGHT_OPEN_SET: ペア成立時にセットのカミが累積される', () => {
+      it('boo 不正解パス: ペア成立時に openedCard が playerAKami に追加される', () => {
+        // boo incorrect: actor=A がセット開示、ペア成立 → A がカミを得る
+        const bonusState: GameState = {
+          phase: 'spotlight-bonus',
+          booResult: 'incorrect',
+          players: [
+            { id: 'A', name: 'A', hand: [mk(6), mk(7)] },  // rank=5 なし → pair card は手札にない
+            { id: 'B', name: 'B', hand: [mk(5), mk(9)] },
+          ],
+          stage: { kami: { ...mk(3), isFaceUp: true }, shimo: { ...mk(3), isFaceUp: true } },
+          deck: [mk(6), mk(11), mk(8)],
+          backstage: [],
+          setRemainingCount: 3,
+          publicInfos: [],
+          playerABooCnt: 0,
+          playerBBooCnt: 0,
+          playerAKami: [mk(3)], // 既に1枚蓄積済み（SPOTLIGHT_REVEAL で追加済み想定）
+          playerBKami: [],
+          round: 1,
+          curtainCallReason: null,
+          spotlightCard: null,
+          backstageRevealedCards: [],
+          backstageResult: null,
+        };
+        // deck[0]=rank6, players[0].hand にrank6あり → ペア成立
+        const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
+        expect(result.phase).toBe('intermission');
+        // playerAKami が1枚増えて合計2枚になる（元の1枚 + 新しいrank6）
+        expect(result.playerAKami).toHaveLength(2);
+        expect(result.playerAKami[1].rank).toBe(6);
+      });
+
+      it('boo 正解パス: ペア成立時に openedCard が playerBKami に追加される', () => {
+        const bonusState: GameState = {
+          phase: 'spotlight-bonus',
+          booResult: 'correct',
+          players: [
+            { id: 'A', name: 'A', hand: [mk(3), mk(7)] },
+            { id: 'B', name: 'B', hand: [mk(5), mk(9)] },  // rank=5 あり → ペア成立
+          ],
+          stage: { kami: { ...mk(4), isFaceUp: true }, shimo: { ...mk(6), isFaceUp: true } },
+          deck: [mk(5), mk(11), mk(8)],
+          backstage: [],
+          setRemainingCount: 3,
+          publicInfos: [],
+          playerABooCnt: 0,
+          playerBBooCnt: 0,
+          playerAKami: [],
+          playerBKami: [mk(4)], // 既に1枚蓄積済み（SPOTLIGHT_REVEAL で追加済み想定）
+          round: 1,
+          curtainCallReason: null,
+          spotlightCard: null,
+          backstageRevealedCards: [],
+          backstageResult: null,
+        };
+        // deck[0]=rank5, players[1].hand にrank5あり → ペア成立
+        const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
+        expect(result.phase).toBe('intermission');
+        // playerBKami が1枚増えて合計2枚
+        expect(result.playerBKami).toHaveLength(2);
+        expect(result.playerBKami[1].rank).toBe(5);
+      });
+    });
+
+    describe('BACKSTAGE_OPEN: ペア成立時に spotlightCard が行動プレイヤーのカミに追加される', () => {
+      it('ペア成立時に spotlightCard が players[0].id のカミ配列に追加される', () => {
+        const spotlightCard = mk(7);
+        const matchCard = mk(7);
+        const backstageState: GameState = {
+          phase: 'backstage',
+          booResult: 'incorrect',
+          players: [
+            { id: 'A', name: 'A', hand: [mk(3)] },
+            { id: 'B', name: 'B', hand: [mk(2)] },
+          ],
+          stage: { kami: { ...mk(5), isFaceUp: true }, shimo: { ...mk(5), isFaceUp: true } },
+          deck: [],
+          backstage: [matchCard, mk(2), mk(9)],
+          setRemainingCount: 0,
+          publicInfos: [],
+          playerABooCnt: 0,
+          playerBBooCnt: 0,
+          playerAKami: [mk(5)], // SPOTLIGHT_REVEAL で蓄積済み
+          playerBKami: [],
+          round: 1,
+          curtainCallReason: null,
+          spotlightCard,
+          backstageRevealedCards: [],
+          backstageResult: null,
+        };
+        const result = gameReducer(backstageState, { type: 'BACKSTAGE_OPEN', cardIndices: [0, 1, 2] });
+        expect(result.backstageResult).toBe('match');
+        // playerAKami に spotlightCard (rank=7) が追加される
+        expect(result.playerAKami).toHaveLength(2);
+        expect(result.playerAKami[1].rank).toBe(7);
+      });
     });
   });
 });

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -33,6 +33,8 @@ export const initialState: GameState = {
   publicInfos: [],
   playerABooCnt: 0,
   playerBBooCnt: 0,
+  playerAKami: [],
+  playerBKami: [],
   round: 0,
   curtainCallReason: null,
   booResult: null,

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -47,6 +47,13 @@ function removeCardAt(cards: Card[], index: number): Card[] {
   return [...cards.slice(0, index), ...cards.slice(index + 1)];
 }
 
+function addKamiToPlayer(state: GameState, playerId: string, card: Card): GameState {
+  if (playerId === 'A') {
+    return { ...state, playerAKami: [...state.playerAKami, card] };
+  }
+  return { ...state, playerBKami: [...state.playerBKami, card] };
+}
+
 export function gameReducer(state: GameState, action: GameAction): GameState {
   switch (action.type) {
     case 'INIT_GAME': {
@@ -127,7 +134,10 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
     case 'WATCH_CLAP': {
       if (state.phase !== 'watch') return state;
-      return { ...state, phase: 'intermission' };
+      const actorId = state.players[0].id;
+      const kamiCard = state.stage.kami;
+      const nextState = { ...state, phase: 'intermission' as const };
+      return kamiCard ? addKamiToPlayer(nextState, actorId, kamiCard) : nextState;
     }
 
     case 'WATCH_BOO': {
@@ -145,8 +155,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       if (state.phase !== 'spotlight') return state;
       if (state.stage.shimo === null || state.stage.kami === null) return state;
       const revealedShimo: Card = { ...state.stage.shimo, isFaceUp: true };
-      const booResult = state.stage.kami.rank !== state.stage.shimo.rank ? 'correct' : 'incorrect';
-      return { ...state, stage: { ...state.stage, shimo: revealedShimo }, booResult };
+      const booResult: 'correct' | 'incorrect' =
+        state.stage.kami.rank !== state.stage.shimo.rank ? 'correct' : 'incorrect';
+      // ブーイング正解: watcher(players[1])がカミを獲得、不正解: actor(players[0])が保持
+      const winnerId = booResult === 'correct' ? state.players[1].id : state.players[0].id;
+      const nextState = { ...state, stage: { ...state.stage, shimo: revealedShimo }, booResult };
+      return addKamiToPlayer(nextState, winnerId, state.stage.kami);
     }
 
     case 'SPOTLIGHT_ENTER_BONUS': {
@@ -195,14 +209,17 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         const players: [Player, Player] = booCorrect
           ? [state.players[0], newPairingPlayer]
           : [newPairingPlayer, state.players[1]];
-        return {
+        // ペア成立: セットカード(kami)を勝者のカミ配列に追加
+        const winnerId = booCorrect ? state.players[1].id : state.players[0].id;
+        const pairState = {
           ...state,
           deck: newDeck,
           setRemainingCount: newSetRemainingCount,
           stage: { kami: { ...openedCard }, shimo: { ...pairCard, isFaceUp: true } },
           players,
-          phase: 'intermission',
+          phase: 'intermission' as const,
         };
+        return addKamiToPlayer(pairState, winnerId, openedCard);
       }
 
       return {
@@ -248,15 +265,18 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
           kami: { ...spotlightCard!, isFaceUp: true },
           shimo: { ...matchedCard, isFaceUp: true },
         };
-        return {
+        // ペア成立: spotlightCard を行動プレイヤー(players[0])のカミ配列に追加
+        const backstagePlayerId = state.players[0].id;
+        const matchState = {
           ...state,
           backstage: newBackstage,
           publicInfos: newPublicInfos,
           stage,
           backstageRevealedCards: selectedCards,
-          backstageResult: 'match',
-          phase: 'backstage-result',
+          backstageResult: 'match' as const,
+          phase: 'backstage-result' as const,
         };
+        return addKamiToPlayer(matchState, backstagePlayerId, spotlightCard!);
       }
 
       return {

--- a/src/lib/curtainCall.test.ts
+++ b/src/lib/curtainCall.test.ts
@@ -24,6 +24,8 @@ const baseState: GameState = {
   publicInfos: [],
   playerABooCnt: 0,
   playerBBooCnt: 0,
+  playerAKami: [],
+  playerBKami: [],
   round: 1,
   curtainCallReason: null,
   booResult: null,

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -31,38 +31,38 @@ const baseState: GameState = {
 
 describe('calculateScore', () => {
   describe('カミ合計', () => {
-    it('stage.kami が null の場合は 0', () => {
-      const result = calculateScore({ ...baseState, stage: { kami: null, shimo: null } }, 'A');
+    it('playerAKami が空の場合は 0', () => {
+      const result = calculateScore({ ...baseState, playerAKami: [] }, 'A');
       expect(result.kamiTotal).toBe(0);
     });
 
     it('数字カードはランク値をそのまま使う（5 → 5）', () => {
-      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(5), isFaceUp: true }, shimo: null } };
+      const state: GameState = { ...baseState, playerAKami: [makeCard(5)] };
       expect(calculateScore(state, 'A').kamiTotal).toBe(5);
     });
 
     it('A は 1', () => {
-      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(1), isFaceUp: true }, shimo: null } };
+      const state: GameState = { ...baseState, playerAKami: [makeCard(1)] };
       expect(calculateScore(state, 'A').kamiTotal).toBe(1);
     });
 
     it('J は 11', () => {
-      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(11), isFaceUp: true }, shimo: null } };
+      const state: GameState = { ...baseState, playerAKami: [makeCard(11)] };
       expect(calculateScore(state, 'A').kamiTotal).toBe(11);
     });
 
     it('Q は 12', () => {
-      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(12), isFaceUp: true }, shimo: null } };
+      const state: GameState = { ...baseState, playerAKami: [makeCard(12)] };
       expect(calculateScore(state, 'A').kamiTotal).toBe(12);
     });
 
     it('K は 13', () => {
-      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(13), isFaceUp: true }, shimo: null } };
+      const state: GameState = { ...baseState, playerAKami: [makeCard(13)] };
       expect(calculateScore(state, 'A').kamiTotal).toBe(13);
     });
 
     it('Joker は 0', () => {
-      const state: GameState = { ...baseState, stage: { kami: { ...makeCard(0, true), isFaceUp: true }, shimo: null } };
+      const state: GameState = { ...baseState, playerAKami: [makeCard(0, true)] };
       expect(calculateScore(state, 'A').kamiTotal).toBe(0);
     });
   });
@@ -138,7 +138,7 @@ describe('calculateScore', () => {
     it('カミ合計 - 手札合計 - ペナルティ の計算が正しい', () => {
       const state: GameState = {
         ...baseState,
-        stage: { kami: { ...makeCard(10), isFaceUp: true }, shimo: null },
+        playerAKami: [makeCard(10)],
         players: [
           { id: 'A', name: 'A', hand: [makeCard(3), makeCard(2)] }, // hand=5
           { id: 'B', name: 'B', hand: [] },
@@ -156,7 +156,7 @@ describe('calculateScore', () => {
     it('ペナルティなしの場合のトータル計算', () => {
       const state: GameState = {
         ...baseState,
-        stage: { kami: { ...makeCard(8), isFaceUp: true }, shimo: null },
+        playerAKami: [makeCard(8)],
         players: [
           { id: 'A', name: 'A', hand: [makeCard(3)] }, // hand=3
           { id: 'B', name: 'B', hand: [] },

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -19,6 +19,8 @@ const baseState: GameState = {
   publicInfos: [],
   playerABooCnt: 3,
   playerBBooCnt: 3,
+  playerAKami: [],
+  playerBKami: [],
   round: 1,
   curtainCallReason: 'joker',
   booResult: null,
@@ -163,6 +165,54 @@ describe('calculateScore', () => {
       };
       const result = calculateScore(state, 'A');
       expect(result.total).toBe(5); // 8 - 3 - 0
+    });
+  });
+
+  describe('累積カミ配列によるスコア計算（Issue #76）', () => {
+    it('playerAKami が複数枚の場合、合計が kamiTotal になる', () => {
+      const state: GameState = {
+        ...baseState,
+        playerAKami: [makeCard(5), makeCard(10), makeCard(3)],
+        playerBKami: [],
+      };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(18); // 5+10+3
+    });
+
+    it('playerBKami が複数枚の場合、合計が kamiTotal になる', () => {
+      const state: GameState = {
+        ...baseState,
+        playerAKami: [],
+        playerBKami: [makeCard(7), makeCard(13)],
+      };
+      expect(calculateScore(state, 'B').kamiTotal).toBe(20); // 7+13
+    });
+
+    it('playerAKami が空の場合、kamiTotal は 0（stage.kami は無視される）', () => {
+      const state: GameState = {
+        ...baseState,
+        stage: { kami: { ...makeCard(9), isFaceUp: true }, shimo: null },
+        playerAKami: [],
+      };
+      // stage.kami ではなく playerAKami を参照するため 0 になる
+      expect(calculateScore(state, 'A').kamiTotal).toBe(0);
+    });
+
+    it('Joker を含む playerAKami の場合、Joker は 0 として合算される', () => {
+      const state: GameState = {
+        ...baseState,
+        playerAKami: [makeCard(5), makeCard(0, true)], // Joker=0
+      };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(5);
+    });
+
+    it('A と B の kamiTotal が互いに独立している', () => {
+      const state: GameState = {
+        ...baseState,
+        playerAKami: [makeCard(8)],
+        playerBKami: [makeCard(12), makeCard(3)],
+      };
+      expect(calculateScore(state, 'A').kamiTotal).toBe(8);
+      expect(calculateScore(state, 'B').kamiTotal).toBe(15);
     });
   });
 });

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -16,13 +16,14 @@ function cardValue(card: Card): number {
  * 指定プレイヤーのスコアを計算する。
  *
  * 計算式: 最終ポイント = カミ合計 - 手札合計 - ペナルティ
- * - カミ合計: stage.kami のカード値
+ * - カミ合計: playerAKami / playerBKami に累積されたカード値の合計
  * - 手札合計: プレイヤーの残り手札のカード値合計
  * - ペナルティ: curtainCallReason === 'set-last-1' の場合のみ適用
  *   各プレイヤーのブーイング宣言が 3 回未満なら不足数 × 15 マイナス
  */
 export function calculateScore(state: GameState, playerId: 'A' | 'B'): ScoreBreakdown {
-  const kamiTotal = state.stage.kami ? cardValue(state.stage.kami) : 0;
+  const kamiCards = playerId === 'A' ? state.playerAKami : state.playerBKami;
+  const kamiTotal = kamiCards.reduce((sum, c) => sum + cardValue(c), 0);
 
   const player = state.players.find((p) => p.id === playerId);
   const handTotal = player ? player.hand.reduce((sum, c) => sum + cardValue(c), 0) : 0;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -51,6 +51,8 @@ export type GameState = {
   publicInfos: PublicInfo[];
   playerABooCnt: number;
   playerBBooCnt: number;
+  playerAKami: Card[]; // プレイヤーAステージに蓄積されたカミ札
+  playerBKami: Card[]; // プレイヤーBステージに蓄積されたカミ札
   round: number;
   curtainCallReason: CurtainCallReason | null;
   booResult: 'correct' | 'incorrect' | null;


### PR DESCRIPTION
## Summary

- `GameState` に `playerAKami: Card[]` / `playerBKami: Card[]` を追加し、各プレイヤーのカミ札を累積管理するよう再設計
- `WATCH_CLAP` / `SPOTLIGHT_REVEAL` / `SPOTLIGHT_OPEN_SET`（ペア）/ `BACKSTAGE_OPEN`（ペア）で適切にカミ札を各プレイヤーの配列に追加
- `calculateScore` を `stage.kami`（単一）から `playerAKami`/`playerBKami` 配列の合計に変更
- 画面コンポーネント（`WatchScreen`・`SpotlightRevealScreen`）は現在ラウンドの提示ペア表示に引き続き `stage` を使用（変更不要）

Closes #76

## Test plan

- [ ] `npx vitest run` → 226件すべてpass
- [ ] `npm run build` → ビルド成功
- [ ] WATCH_CLAP 後、reducer の `playerAKami` にカミ札が追加されることをテストで確認済み
- [ ] boo 正解・不正解それぞれで正しいプレイヤーにカミが蓄積されることをテストで確認済み
- [ ] 複数ラウンドにわたるカミ累積と最終スコア算出をテストで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)