### PR TITLE
feat: 手札を数字の大きい順にソートして表示する（Issue #88）

### DIFF
--- a/src/lib/deck.test.ts
+++ b/src/lib/deck.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createDeck, createDeckWithJoker, shuffle, deal } from './deck';
+import { createDeck, createDeckWithJoker, shuffle, deal, sortHand } from './deck';
 
 describe('createDeck', () => {
   it('52枚を返す', () => {
@@ -80,5 +80,44 @@ describe('deal', () => {
   it('空配列を指定した場合は空の結果を返す', () => {
     const deck = createDeck();
     expect(deal(deck, [])).toEqual([]);
+  });
+});
+
+describe('sortHand', () => {
+  it('rankの大きい順に並ぶ', () => {
+    const hand = [
+      { suit: 'spades' as const, rank: 3, isJoker: false, isFaceUp: true },
+      { suit: 'hearts' as const, rank: 13, isJoker: false, isFaceUp: true },
+      { suit: 'clubs' as const, rank: 7, isJoker: false, isFaceUp: true },
+    ];
+    const sorted = sortHand(hand);
+    expect(sorted[0].rank).toBe(13);
+    expect(sorted[1].rank).toBe(7);
+    expect(sorted[2].rank).toBe(3);
+  });
+
+  it('Joker（rank=0）は末尾に来る', () => {
+    const hand = [
+      { suit: 'spades' as const, rank: 0, isJoker: true, isFaceUp: true },
+      { suit: 'hearts' as const, rank: 5, isJoker: false, isFaceUp: true },
+      { suit: 'clubs' as const, rank: 11, isJoker: false, isFaceUp: true },
+    ];
+    const sorted = sortHand(hand);
+    expect(sorted[sorted.length - 1].isJoker).toBe(true);
+    expect(sorted[0].rank).toBe(11);
+  });
+
+  it('元の配列を変更しない', () => {
+    const hand = [
+      { suit: 'spades' as const, rank: 5, isJoker: false, isFaceUp: true },
+      { suit: 'hearts' as const, rank: 10, isJoker: false, isFaceUp: true },
+    ];
+    const original = [...hand];
+    sortHand(hand);
+    expect(hand).toEqual(original);
+  });
+
+  it('空配列を受け取ったら空配列を返す', () => {
+    expect(sortHand([])).toEqual([]);
   });
 });

--- a/src/lib/deck.ts
+++ b/src/lib/deck.ts
@@ -26,6 +26,10 @@ export function shuffle(cards: Card[]): Card[] {
   return result;
 }
 
+export function sortHand(cards: Card[]): Card[] {
+  return [...cards].sort((a, b) => b.rank - a.rank);
+}
+
 export function deal(deck: Card[], counts: number[]): Card[][] {
   const total = counts.reduce((a, b) => a + b, 0);
   if (total > deck.length) {

--- a/src/screens/ActionScreen.tsx
+++ b/src/screens/ActionScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
 import PassDevice from '@/components/PassDevice';
+import { sortHand } from '@/lib/deck';
 import styles from './ActionScreen.module.css';
 
 type SelectionStep = 'selectingActor' | 'selectingKuroko' | 'confirmed';
@@ -15,6 +16,7 @@ export default function ActionScreen() {
   const [showPassDevice, setShowPassDevice] = useState(false);
 
   const hand = state.players[0].hand;
+  const sortedHand = sortHand(hand);
   const actionPlayer = state.players[0];
 
   const handleCardClick = (index: number) => {
@@ -101,15 +103,18 @@ export default function ActionScreen() {
       </div>
 
       <div className={styles.grid}>
-        {hand.map((card, i) => (
-          <Card
-            key={i}
-            card={{ ...card, isFaceUp: true }}
-            isSelected={i === kamiIndex}
-            isSelectedShimo={i === shimoIndex}
-            onClick={getCardOnClick(i)}
-          />
-        ))}
+        {sortedHand.map((card) => {
+          const i = hand.indexOf(card);
+          return (
+            <Card
+              key={i}
+              card={{ ...card, isFaceUp: true }}
+              isSelected={i === kamiIndex}
+              isSelectedShimo={i === shimoIndex}
+              onClick={getCardOnClick(i)}
+            />
+          );
+        })}
       </div>
 
       <button

--- a/src/screens/ScoutScreen.tsx
+++ b/src/screens/ScoutScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
+import { sortHand } from '@/lib/deck';
 import styles from './ScoutScreen.module.css';
 
 export default function ScoutScreen() {
@@ -9,6 +10,7 @@ export default function ScoutScreen() {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
   const opponentHand = state.players[1].hand;
+  const sortedOpponentHand = sortHand(opponentHand);
 
   const handleCardClick = (index: number) => {
     if (index === selectedIndex) {
@@ -28,14 +30,17 @@ export default function ScoutScreen() {
       <h1 className={styles.heading}>スカウト</h1>
       <p className={styles.sub}>相手の手札から1枚選んでください</p>
       <div className={styles.grid}>
-        {opponentHand.map((card, i) => (
-          <Card
-            key={i}
-            card={{ ...card, isFaceUp: false }}
-            isSelected={i === selectedIndex}
-            onClick={() => handleCardClick(i)}
-          />
-        ))}
+        {sortedOpponentHand.map((card) => {
+          const i = opponentHand.indexOf(card);
+          return (
+            <Card
+              key={i}
+              card={{ ...card, isFaceUp: false }}
+              isSelected={i === selectedIndex}
+              onClick={() => handleCardClick(i)}
+            />
+          );
+        })}
       </div>
       <button
         className={styles.confirmBtn}


### PR DESCRIPTION
## Summary

- `sortHand` ユーティリティを `src/lib/deck.ts` に追加（rank 降順、Joker 末尾）
- ActionScreen（役者手札）と ScoutScreen（相手手札）の表示に適用
- 表示ソート用のコピーを使い、元 state 配列は変更しない設計
- ソート表示 index → 元 index のマッピングにより、reducer への dispatch は従来通り動作

Closes #88

## Test plan

- [ ] `npx vitest run` → 289 tests passed
- [ ] `npx eslint .` → エラーなし
- [ ] `npx tsc --noEmit` → エラーなし
- [ ] ActionScreen で手札が K→A→Joker の順に表示されることを手動確認
- [ ] ScoutScreen で相手手札（裏向き）もソート順で表示されることを確認
- [ ] カード選択・dispatch が正しい元 index で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)