### PR TITLE
[Bug] バックステージ担当者が常に players[0] として処理される (#80)

### DIFF
--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -24,6 +24,7 @@ const baseState: GameState = {
   spotlightCard: null,
   backstageRevealedCards: [],
   backstageResult: null,
+  backstagePlayerId: null,
 };
 
 describe('InfoOverlay', () => {

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -465,9 +465,11 @@ describe('gameReducer', () => {
       if (!state) return;
       const resultState = gameReducer(state, { type: 'BACKSTAGE_OPEN', cardIndices: [0, 1, 2] });
       if (resultState.backstageResult !== 'no-match') return;
-      const handBefore = resultState.players[0].hand.length;
+      // buildBackstageState は booResult='incorrect' → watcher(players[1]) がバックステージ担当
+      const backstagePlayerIndex = resultState.players[0].id === resultState.backstagePlayerId ? 0 : 1;
+      const handBefore = resultState.players[backstagePlayerIndex].hand.length;
       const final = gameReducer(resultState, { type: 'BACKSTAGE_TAKE_HAND', cardIndex: 0 });
-      expect(final.players[0].hand).toHaveLength(handBefore + 1);
+      expect(final.players[backstagePlayerIndex].hand).toHaveLength(handBefore + 1);
     });
 
     it('BACKSTAGE_TAKE_HAND でバックステージが1枚減る', () => {

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -312,6 +312,7 @@ describe('gameReducer', () => {
           spotlightCard: null,
           backstageRevealedCards: [],
           backstageResult: null,
+          backstagePlayerId: null,
         };
         const result = gameReducer(booCorrectState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
         expect(result.phase).toBe('intermission');
@@ -341,6 +342,7 @@ describe('gameReducer', () => {
           spotlightCard: null,
           backstageRevealedCards: [],
           backstageResult: null,
+          backstagePlayerId: null,
         };
         const result = gameReducer(booCorrectState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
         expect(result.phase).toBe('backstage');
@@ -651,6 +653,166 @@ describe('gameReducer', () => {
     });
   });
 
+  describe('バックステージ担当者判定（Issue #80）', () => {
+    const mk = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+
+    // SPOTLIGHT_OPEN_SET でペア不成立 → backstage に入るヘルパー
+    function buildFromNoPair(booResult: 'correct' | 'incorrect'): GameState | null {
+      const bonusState: GameState = {
+        phase: 'spotlight-bonus',
+        booResult,
+        players: [
+          { id: 'A', name: 'A', hand: [mk(3), mk(7)] },  // rank=5 なし
+          { id: 'B', name: 'B', hand: [mk(9), mk(11)] }, // rank=5 なし
+        ],
+        stage: { kami: { ...mk(4), isFaceUp: true }, shimo: { ...mk(6), isFaceUp: true } },
+        deck: [mk(5), mk(12), mk(8)],
+        backstage: [mk(9), mk(11), mk(4)],
+        setRemainingCount: 3,
+        publicInfos: [],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        round: 1,
+        curtainCallReason: null,
+        spotlightCard: null,
+        backstageRevealedCards: [],
+        backstageResult: null,
+        backstagePlayerId: null,
+      };
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
+      return result.phase === 'backstage' ? result : null;
+    }
+
+    it('boo 不正解時: SPOTLIGHT_OPEN_SET（ペア不成立）→ backstagePlayerId が watcher(players[1].id=B) になる', () => {
+      const state = buildFromNoPair('incorrect');
+      if (!state) throw new Error('backstage state を構築できませんでした');
+      expect(state.backstagePlayerId).toBe('B');
+    });
+
+    it('boo 正解時: SPOTLIGHT_OPEN_SET（ペア不成立）→ backstagePlayerId が actor(players[0].id=A) になる', () => {
+      const state = buildFromNoPair('correct');
+      if (!state) throw new Error('backstage state を構築できませんでした');
+      expect(state.backstagePlayerId).toBe('A');
+    });
+
+    it('boo 不正解時: SPOTLIGHT_SKIP_SET → backstagePlayerId が watcher(players[1].id=B) になる', () => {
+      const bonusState: GameState = {
+        phase: 'spotlight-bonus',
+        booResult: 'incorrect',
+        players: [
+          { id: 'A', name: 'A', hand: [mk(3)] },
+          { id: 'B', name: 'B', hand: [mk(2)] },
+        ],
+        stage: { kami: null, shimo: null },
+        deck: [],
+        backstage: [],
+        setRemainingCount: 0,
+        publicInfos: [],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        round: 1,
+        curtainCallReason: null,
+        spotlightCard: null,
+        backstageRevealedCards: [],
+        backstageResult: null,
+        backstagePlayerId: null,
+      };
+      const result = gameReducer(bonusState, { type: 'SPOTLIGHT_SKIP_SET' });
+      expect(result.phase).toBe('backstage');
+      expect(result.backstagePlayerId).toBe('B');
+    });
+
+    it('boo 不正解時: BACKSTAGE_OPEN の publicInfos が watcher(B) のIDで記録される', () => {
+      const state: GameState = {
+        phase: 'backstage',
+        booResult: 'incorrect',
+        players: [
+          { id: 'A', name: 'A', hand: [mk(3)] },
+          { id: 'B', name: 'B', hand: [mk(2)] },
+        ],
+        stage: { kami: null, shimo: null },
+        deck: [],
+        backstage: [mk(9), mk(11), mk(4)],
+        setRemainingCount: 0,
+        publicInfos: [],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        round: 1,
+        curtainCallReason: null,
+        spotlightCard: null,
+        backstageRevealedCards: [],
+        backstageResult: null,
+        backstagePlayerId: 'B', // watcher = B（修正後にセットされる値）
+      };
+      const result = gameReducer(state, { type: 'BACKSTAGE_OPEN', cardIndices: [0, 1, 2] });
+      expect(result.publicInfos.every((p) => p.playerId === 'B')).toBe(true);
+    });
+
+    it('boo 不正解時: BACKSTAGE_TAKE_HAND でカードが watcher(players[1]=B) に追加される', () => {
+      const state: GameState = {
+        phase: 'backstage-result',
+        booResult: 'incorrect',
+        players: [
+          { id: 'A', name: 'A', hand: [mk(3)] },
+          { id: 'B', name: 'B', hand: [mk(2)] },
+        ],
+        stage: { kami: null, shimo: null },
+        deck: [],
+        backstage: [mk(9), mk(11), mk(4)],
+        setRemainingCount: 0,
+        publicInfos: [],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        round: 1,
+        curtainCallReason: null,
+        spotlightCard: null,
+        backstageRevealedCards: [mk(9), mk(11), mk(4)],
+        backstageResult: 'no-match',
+        backstagePlayerId: 'B', // watcher = B
+      };
+      const result = gameReducer(state, { type: 'BACKSTAGE_TAKE_HAND', cardIndex: 0 });
+      expect(result.players[1].hand).toHaveLength(2); // B: 1 + 1
+      expect(result.players[0].hand).toHaveLength(1); // A: 変化なし
+    });
+
+    it('boo 正解時: BACKSTAGE_TAKE_HAND でカードが actor(players[0]=A) に追加される', () => {
+      const state: GameState = {
+        phase: 'backstage-result',
+        booResult: 'correct',
+        players: [
+          { id: 'A', name: 'A', hand: [mk(3)] },
+          { id: 'B', name: 'B', hand: [mk(2)] },
+        ],
+        stage: { kami: null, shimo: null },
+        deck: [],
+        backstage: [mk(9), mk(11), mk(4)],
+        setRemainingCount: 0,
+        publicInfos: [],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        round: 1,
+        curtainCallReason: null,
+        spotlightCard: null,
+        backstageRevealedCards: [mk(9), mk(11), mk(4)],
+        backstageResult: 'no-match',
+        backstagePlayerId: 'A', // actor = A
+      };
+      const result = gameReducer(state, { type: 'BACKSTAGE_TAKE_HAND', cardIndex: 0 });
+      expect(result.players[0].hand).toHaveLength(2); // A: 1 + 1
+      expect(result.players[1].hand).toHaveLength(1); // B: 変化なし
+    });
+  });
+
   describe('不正遷移', () => {
     it('standby フェーズで SCOUT_CARD を dispatch しても state が変わらない', () => {
       const result = gameReducer(initialState, { type: 'SCOUT_CARD', cardIndex: 0 });
@@ -696,6 +858,7 @@ describe('gameReducer', () => {
         spotlightCard: null,
         backstageRevealedCards: [],
         backstageResult: null,
+        backstagePlayerId: null,
       };
     }
 
@@ -789,6 +952,7 @@ describe('gameReducer', () => {
           spotlightCard: null,
           backstageRevealedCards: [],
           backstageResult: null,
+          backstagePlayerId: null,
         };
         // deck[0]=rank6, players[0].hand にrank6あり → ペア成立
         const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
@@ -820,6 +984,7 @@ describe('gameReducer', () => {
           spotlightCard: null,
           backstageRevealedCards: [],
           backstageResult: null,
+          backstagePlayerId: null,
         };
         // deck[0]=rank5, players[1].hand にrank5あり → ペア成立
         const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: 0 });
@@ -855,6 +1020,7 @@ describe('gameReducer', () => {
           spotlightCard,
           backstageRevealedCards: [],
           backstageResult: null,
+          backstagePlayerId: 'A', // boo incorrect → watcher=B のはずだが、このテストは players[0]=A を担当者として設定
         };
         const result = gameReducer(backstageState, { type: 'BACKSTAGE_OPEN', cardIndices: [0, 1, 2] });
         expect(result.backstageResult).toBe('match');

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -995,8 +995,8 @@ describe('gameReducer', () => {
       });
     });
 
-    describe('BACKSTAGE_OPEN: ペア成立時に spotlightCard が行動プレイヤーのカミに追加される', () => {
-      it('ペア成立時に spotlightCard が players[0].id のカミ配列に追加される', () => {
+    describe('BACKSTAGE_OPEN: ペア成立時に spotlightCard がバックステージ担当者のカミに追加される', () => {
+      it('boo 不正解時: ペア成立で spotlightCard が watcher(B=players[1]) のカミ配列に追加される', () => {
         const spotlightCard = mk(7);
         const matchCard = mk(7);
         const backstageState: GameState = {
@@ -1020,13 +1020,14 @@ describe('gameReducer', () => {
           spotlightCard,
           backstageRevealedCards: [],
           backstageResult: null,
-          backstagePlayerId: 'A', // boo incorrect → watcher=B のはずだが、このテストは players[0]=A を担当者として設定
+          backstagePlayerId: 'B', // boo incorrect → watcher = B
         };
         const result = gameReducer(backstageState, { type: 'BACKSTAGE_OPEN', cardIndices: [0, 1, 2] });
         expect(result.backstageResult).toBe('match');
-        // playerAKami に spotlightCard (rank=7) が追加される
-        expect(result.playerAKami).toHaveLength(2);
-        expect(result.playerAKami[1].rank).toBe(7);
+        // playerBKami に spotlightCard (rank=7) が追加される（watcher=B が担当）
+        expect(result.playerBKami).toHaveLength(1);
+        expect(result.playerBKami[0].rank).toBe(7);
+        expect(result.playerAKami).toHaveLength(1); // A は変化なし
       });
     });
   });

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -223,18 +223,25 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         return addKamiToPlayer(pairState, winnerId, openedCard);
       }
 
+      // boo 正解: actor(players[0])が敗者 → バックステージ担当
+      // boo 不正解: watcher(players[1])が敗者 → バックステージ担当
+      const backstagePlayerId =
+        state.booResult === 'correct' ? state.players[0].id : state.players[1].id;
       return {
         ...state,
         deck: newDeck,
         setRemainingCount: newSetRemainingCount,
         spotlightCard: openedCard,
         phase: 'backstage',
+        backstagePlayerId,
       };
     }
 
     case 'SPOTLIGHT_SKIP_SET': {
       if (state.phase !== 'spotlight' && state.phase !== 'spotlight-bonus') return state;
-      return { ...state, phase: 'backstage' };
+      const backstagePlayerId =
+        state.booResult === 'correct' ? state.players[0].id : state.players[1].id;
+      return { ...state, phase: 'backstage', backstagePlayerId };
     }
 
     case 'BACKSTAGE_OPEN': {
@@ -245,10 +252,11 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
       const selectedCards = cardIndices.map((i) => state.backstage[i]) as [Card, Card, Card];
 
+      const backstagePlayerId = state.backstagePlayerId!;
       const newPublicInfos = buildPublicInfos(
         state.publicInfos,
         selectedCards,
-        state.players[0].id,
+        backstagePlayerId,
         state.round,
       );
 
@@ -266,8 +274,6 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
           kami: { ...spotlightCard!, isFaceUp: true },
           shimo: { ...matchedCard, isFaceUp: true },
         };
-        // ペア成立: spotlightCard を行動プレイヤー(players[0])のカミ配列に追加
-        const backstagePlayerId = state.players[0].id;
         const matchState = {
           ...state,
           backstage: newBackstage,
@@ -296,6 +302,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         spotlightCard: null,
         backstageRevealedCards: [],
         backstageResult: null,
+        backstagePlayerId: null,
         phase: 'intermission',
       };
     }
@@ -306,11 +313,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       const card = state.backstage[action.cardIndex];
       if (card === undefined) return state;
       const newBackstage = removeCardAt(state.backstage, action.cardIndex);
-      const newPlayerA: Player = {
-        ...state.players[0],
-        hand: [...state.players[0].hand, card],
-      };
-      const players: [Player, Player] = [newPlayerA, state.players[1]];
+      const backstagePlayerIndex = state.players[0].id === state.backstagePlayerId ? 0 : 1;
+      const backstagePlayer = state.players[backstagePlayerIndex];
+      const newPlayer: Player = { ...backstagePlayer, hand: [...backstagePlayer.hand, card] };
+      const players: [Player, Player] = backstagePlayerIndex === 0
+        ? [newPlayer, state.players[1]]
+        : [state.players[0], newPlayer];
       return {
         ...state,
         backstage: newBackstage,
@@ -318,6 +326,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         spotlightCard: null,
         backstageRevealedCards: [],
         backstageResult: null,
+        backstagePlayerId: null,
         phase: 'intermission',
       };
     }

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -41,6 +41,7 @@ export const initialState: GameState = {
   spotlightCard: null,
   backstageRevealedCards: [],
   backstageResult: null,
+  backstagePlayerId: null,
 };
 
 function removeCardAt(cards: Card[], index: number): Card[] {

--- a/src/lib/curtainCall.test.ts
+++ b/src/lib/curtainCall.test.ts
@@ -32,6 +32,7 @@ const baseState: GameState = {
   spotlightCard: null,
   backstageRevealedCards: [],
   backstageResult: null,
+  backstagePlayerId: null,
 };
 
 describe('checkCurtainCall', () => {

--- a/src/lib/scoring.test.ts
+++ b/src/lib/scoring.test.ts
@@ -27,6 +27,7 @@ const baseState: GameState = {
   spotlightCard: null,
   backstageRevealedCards: [],
   backstageResult: null,
+  backstagePlayerId: null,
 };
 
 describe('calculateScore', () => {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -59,4 +59,5 @@ export type GameState = {
   spotlightCard: Card | null;
   backstageRevealedCards: Card[];
   backstageResult: BackstageResult | null;
+  backstagePlayerId: string | null; // バックステージ担当者ID（boo敗者）
 };


### PR DESCRIPTION
## Summary

- `GameState` に `backstagePlayerId: string | null` フィールドを追加
- `SPOTLIGHT_OPEN_SET`（ペア不成立）・`SPOTLIGHT_SKIP_SET` で `backstagePlayerId` を正しく設定
  - `booResult=correct` → actor（players[0]）が敗者 → `players[0].id`
  - `booResult=incorrect` → watcher（players[1]）が敗者 → `players[1].id`
- `BACKSTAGE_OPEN` / `BACKSTAGE_TAKE_HAND` が `backstagePlayerId` を参照するよう修正

## Acceptance Criteria

- [x] ブーイング不正解時は watcher 側がバックステージを担当する
- [x] ブーイング正解時は actor 側がバックステージを担当する
- [x] 公開情報の `playerId` と手札取得先が担当者と一致する
- [x] 双方の分岐を検証する reducer テストが追加されている（6件追加）

## Test plan

- `npx vitest run` → 235 passed (0 failed)
- `npx eslint .` → エラーなし

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)