### PR TITLE
[Bug] BackstageScreen スキップ経由時に説明テキストを追加（Issue #105）

### DIFF
--- a/src/screens/BackstageScreen.skip.test.tsx
+++ b/src/screens/BackstageScreen.skip.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { initialState } from '@/game/reducer';
+
+vi.mock('@/game/context', () => ({
+  useGameState: () => ({ ...initialState, phase: 'backstage', spotlightCard: null }),
+  useGameDispatch: () => vi.fn(),
+}));
+
+import BackstageScreen from './BackstageScreen';
+
+describe('BackstageScreen (spotlightCard === null)', () => {
+  it('スキップ経由時に説明テキストが表示される', () => {
+    render(<BackstageScreen />);
+    expect(
+      screen.getByText('セットをオープンしなかったため、バックステージフェーズは発生しません。'),
+    ).toBeDefined();
+  });
+
+  it('スキップ経由時に「インターミッションへ」ボタンが表示される', () => {
+    render(<BackstageScreen />);
+    expect(screen.getByRole('button', { name: 'インターミッションへ' })).toBeDefined();
+  });
+});

--- a/src/screens/BackstageScreen.tsx
+++ b/src/screens/BackstageScreen.tsx
@@ -74,6 +74,9 @@ export default function BackstageScreen() {
     return (
       <div className={styles.screen}>
         <h1 className={styles.heading}>バックステージ</h1>
+        <p className={styles.instruction}>
+          セットをオープンしなかったため、バックステージフェーズは発生しません。
+        </p>
         <button
           className={styles.proceedBtn}
           onClick={() => dispatch({ type: 'BACKSTAGE_PROCEED' })}


### PR DESCRIPTION
## 概要

`spotlightCard === null` のバックステージコードパスに文脈説明テキストを追加する。

## 変更内容

- `BackstageScreen.tsx`: スキップ経由コードパスに「セットをオープンしなかったため、バックステージフェーズは発生しません。」を追加
- `BackstageScreen.skip.test.tsx`: `spotlightCard === null` 状態をモックして説明テキストとボタンの存在を確認するテストを新規追加

## テスト

- [ ] `BackstageScreen.skip.test.tsx` の新規テスト2件がパスすること
- [ ] 既存の `BackstageScreen.test.tsx` の9件がパスすること

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)