### PR TITLE
[Bug] 裏向きJOKERがカード裏面として描画されるよう修正する（Issue #86）

### DIFF
--- a/src/components/Card.test.tsx
+++ b/src/components/Card.test.tsx
@@ -24,6 +24,13 @@ const jokerCard = (): CardType => ({
   isFaceUp: true,
 });
 
+const faceDownJokerCard = (): CardType => ({
+  suit: 'spades',
+  rank: 0,
+  isJoker: true,
+  isFaceUp: false,
+});
+
 describe('Card', () => {
   it('表向きカードがスートとランクを表示する', () => {
     render(<Card card={faceUpCard('spades', 1)} />);
@@ -57,6 +64,17 @@ describe('Card', () => {
   it('ジョーカーがJOKERラベルを表示する', () => {
     render(<Card card={jokerCard()} />);
     expect(screen.getByText('JOKER')).toBeDefined();
+  });
+
+  it('裏向きジョーカーはJOKERラベルを表示しない', () => {
+    render(<Card card={faceDownJokerCard()} />);
+    expect(screen.queryByText('JOKER')).toBeNull();
+  });
+
+  it('裏向きジョーカーはbackクラスを持つ', () => {
+    const { container } = render(<Card card={faceDownJokerCard()} />);
+    const el = container.querySelector('[class*="back"]');
+    expect(el).toBeTruthy();
   });
 
   it('selected状態でselectedクラスが付く', () => {

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -48,19 +48,19 @@ export default function Card({ card, isSelected, isSelectedShimo, onClick, anima
 
   const animStyle = animateDeal && dealDelay != null ? { animationDelay: `${dealDelay}s` } : undefined;
 
+  if (!card.isFaceUp) {
+    classNames.push(styles.back);
+    return (
+      <div className={classNames.join(' ')} style={animStyle} onClick={onClick} role={onClick ? 'button' : undefined} />
+    );
+  }
+
   if (card.isJoker) {
     classNames.push(styles.joker);
     return (
       <div className={classNames.join(' ')} style={animStyle} onClick={onClick} role={onClick ? 'button' : undefined}>
         <span className={styles.jokerLabel}>JOKER</span>
       </div>
-    );
-  }
-
-  if (!card.isFaceUp) {
-    classNames.push(styles.back);
-    return (
-      <div className={classNames.join(' ')} style={animStyle} onClick={onClick} role={onClick ? 'button' : undefined} />
     );
   }
 


### PR DESCRIPTION
## Summary
- `Card` コンポーネントで `isFaceUp` の判定を `isJoker` より先に行うよう修正
- 裏向き JOKER が他の裏向きカードと同様にカード裏面として表示されるようになった
- 裏向き / 表向き JOKER の回帰テストを追加（+2件）

## Test plan
- [ ] `npx vitest run src/components/Card.test.tsx` — 18件全パス
- [ ] `npx vitest run` — 246件全パス
- [ ] 裏向き JOKER が `JOKER` ラベルを表示しないことをテストで検証済み
- [ ] 表向き JOKER は従来どおり `JOKER` と表示されることをテストで検証済み

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)