### PR TITLE
[Bug] 各画面が viewport の上半分しか使われず下が空白になる修正

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,3 +3,13 @@
   margin: 0;
   padding: 0;
 }
+
+html, body {
+  height: 100%;
+}
+
+#__next {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## Summary

- `html, body { height: 100% }` を追加し `#__next` が親の高さを継承できるようにした
- `#__next { min-height: 100dvh; display: flex; flex-direction: column; }` を追加し、各画面の `.screen { flex: 1 }` が正しく viewport 全体に伸長できるようにした
- `min-height` を使用しているためコンテンツが多い画面でのスクロールも維持される

## Test plan

- [ ] スマホサイズ（390×844px）で各ゲーム画面が viewport 全体を使って表示されることを手動確認
- [ ] TitleScreen・ResultScreen を含む全画面で同様に機能することを確認
- [ ] コンテンツが多い画面でスクロールが正常に動作することを確認

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)