### PR TITLE
feat: スカウト/アクション後に結果確認画面を追加（Issue #81）

### DIFF
--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -1,8 +1,10 @@
 import { useGameState } from '@/game/context';
+import ActionResultScreen from '@/screens/ActionResultScreen';
 import ActionScreen from '@/screens/ActionScreen';
 import BackstageScreen from '@/screens/BackstageScreen';
 import IntermissionScreen from '@/screens/IntermissionScreen';
 import ResultScreen from '@/screens/ResultScreen';
+import ScoutResultScreen from '@/screens/ScoutResultScreen';
 import ScoutScreen from '@/screens/ScoutScreen';
 import SpotlightBonusScreen from '@/screens/SpotlightBonusScreen';
 import SpotlightRevealScreen from '@/screens/SpotlightRevealScreen';
@@ -22,8 +24,12 @@ export default function GameRouter() {
       return <StandbyScreen />;
     case 'scout':
       return <ScoutScreen />;
+    case 'scout-result':
+      return <ScoutResultScreen />;
     case 'action':
       return <ActionScreen />;
+    case 'action-result':
+      return <ActionResultScreen />;
     case 'watch':
       return <WatchScreen />;
     case 'spotlight':

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -87,9 +87,9 @@ describe('gameReducer', () => {
       scoutState = gameReducer(afterInit, { type: 'START_SCOUT' });
     });
 
-    it('phase が action になる', () => {
+    it('phase が scout-result になる', () => {
       const result = gameReducer(scoutState, { type: 'SCOUT_CARD', cardIndex: 0 });
-      expect(result.phase).toBe('action');
+      expect(result.phase).toBe('scout-result');
     });
 
     it('Aの手札が1枚増える', () => {
@@ -110,7 +110,7 @@ describe('gameReducer', () => {
   });
 
   describe('ACTION_PLAY', () => {
-    it('phase が watch になる', () => {
+    it('phase が action-result になる', () => {
       const afterInit = gameReducer(initialState, {
         type: 'INIT_GAME',
         playerAName: 'Alice',
@@ -118,8 +118,9 @@ describe('gameReducer', () => {
       });
       const afterStart = gameReducer(afterInit, { type: 'START_SCOUT' });
       const afterScout = gameReducer(afterStart, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const result = gameReducer(afterScout, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      expect(result.phase).toBe('watch');
+      const afterProceed = gameReducer(afterScout, { type: 'SCOUT_RESULT_PROCEED' });
+      const result = gameReducer(afterProceed, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      expect(result.phase).toBe('action-result');
     });
 
     it('ステージにkami/shimoがセットされる', () => {
@@ -130,9 +131,10 @@ describe('gameReducer', () => {
       });
       const afterStart = gameReducer(afterInit, { type: 'START_SCOUT' });
       const afterScout = gameReducer(afterStart, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const kami = afterScout.players[0].hand[0];
-      const shimo = afterScout.players[0].hand[1];
-      const result = gameReducer(afterScout, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const afterProceed = gameReducer(afterScout, { type: 'SCOUT_RESULT_PROCEED' });
+      const kami = afterProceed.players[0].hand[0];
+      const shimo = afterProceed.players[0].hand[1];
+      const result = gameReducer(afterProceed, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
       expect(result.stage.kami).toEqual({ ...kami, isFaceUp: true });
       expect(result.stage.shimo).toEqual({ ...shimo, isFaceUp: false });
     });
@@ -144,7 +146,9 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      watchState = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      watchState = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
     });
 
     it('WATCH_CLAP で phase が intermission になる', () => {
@@ -174,8 +178,10 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      spotlightState = gameReducer(s4, { type: 'WATCH_BOO' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      spotlightState = gameReducer(s6, { type: 'WATCH_BOO' });
     });
 
     it('shimo が表向きになる', () => {
@@ -205,9 +211,11 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      spotlightState = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      spotlightState = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
     });
 
     it('spotlight → spotlight-bonus に遷移する', () => {
@@ -227,12 +235,14 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const s7 = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      const s8 = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
+      const s9 = gameReducer(s8, { type: 'SPOTLIGHT_ENTER_BONUS' });
       // 既存テストは boo 不正解（actor の手札参照）パスを検証するため明示的に設定
-      bonusState = { ...s7, booResult: 'incorrect' as const };
+      bonusState = { ...s9, booResult: 'incorrect' as const };
     });
 
     it('spotlight-bonus 以外では無効', () => {
@@ -355,10 +365,12 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const bonusState = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      const s8 = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
+      const bonusState = gameReducer(s8, { type: 'SPOTLIGHT_ENTER_BONUS' });
       const result = gameReducer(bonusState, { type: 'SPOTLIGHT_SKIP_SET' });
       expect(result.phase).toBe('intermission');
       expect(result.backstagePlayerId).toBeNull();
@@ -368,10 +380,12 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const result = gameReducer(s6, { type: 'SPOTLIGHT_SKIP_SET' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      const s8 = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
+      const result = gameReducer(s8, { type: 'SPOTLIGHT_SKIP_SET' });
       expect(result.phase).toBe('intermission');
       expect(result.backstagePlayerId).toBeNull();
     });
@@ -383,20 +397,22 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const s7raw = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      const s8 = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
+      const s9raw = gameReducer(s8, { type: 'SPOTLIGHT_ENTER_BONUS' });
       // boo 不正解パスを確定させて既存テストを安定化
-      const s7 = { ...s7raw, booResult: 'incorrect' as const };
+      const s9 = { ...s9raw, booResult: 'incorrect' as const };
 
       // ペア不成立のセットカードを探す
-      const playerAHand = s7.players[0].hand;
-      const noPairSetIndex = s7.deck.findIndex(
+      const playerAHand = s9.players[0].hand;
+      const noPairSetIndex = s9.deck.findIndex(
         (sc) => !sc.isJoker && !playerAHand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
       );
       if (noPairSetIndex === -1) return null;
-      return gameReducer(s7, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
+      return gameReducer(s9, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
     }
 
     it('backstage フェーズで spotlightCard がセットされている', () => {
@@ -430,16 +446,18 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const s7raw = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
-      const s7 = { ...s7raw, booResult: 'incorrect' as const };
-      const noPairSetIndex = s7.deck.findIndex(
-        (sc) => !sc.isJoker && !s7.players[0].hand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      const s8 = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
+      const s9raw = gameReducer(s8, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s9 = { ...s9raw, booResult: 'incorrect' as const };
+      const noPairSetIndex = s9.deck.findIndex(
+        (sc) => !sc.isJoker && !s9.players[0].hand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
       );
       if (noPairSetIndex === -1) return;
-      const backstageState = gameReducer(s7, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
+      const backstageState = gameReducer(s9, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
       if (backstageState.spotlightCard === null) return;
 
       // バックステージからスポットライトカードと同rankのカードを含む3枚を探す
@@ -499,16 +517,18 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const s7raw = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
-      const s7 = { ...s7raw, booResult: 'incorrect' as const };
-      const noPairSetIndex = s7.deck.findIndex(
-        (sc) => !sc.isJoker && !s7.players[0].hand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      const s8 = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
+      const s9raw = gameReducer(s8, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const s9 = { ...s9raw, booResult: 'incorrect' as const };
+      const noPairSetIndex = s9.deck.findIndex(
+        (sc) => !sc.isJoker && !s9.players[0].hand.some((hc) => !hc.isJoker && hc.rank === sc.rank),
       );
       if (noPairSetIndex === -1) return;
-      const backstageState = gameReducer(s7, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
+      const backstageState = gameReducer(s9, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: noPairSetIndex });
       if (backstageState.spotlightCard === null) return;
 
       const { spotlightCard, backstage } = backstageState;
@@ -540,11 +560,13 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      const s5 = gameReducer(s4, { type: 'WATCH_BOO' });
-      const s6 = gameReducer(s5, { type: 'SPOTLIGHT_REVEAL' });
-      const s7 = gameReducer(s6, { type: 'SPOTLIGHT_ENTER_BONUS' });
-      const result = gameReducer(s7, { type: 'SPOTLIGHT_SKIP_SET' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      const s7 = gameReducer(s6, { type: 'WATCH_BOO' });
+      const s8 = gameReducer(s7, { type: 'SPOTLIGHT_REVEAL' });
+      const s9 = gameReducer(s8, { type: 'SPOTLIGHT_ENTER_BONUS' });
+      const result = gameReducer(s9, { type: 'SPOTLIGHT_SKIP_SET' });
       expect(result.phase).toBe('intermission');
     });
   });
@@ -555,8 +577,10 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const s4 = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      return gameReducer(s4, { type: 'WATCH_CLAP' });
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const s5 = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const s6 = gameReducer(s5, { type: 'ACTION_RESULT_PROCEED' });
+      return gameReducer(s6, { type: 'WATCH_CLAP' });
     }
 
     it('通常継続時に scout フェーズへ遷移する', () => {
@@ -831,10 +855,7 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'Alice', playerBName: 'Bob' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const afterScout = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const scoutResultState: GameState = { ...afterScout, phase: 'scout-result' as any };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = gameReducer(scoutResultState, { type: 'SCOUT_RESULT_PROCEED' } as any);
+      const result = gameReducer(afterScout, { type: 'SCOUT_RESULT_PROCEED' });
       expect(result.phase).toBe('action');
     });
   });
@@ -844,11 +865,9 @@ describe('gameReducer', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'Alice', playerBName: 'Bob' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
-      const afterAction = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const actionResultState: GameState = { ...afterAction, phase: 'action-result' as any };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = gameReducer(actionResultState, { type: 'ACTION_RESULT_PROCEED' } as any);
+      const s4 = gameReducer(s3, { type: 'SCOUT_RESULT_PROCEED' });
+      const afterAction = gameReducer(s4, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      const result = gameReducer(afterAction, { type: 'ACTION_RESULT_PROCEED' });
       expect(result.phase).toBe('watch');
     });
   });

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -826,6 +826,33 @@ describe('gameReducer', () => {
     });
   });
 
+  describe('SCOUT_RESULT_PROCEED', () => {
+    it('scout-result フェーズで SCOUT_RESULT_PROCEED → action になる', () => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'Alice', playerBName: 'Bob' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const afterScout = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const scoutResultState: GameState = { ...afterScout, phase: 'scout-result' as any };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = gameReducer(scoutResultState, { type: 'SCOUT_RESULT_PROCEED' } as any);
+      expect(result.phase).toBe('action');
+    });
+  });
+
+  describe('ACTION_RESULT_PROCEED', () => {
+    it('action-result フェーズで ACTION_RESULT_PROCEED → watch になる', () => {
+      const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'Alice', playerBName: 'Bob' });
+      const s2 = gameReducer(s1, { type: 'START_SCOUT' });
+      const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
+      const afterAction = gameReducer(s3, { type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const actionResultState: GameState = { ...afterAction, phase: 'action-result' as any };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = gameReducer(actionResultState, { type: 'ACTION_RESULT_PROCEED' } as any);
+      expect(result.phase).toBe('watch');
+    });
+  });
+
   describe('不正遷移', () => {
     it('standby フェーズで SCOUT_CARD を dispatch しても state が変わらない', () => {
       const result = gameReducer(initialState, { type: 'SCOUT_CARD', cardIndex: 0 });

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -6,7 +6,9 @@ export type GameAction =
   | { type: 'INIT_GAME'; playerAName: string; playerBName: string }
   | { type: 'START_SCOUT' }
   | { type: 'SCOUT_CARD'; cardIndex: number }
+  | { type: 'SCOUT_RESULT_PROCEED' }
   | { type: 'ACTION_PLAY'; kamiIndex: number; shimoIndex: number }
+  | { type: 'ACTION_RESULT_PROCEED' }
   | { type: 'WATCH_CLAP' }
   | { type: 'WATCH_BOO' }
   | { type: 'SPOTLIGHT_REVEAL' }
@@ -105,7 +107,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       };
       const players: [Player, Player] = [newPlayerA, newPlayerB];
 
-      return { ...state, phase: 'action', players };
+      return { ...state, phase: 'scout-result', players };
+    }
+
+    case 'SCOUT_RESULT_PROCEED': {
+      if (state.phase !== 'scout-result') return state;
+      return { ...state, phase: 'action' };
     }
 
     case 'ACTION_PLAY': {
@@ -130,7 +137,12 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       const newPlayerA: Player = { ...state.players[0], hand: newHand };
       const players: [Player, Player] = [newPlayerA, state.players[1]];
 
-      return { ...state, phase: 'watch', players, stage: { kami, shimo } };
+      return { ...state, phase: 'action-result', players, stage: { kami, shimo } };
+    }
+
+    case 'ACTION_RESULT_PROCEED': {
+      if (state.phase !== 'action-result') return state;
+      return { ...state, phase: 'watch' };
     }
 
     case 'WATCH_CLAP': {

--- a/src/screens/ActionResultScreen.module.css
+++ b/src/screens/ActionResultScreen.module.css
@@ -1,0 +1,67 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 40px 16px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--accent, #60a5fa);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.sub {
+  font-size: 14px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+  text-align: center;
+}
+
+.stage {
+  display: flex;
+  gap: 32px;
+  justify-content: center;
+}
+
+.slot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.label {
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+}
+
+.empty {
+  width: 64px;
+  height: 96px;
+  border-radius: 8px;
+  border: 2px dashed var(--muted, #7a8aaa);
+  opacity: 0.3;
+}
+
+.proceedBtn {
+  padding: 12px 28px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+  border: 2px solid var(--accent, #60a5fa);
+  background: transparent;
+  color: var(--accent, #60a5fa);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.proceedBtn:active {
+  background: rgba(96, 165, 250, 0.12);
+}

--- a/src/screens/ActionResultScreen.test.tsx
+++ b/src/screens/ActionResultScreen.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
+import ActionResultScreen from './ActionResultScreen';
+
+function ActionResultWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return (
+      <button onClick={() => dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })}>
+        init
+      </button>
+    );
+  }
+  if (state.phase === 'standby') {
+    return <button onClick={() => dispatch({ type: 'START_SCOUT' })}>start</button>;
+  }
+  if (state.phase === 'scout') {
+    return <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((state.phase as any) === 'scout-result') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' } as any)}>scout-result-proceed</button>;
+  }
+  if (state.phase === 'action') {
+    return (
+      <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>action</button>
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((state.phase as any) === 'action-result') {
+    return <ActionResultScreen />;
+  }
+  return <div data-testid="after-action-result">phase: {state.phase}</div>;
+}
+
+function renderActionResult() {
+  render(
+    <GameProvider>
+      <ActionResultWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+  fireEvent.click(screen.getByRole('button', { name: 'start' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout-result-proceed' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action' }));
+}
+
+describe('ActionResultScreen', () => {
+  it('ステージ確認画面が表示される', () => {
+    renderActionResult();
+    expect(screen.getByText('ステージ確認')).toBeDefined();
+  });
+
+  it('役者（カミ）ラベルが表示される', () => {
+    renderActionResult();
+    expect(screen.getByText('役者（カミ）')).toBeDefined();
+  });
+
+  it('黒子（シモ）ラベルが表示される', () => {
+    renderActionResult();
+    expect(screen.getByText('黒子（シモ）')).toBeDefined();
+  });
+
+  it('「ウォッチへ」ボタンが表示される', () => {
+    renderActionResult();
+    expect(screen.getByRole('button', { name: 'ウォッチへ' })).toBeDefined();
+  });
+
+  it('「ウォッチへ」をタップすると watch フェーズへ進む', () => {
+    renderActionResult();
+    fireEvent.click(screen.getByRole('button', { name: 'ウォッチへ' }));
+    expect(screen.getByTestId('after-action-result').textContent).toBe('phase: watch');
+  });
+});

--- a/src/screens/ActionResultScreen.test.tsx
+++ b/src/screens/ActionResultScreen.test.tsx
@@ -20,18 +20,15 @@ function ActionResultWrapper() {
   if (state.phase === 'scout') {
     return <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((state.phase as any) === 'scout-result') {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' } as any)}>scout-result-proceed</button>;
+  if (state.phase === 'scout-result') {
+    return <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-result-proceed</button>;
   }
   if (state.phase === 'action') {
     return (
       <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>action</button>
     );
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((state.phase as any) === 'action-result') {
+  if (state.phase === 'action-result') {
     return <ActionResultScreen />;
   }
   return <div data-testid="after-action-result">phase: {state.phase}</div>;

--- a/src/screens/ActionResultScreen.tsx
+++ b/src/screens/ActionResultScreen.tsx
@@ -1,0 +1,39 @@
+import { useGameDispatch, useGameState } from '@/game/context';
+import Card from '@/components/Card';
+import styles from './ActionResultScreen.module.css';
+
+export default function ActionResultScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+
+  const { kami, shimo } = state.stage;
+  const actor = state.players[0];
+  const watcher = state.players[1];
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>ステージ確認</h1>
+      <p className={styles.sub}>
+        {actor.name} がステージへ出しました。{watcher.name} は確認してください。
+      </p>
+
+      <div className={styles.stage}>
+        <div className={styles.slot}>
+          <span className={styles.label}>役者（カミ）</span>
+          {kami ? <Card card={kami} /> : <div className={styles.empty} />}
+        </div>
+        <div className={styles.slot}>
+          <span className={styles.label}>黒子（シモ）</span>
+          {shimo ? <Card card={shimo} /> : <div className={styles.empty} />}
+        </div>
+      </div>
+
+      <button
+        className={styles.proceedBtn}
+        onClick={() => dispatch({ type: 'ACTION_RESULT_PROCEED' })}
+      >
+        ウォッチへ
+      </button>
+    </div>
+  );
+}

--- a/src/screens/ActionScreen.test.tsx
+++ b/src/screens/ActionScreen.test.tsx
@@ -27,6 +27,11 @@ function ActionWrapper() {
       <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
     );
   }
+  if (state.phase === 'scout-result') {
+    return (
+      <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-proceed</button>
+    );
+  }
   if (state.phase === 'action') {
     return <ActionScreen />;
   }
@@ -42,6 +47,7 @@ function renderAction() {
   fireEvent.click(screen.getByRole('button', { name: 'init' }));
   fireEvent.click(screen.getByRole('button', { name: 'start' }));
   fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' }));
 }
 
 describe('ActionScreen', () => {
@@ -197,9 +203,15 @@ describe('ActionScreen ラウンド2', () => {
     if (state.phase === 'scout') {
       return <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>;
     }
+    if (state.phase === 'scout-result') {
+      return <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-proceed</button>;
+    }
     // ラウンド1のアクション: アリス（players[0]）が actor → 自動で ACTION_PLAY
     if (state.phase === 'action' && state.players[0].name === 'アリス') {
       return <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>action1</button>;
+    }
+    if (state.phase === 'action-result' && state.players[0].name === 'アリス') {
+      return <button onClick={() => dispatch({ type: 'ACTION_RESULT_PROCEED' })}>action-proceed1</button>;
     }
     if (state.phase === 'watch') {
       return <button onClick={() => dispatch({ type: 'WATCH_CLAP' })}>clap</button>;
@@ -222,11 +234,14 @@ describe('ActionScreen ラウンド2', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'init' }));
     fireEvent.click(screen.getByRole('button', { name: 'start' }));
-    fireEvent.click(screen.getByRole('button', { name: 'scout' }));   // Round 1 scout
-    fireEvent.click(screen.getByRole('button', { name: 'action1' })); // Round 1 action
-    fireEvent.click(screen.getByRole('button', { name: 'clap' }));    // Watch → Intermission
-    fireEvent.click(screen.getByRole('button', { name: 'inter' }));   // Intermission → Round 2 scout
-    fireEvent.click(screen.getByRole('button', { name: 'scout' }));   // Round 2 scout → action
+    fireEvent.click(screen.getByRole('button', { name: 'scout' }));        // Round 1 scout
+    fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' })); // scout-result → action
+    fireEvent.click(screen.getByRole('button', { name: 'action1' }));      // Round 1 action
+    fireEvent.click(screen.getByRole('button', { name: 'action-proceed1' })); // action-result → watch
+    fireEvent.click(screen.getByRole('button', { name: 'clap' }));         // Watch → Intermission
+    fireEvent.click(screen.getByRole('button', { name: 'inter' }));        // Intermission → Round 2 scout
+    fireEvent.click(screen.getByRole('button', { name: 'scout' }));        // Round 2 scout
+    fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' })); // scout-result → Round 2 action
   }
 
   it('ラウンド2のPassDeviceには新しいウォッチャー（アリス）の名前が表示される', () => {

--- a/src/screens/BackstageScreen.test.tsx
+++ b/src/screens/BackstageScreen.test.tsx
@@ -22,12 +22,18 @@ function BackstageWrapper() {
   if (state.phase === 'scout') {
     return <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>;
   }
+  if (state.phase === 'scout-result') {
+    return <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-proceed</button>;
+  }
   if (state.phase === 'action') {
     return (
       <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>
         action
       </button>
     );
+  }
+  if (state.phase === 'action-result') {
+    return <button onClick={() => dispatch({ type: 'ACTION_RESULT_PROCEED' })}>action-proceed</button>;
   }
   if (state.phase === 'watch') {
     return <button onClick={() => dispatch({ type: 'WATCH_BOO' })}>boo</button>;
@@ -73,7 +79,9 @@ function renderBackstage() {
   fireEvent.click(screen.getByRole('button', { name: 'init' }));
   fireEvent.click(screen.getByRole('button', { name: 'start' }));
   fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'action' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'boo' }));
   fireEvent.click(screen.getByRole('button', { name: 'reveal' }));
   fireEvent.click(screen.getByRole('button', { name: 'enter-bonus' }));

--- a/src/screens/IntermissionScreen.test.tsx
+++ b/src/screens/IntermissionScreen.test.tsx
@@ -34,12 +34,18 @@ function IntermissionWrapper() {
       <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
     );
   }
+  if (state.phase === 'scout-result') {
+    return <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-proceed</button>;
+  }
   if (state.phase === 'action') {
     return (
       <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>
         action
       </button>
     );
+  }
+  if (state.phase === 'action-result') {
+    return <button onClick={() => dispatch({ type: 'ACTION_RESULT_PROCEED' })}>action-proceed</button>;
   }
   if (state.phase === 'watch') {
     return <button onClick={() => dispatch({ type: 'WATCH_CLAP' })}>clap</button>;
@@ -56,7 +62,9 @@ function renderIntermission() {
   fireEvent.click(screen.getByRole('button', { name: 'init' }));
   fireEvent.click(screen.getByRole('button', { name: 'start' }));
   fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'action' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'clap' }));
 }
 

--- a/src/screens/ScoutResultScreen.module.css
+++ b/src/screens/ScoutResultScreen.module.css
@@ -1,0 +1,44 @@
+.screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  padding: 40px 16px;
+  background: var(--bg, #0f172a);
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--accent, #60a5fa);
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.info {
+  font-size: 16px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+  text-align: center;
+}
+
+.info strong {
+  color: var(--fg, #e2e8f0);
+}
+
+.proceedBtn {
+  padding: 12px 28px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+  border: 2px solid var(--accent, #60a5fa);
+  background: transparent;
+  color: var(--accent, #60a5fa);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.proceedBtn:active {
+  background: rgba(96, 165, 250, 0.12);
+}

--- a/src/screens/ScoutResultScreen.test.tsx
+++ b/src/screens/ScoutResultScreen.test.tsx
@@ -20,8 +20,7 @@ function ScoutResultWrapper() {
   if (state.phase === 'scout') {
     return <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((state.phase as any) === 'scout-result') {
+  if (state.phase === 'scout-result') {
     return <ScoutResultScreen />;
   }
   return <div data-testid="after-scout-result">phase: {state.phase}</div>;

--- a/src/screens/ScoutResultScreen.test.tsx
+++ b/src/screens/ScoutResultScreen.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
+import ScoutResultScreen from './ScoutResultScreen';
+
+function ScoutResultWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return (
+      <button onClick={() => dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })}>
+        init
+      </button>
+    );
+  }
+  if (state.phase === 'standby') {
+    return <button onClick={() => dispatch({ type: 'START_SCOUT' })}>start</button>;
+  }
+  if (state.phase === 'scout') {
+    return <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((state.phase as any) === 'scout-result') {
+    return <ScoutResultScreen />;
+  }
+  return <div data-testid="after-scout-result">phase: {state.phase}</div>;
+}
+
+function renderScoutResult() {
+  render(
+    <GameProvider>
+      <ScoutResultWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+  fireEvent.click(screen.getByRole('button', { name: 'start' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+}
+
+describe('ScoutResultScreen', () => {
+  it('スカウト完了画面が表示される', () => {
+    renderScoutResult();
+    expect(screen.getByText('スカウト完了')).toBeDefined();
+  });
+
+  it('手札枚数の案内が表示される', () => {
+    renderScoutResult();
+    expect(screen.getByText(/手札/)).toBeDefined();
+  });
+
+  it('「アクションへ」ボタンが表示される', () => {
+    renderScoutResult();
+    expect(screen.getByRole('button', { name: 'アクションへ' })).toBeDefined();
+  });
+
+  it('「アクションへ」をタップすると action フェーズへ進む', () => {
+    renderScoutResult();
+    fireEvent.click(screen.getByRole('button', { name: 'アクションへ' }));
+    expect(screen.getByTestId('after-scout-result').textContent).toBe('phase: action');
+  });
+});

--- a/src/screens/ScoutResultScreen.tsx
+++ b/src/screens/ScoutResultScreen.tsx
@@ -1,0 +1,24 @@
+import { useGameDispatch, useGameState } from '@/game/context';
+import styles from './ScoutResultScreen.module.css';
+
+export default function ScoutResultScreen() {
+  const state = useGameState();
+  const dispatch = useGameDispatch();
+
+  const actor = state.players[0];
+
+  return (
+    <div className={styles.screen}>
+      <h1 className={styles.heading}>スカウト完了</h1>
+      <p className={styles.info}>
+        {actor.name} の手札が <strong>{actor.hand.length}枚</strong> になりました
+      </p>
+      <button
+        className={styles.proceedBtn}
+        onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}
+      >
+        アクションへ
+      </button>
+    </div>
+  );
+}

--- a/src/screens/ScoutScreen.test.tsx
+++ b/src/screens/ScoutScreen.test.tsx
@@ -27,6 +27,7 @@ function ScoutWrapper() {
   if (state.phase === 'scout') {
     return <ScoutScreen />;
   }
+  // scout-result まで進んだら after-scout として扱う（GameRouter が ScoutResultScreen を担当）
   return <div data-testid="after-scout">phase: {state.phase}</div>;
 }
 
@@ -102,12 +103,12 @@ describe('ScoutScreen', () => {
     expect(screen.queryByText('さんに渡してください')).toBeNull();
   });
 
-  it('「スカウト確定」後、直接アクションフェーズへ遷移する', () => {
+  it('「スカウト確定」後、scout-result フェーズへ遷移する', () => {
     renderScout();
     const allButtons = screen.getAllByRole('button');
     const firstCard = allButtons.find((b) => b.textContent === '') ?? allButtons[0];
     fireEvent.click(firstCard);
     fireEvent.click(screen.getByRole('button', { name: 'スカウト確定' }));
-    expect(screen.getByTestId('after-scout').textContent).toBe('phase: action');
+    expect(screen.getByTestId('after-scout').textContent).toBe('phase: scout-result');
   });
 });

--- a/src/screens/SpotlightBonusScreen.test.tsx
+++ b/src/screens/SpotlightBonusScreen.test.tsx
@@ -27,11 +27,21 @@ function BonusWrapper() {
       <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
     );
   }
+  if (state.phase === 'scout-result') {
+    return (
+      <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-proceed</button>
+    );
+  }
   if (state.phase === 'action') {
     return (
       <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>
         action
       </button>
+    );
+  }
+  if (state.phase === 'action-result') {
+    return (
+      <button onClick={() => dispatch({ type: 'ACTION_RESULT_PROCEED' })}>action-proceed</button>
     );
   }
   if (state.phase === 'watch') {
@@ -60,7 +70,9 @@ function renderBonus() {
   fireEvent.click(screen.getByRole('button', { name: 'init' }));
   fireEvent.click(screen.getByRole('button', { name: 'start' }));
   fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'action' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'boo' }));
   fireEvent.click(screen.getByRole('button', { name: 'reveal' }));
   fireEvent.click(screen.getByRole('button', { name: 'enter-bonus' }));

--- a/src/screens/SpotlightRevealScreen.test.tsx
+++ b/src/screens/SpotlightRevealScreen.test.tsx
@@ -27,11 +27,21 @@ function SpotlightWrapper() {
       <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
     );
   }
+  if (state.phase === 'scout-result') {
+    return (
+      <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-proceed</button>
+    );
+  }
   if (state.phase === 'action') {
     return (
       <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>
         action
       </button>
+    );
+  }
+  if (state.phase === 'action-result') {
+    return (
+      <button onClick={() => dispatch({ type: 'ACTION_RESULT_PROCEED' })}>action-proceed</button>
     );
   }
   if (state.phase === 'watch') {
@@ -52,7 +62,9 @@ function renderSpotlight() {
   fireEvent.click(screen.getByRole('button', { name: 'init' }));
   fireEvent.click(screen.getByRole('button', { name: 'start' }));
   fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'action' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'boo' }));
 }
 

--- a/src/screens/WatchScreen.test.tsx
+++ b/src/screens/WatchScreen.test.tsx
@@ -27,11 +27,21 @@ function WatchWrapper() {
       <button onClick={() => dispatch({ type: 'SCOUT_CARD', cardIndex: 0 })}>scout</button>
     );
   }
+  if (state.phase === 'scout-result') {
+    return (
+      <button onClick={() => dispatch({ type: 'SCOUT_RESULT_PROCEED' })}>scout-proceed</button>
+    );
+  }
   if (state.phase === 'action') {
     return (
       <button onClick={() => dispatch({ type: 'ACTION_PLAY', kamiIndex: 0, shimoIndex: 1 })}>
         action
       </button>
+    );
+  }
+  if (state.phase === 'action-result') {
+    return (
+      <button onClick={() => dispatch({ type: 'ACTION_RESULT_PROCEED' })}>action-proceed</button>
     );
   }
   if (state.phase === 'watch') {
@@ -49,7 +59,9 @@ function renderWatch() {
   fireEvent.click(screen.getByRole('button', { name: 'init' }));
   fireEvent.click(screen.getByRole('button', { name: 'start' }));
   fireEvent.click(screen.getByRole('button', { name: 'scout' }));
+  fireEvent.click(screen.getByRole('button', { name: 'scout-proceed' }));
   fireEvent.click(screen.getByRole('button', { name: 'action' }));
+  fireEvent.click(screen.getByRole('button', { name: 'action-proceed' }));
 }
 
 describe('WatchScreen', () => {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -21,7 +21,9 @@ export type Stage = {
 export type GamePhase =
   | 'standby'
   | 'scout'
+  | 'scout-result'
   | 'action'
+  | 'action-result'
   | 'watch'
   | 'spotlight'
   | 'spotlight-bonus'


### PR DESCRIPTION
## 概要

スカウト完了後・アクション後に結果確認画面を挟み、双方がフェーズ進行前に内容を確認できるようにする。

## 変更内容

- **GamePhase 追加**: `scout-result` / `action-result` の2フェーズ
- **ScoutResultScreen**: スカウト完了後の確認画面（手札枚数 → 「アクションへ」）
- **ActionResultScreen**: ステージ確認画面（役者札/黒子札表示 → 「ウォッチへ」）
- フェーズ遷移変更: `SCOUT_CARD` → `scout-result`、`ACTION_PLAY` → `action-result`
- 新アクション追加: `SCOUT_RESULT_PROCEED`、`ACTION_RESULT_PROCEED`
- 既存テスト（全画面ラッパー）を新フェーズ対応に更新

## Acceptance Criteria 確認

- [x] 直前に選択・開示されたカード内容を確認できる（ActionResultScreen でカミ/シモ表示）
- [x] ペア成立/不成立、ブーイング正誤、移動先が画面で分かる（既存 BackstageScreen / SpotlightRevealScreen で対応済み）
- [x] 次のフェーズへ進む前に双方が結果を確認できる（各確認画面で「次へ」ボタン押下まで遷移しない）

Closes #81