### PR TITLE
[Bug] 偶数ラウンドの次スカウト手札不足判定を修正する（Issue #78）

### DIFF
--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -590,6 +590,37 @@ describe('gameReducer', () => {
       expect(result.curtainCallReason).toBe('hand-shortage');
     });
 
+    it('偶数ラウンドでも次スカウトは players[1] であり players[0] の手札不足では curtain-call にならない', () => {
+      const base = buildIntermissionState();
+      // round=2 相当: players[0] が手札 0 枚、players[1] は手札あり
+      // 次のスカウトは常に players[1] なので hand-shortage にならないはず
+      const stateRound2 = {
+        ...base,
+        round: 2,
+        players: [
+          { ...base.players[0], hand: [] },
+          { ...base.players[1] },
+        ] as typeof base.players,
+      };
+      const result = gameReducer(stateRound2, { type: 'INTERMISSION' });
+      expect(result.phase).toBe('scout');
+    });
+
+    it('偶数ラウンドで players[1] の手札が 0 枚のとき curtain-call に遷移する', () => {
+      const base = buildIntermissionState();
+      const stateRound2Empty = {
+        ...base,
+        round: 2,
+        players: [
+          { ...base.players[0] },
+          { ...base.players[1], hand: [] },
+        ] as typeof base.players,
+      };
+      const result = gameReducer(stateRound2Empty, { type: 'INTERMISSION' });
+      expect(result.phase).toBe('curtain-call');
+      expect(result.curtainCallReason).toBe('hand-shortage');
+    });
+
     it('intermission 以外のフェーズでは INTERMISSION が無効', () => {
       const result = gameReducer(initialState, { type: 'INTERMISSION' });
       expect(result).toBe(initialState);

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -324,12 +324,9 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     case 'INTERMISSION': {
       if (state.phase !== 'intermission') return state;
 
-      // 手札不足チェック：次のスカウト担当（ラウンド偶数でBがスカウト）の手札0枚
-      const nextScoutIsA = state.round % 2 === 0;
-      const nextScoutHand = nextScoutIsA
-        ? state.players[0].hand
-        : state.players[1].hand;
-      const otherHand = nextScoutIsA ? state.players[1].hand : state.players[0].hand;
+      // 手札不足チェック：players 配列はラウンドごとに入れ替わるため、次のスカウトは常に players[1]
+      const nextScoutHand = state.players[1].hand;
+      const otherHand = state.players[0].hand;
 
       if (nextScoutHand.length === 0 || (nextScoutHand.length === 1 && otherHand.length === 0)) {
         return { ...state, phase: 'curtain-call', curtainCallReason: 'hand-shortage' };

--- a/src/lib/curtainCall.test.ts
+++ b/src/lib/curtainCall.test.ts
@@ -123,12 +123,22 @@ describe('checkCurtainCall', () => {
       expect(checkCurtainCall(state)).toBeNull();
     });
 
-    it('ラウンド偶数時は players[0] が次スカウトとして判定される', () => {
-      // round=2 → nextScoutIsA = (2 % 2 === 0) = true → nextScout = players[0]
+    it('ラウンド偶数でも次スカウトは players[1] であり players[0] の手札不足では hand-shortage にならない', () => {
+      // round=2: players[0] = 現在のスカウト → 次のスカウトは players[1]
+      // players[0] が 0 枚でも players[1] が 5 枚あれば継続できる
       const state: GameState = {
         ...baseState,
         round: 2,
         players: [makePlayer('A', 0), makePlayer('B', 5)],
+      };
+      expect(checkCurtainCall(state)).toBeNull();
+    });
+
+    it('偶数ラウンドで players[1] の手札が 0 枚のとき hand-shortage を返す', () => {
+      const state: GameState = {
+        ...baseState,
+        round: 2,
+        players: [makePlayer('A', 5), makePlayer('B', 0)],
       };
       expect(checkCurtainCall(state)).toBe('hand-shortage');
     });

--- a/src/lib/curtainCall.ts
+++ b/src/lib/curtainCall.ts
@@ -17,10 +17,9 @@ export function checkCurtainCall(state: GameState): CurtainCallReason | null {
   if (state.setRemainingCount <= 1 && state.deck.length > 0) return 'set-last-1';
 
   // 条件③: 手札不足（次のスカウト担当の手札が続行不可）
-  // round が奇数: players[0] がスカウト担当 → 次は players[1]（= round 偶数で A）
-  const nextScoutIsA = state.round % 2 === 0;
-  const nextScoutHand = nextScoutIsA ? state.players[0].hand : state.players[1].hand;
-  const otherHand = nextScoutIsA ? state.players[1].hand : state.players[0].hand;
+  // players 配列はラウンドごとに入れ替わるため、次のスカウトは常に現在の players[1]
+  const nextScoutHand = state.players[1].hand;
+  const otherHand = state.players[0].hand;
   if (nextScoutHand.length === 0 || (nextScoutHand.length === 1 && otherHand.length === 0)) {
     return 'hand-shortage';
   }


### PR DESCRIPTION
## 概要

`INTERMISSION` と `checkCurtainCall` において、偶数ラウンドで次スカウトの手札不足判定対象が逆になるバグを修正する。

Closes #78

## 原因

`players` 配列はラウンドごとに入れ替わる（`players[0]` = 現ラウンドのスカウト）にもかかわらず、`round % 2 === 0` で A/B の固定 ID を前提にした判定をしていた。偶数ラウンドでは判定対象が逆転していた。

## 修正内容

次のスカウトは配列の入れ替わりに関係なく **常に現在の `players[1]`** として判定するよう変更。

```ts
// Before
const nextScoutIsA = state.round % 2 === 0;
const nextScoutHand = nextScoutIsA ? state.players[0].hand : state.players[1].hand;

// After
const nextScoutHand = state.players[1].hand;
```

## テスト

- 偶数ラウンドで `players[0]` が手札 0 枚でも継続できることを検証
- 偶数ラウンドで `players[1]` が手札 0 枚のとき `curtain-call` になることを検証
- 全 229 テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)