### PR TITLE
[Bug] 同一プレイヤー継続時の PassDevice 誤表示を修正する（Issue #83）

### DIFF
--- a/src/screens/ActionScreen.test.tsx
+++ b/src/screens/ActionScreen.test.tsx
@@ -127,4 +127,18 @@ describe('ActionScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: 'ステージへ出す' }));
     expect(screen.getByRole('button', { name: '長押しで進む' })).toBeDefined();
   });
+
+  it('PassDeviceにはウォッチャー（ボブ）の名前が表示される', () => {
+    renderAction();
+    const cardButtons = screen.getAllByRole('button').filter(
+      (b) => b.getAttribute('aria-label') !== 'ステージへ出す',
+    );
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'ステージへ出す' }));
+    // PassDevice はウォッチャー（ボブ）に渡すもの
+    expect(screen.getByText('ボブ')).toBeDefined();
+    // アクター（アリス）の名前は表示されない
+    expect(screen.queryByText('アリス')).toBeNull();
+  });
 });

--- a/src/screens/ActionScreen.test.tsx
+++ b/src/screens/ActionScreen.test.tsx
@@ -142,3 +142,65 @@ describe('ActionScreen', () => {
     expect(screen.queryByText('アリス')).toBeNull();
   });
 });
+
+// INTERMISSION でスワップされた後も PassDevice が正しいウォッチャー名を表示することを確認
+describe('ActionScreen ラウンド2', () => {
+  function Round2ActionWrapper() {
+    const dispatch = useGameDispatch();
+    const state = useGameState();
+
+    if (state.phase === 'standby' && state.players[0].name === '') {
+      return <button onClick={() => dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })}>init</button>;
+    }
+    if (state.phase === 'standby') {
+      return <button onClick={() => dispatch({ type: 'START_SCOUT' })}>start</button>;
+    }
+    if (state.phase === 'scout') {
+      return <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>;
+    }
+    // ラウンド1のアクション: アリス（players[0]）が actor → 自動で ACTION_PLAY
+    if (state.phase === 'action' && state.players[0].name === 'アリス') {
+      return <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>action1</button>;
+    }
+    if (state.phase === 'watch') {
+      return <button onClick={() => dispatch({ type: 'WATCH_CLAP' })}>clap</button>;
+    }
+    if (state.phase === 'intermission') {
+      return <button onClick={() => dispatch({ type: 'INTERMISSION' })}>inter</button>;
+    }
+    // ラウンド2のアクション: ボブ（players[0]）が actor → ActionScreen を表示
+    if (state.phase === 'action' && state.players[0].name === 'ボブ') {
+      return <ActionScreen />;
+    }
+    return <div data-testid="phase">{state.phase}</div>;
+  }
+
+  function renderActionRound2() {
+    render(
+      <GameProvider>
+        <Round2ActionWrapper />
+      </GameProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'init' }));
+    fireEvent.click(screen.getByRole('button', { name: 'start' }));
+    fireEvent.click(screen.getByRole('button', { name: 'scout' }));   // Round 1 scout
+    fireEvent.click(screen.getByRole('button', { name: 'action1' })); // Round 1 action
+    fireEvent.click(screen.getByRole('button', { name: 'clap' }));    // Watch → Intermission
+    fireEvent.click(screen.getByRole('button', { name: 'inter' }));   // Intermission → Round 2 scout
+    fireEvent.click(screen.getByRole('button', { name: 'scout' }));   // Round 2 scout → action
+  }
+
+  it('ラウンド2のPassDeviceには新しいウォッチャー（アリス）の名前が表示される', () => {
+    renderActionRound2();
+    const cardButtons = screen.getAllByRole('button').filter(
+      (b) => b.getAttribute('aria-label') !== 'ステージへ出す',
+    );
+    fireEvent.click(cardButtons[0]);
+    fireEvent.click(cardButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'ステージへ出す' }));
+    // ラウンド2ではアリスがウォッチャー
+    expect(screen.getByText('アリス')).toBeDefined();
+    // アクター（ボブ）の名前は表示されない
+    expect(screen.queryByText('ボブ')).toBeNull();
+  });
+});

--- a/src/screens/ActionScreen.tsx
+++ b/src/screens/ActionScreen.tsx
@@ -36,7 +36,7 @@ export default function ActionScreen() {
   if (showPassDevice && kamiIndex !== null && shimoIndex !== null) {
     return (
       <PassDevice
-        playerName={actionPlayer.name}
+        playerName={state.players[1].name}
         onComplete={() => dispatch({ type: 'ACTION_PLAY', kamiIndex, shimoIndex })}
       />
     );

--- a/src/screens/ActionScreen.tsx
+++ b/src/screens/ActionScreen.tsx
@@ -34,6 +34,8 @@ export default function ActionScreen() {
   };
 
   if (showPassDevice && kamiIndex !== null && shimoIndex !== null) {
+    // players[0] = actor（現ラウンド先攻）、players[1] = watcher（現ラウンド後攻）
+    // INTERMISSION でスワップされるため、この不変条件は全ラウンドで成立する
     return (
       <PassDevice
         playerName={state.players[1].name}

--- a/src/screens/ScoutScreen.test.tsx
+++ b/src/screens/ScoutScreen.test.tsx
@@ -85,24 +85,21 @@ describe('ScoutScreen', () => {
     expect(btn.hasAttribute('disabled')).toBe(false);
   });
 
-  it('「スカウト確定」でPassDevice画面に遷移する', () => {
+  it('「スカウト確定」後、PassDeviceは表示されない', () => {
     renderScout();
     const allButtons = screen.getAllByRole('button');
     const firstCard = allButtons.find((b) => b.textContent === '') ?? allButtons[0];
     fireEvent.click(firstCard);
     fireEvent.click(screen.getByRole('button', { name: 'スカウト確定' }));
-    expect(screen.getByText('さんに渡してください')).toBeDefined();
+    expect(screen.queryByText('さんに渡してください')).toBeNull();
   });
 
-  it('PassDevice完了後にActionフェーズへ遷移する', () => {
+  it('「スカウト確定」後、直接アクションフェーズへ遷移する', () => {
     renderScout();
     const allButtons = screen.getAllByRole('button');
     const firstCard = allButtons.find((b) => b.textContent === '') ?? allButtons[0];
     fireEvent.click(firstCard);
     fireEvent.click(screen.getByRole('button', { name: 'スカウト確定' }));
-    // PassDeviceのonCompleteを直接トリガー（aria-label="長押しで進む"のボタンのPointerDownで即完了させる代わりに
-    // onComplete を模倣するため、PointerDown→PointerUp を連打する方法もあるが、
-    // ここではスカウト確定後のpassdevice画面にいることを確認するにとどめる）
-    expect(screen.getByRole('button', { name: '長押しで進む' })).toBeDefined();
+    expect(screen.getByTestId('after-scout').textContent).toBe('phase: action');
   });
 });

--- a/src/screens/ScoutScreen.tsx
+++ b/src/screens/ScoutScreen.tsx
@@ -1,16 +1,13 @@
 import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
-import PassDevice from '@/components/PassDevice';
 import styles from './ScoutScreen.module.css';
 
 export default function ScoutScreen() {
   const state = useGameState();
   const dispatch = useGameDispatch();
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [showPassDevice, setShowPassDevice] = useState(false);
 
-  const scoutPlayer = state.players[0];
   const opponentHand = state.players[1].hand;
 
   const handleCardClick = (index: number) => {
@@ -20,17 +17,8 @@ export default function ScoutScreen() {
 
   const handleConfirm = () => {
     if (selectedIndex === null) return;
-    setShowPassDevice(true);
+    dispatch({ type: 'SCOUT_CARD', cardIndex: selectedIndex });
   };
-
-  if (showPassDevice && selectedIndex !== null) {
-    return (
-      <PassDevice
-        playerName={scoutPlayer.name}
-        onComplete={() => dispatch({ type: 'SCOUT_CARD', cardIndex: selectedIndex })}
-      />
-    );
-  }
 
   return (
     <div className={styles.screen}>


### PR DESCRIPTION
## 概要

スカウト確定後、同一プレイヤーがアクションを続けるにもかかわらず PassDevice（端末受け渡し画面）が表示されていた問題を修正する。

Closes #83

## 変更内容

- **ScoutScreen**: スカウト→アクションは同一プレイヤーが続投するため PassDevice を削除。確定時に直接 `SCOUT_CARD` を dispatch するよう変更
- **ActionScreen**: アクション→ウォッチは担当者が変わるため PassDevice は維持しつつ、表示名をウォッチャー（`players[1]`）に修正（従来は誤って `players[0]` を表示していた）
- **ScoutScreen.test.tsx**: 「スカウト確定後に PassDevice なしで直接アクションフェーズへ遷移する」テストに更新
- **ActionScreen.test.tsx**: PassDevice にウォッチャー（ボブ）の名前が表示されることを検証するテスト追加

## テスト計画

- [x] `npx vitest run` — 236 tests passed
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx eslint .` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)