### PR TITLE
feat: InfoOverlay のスコア速報にカミ合計点・手札合計点・暫定スコアを表示する

### DIFF
--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -1,4 +1,5 @@
 import type { GameState, Card } from '@/types/game';
+import { calculateScore } from '@/lib/scoring';
 import styles from './InfoOverlay.module.css';
 
 const BOO_MAX = 3;
@@ -30,6 +31,9 @@ export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
   const [playerA, playerB] = players;
 
   const booCounts = [playerABooCnt, playerBBooCnt];
+  const scoreA = calculateScore(gameState, 'A');
+  const scoreB = calculateScore(gameState, 'B');
+  const scores = [scoreA, scoreB];
 
   return (
     <div
@@ -53,13 +57,17 @@ export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
         <div className={styles.section}>
           <h4 className={styles.sectionTitle}>スコア（暫定）</h4>
           <div className={styles.scoreCompare}>
-            {[playerA, playerB].map((player) => (
+            {[playerA, playerB].map((player, i) => (
               <div key={player.id} className={styles.scoreCol}>
                 <div className={styles.sName}>{player.name}</div>
-                <div className={styles.sTotal}>{player.hand.length}</div>
+                <div className={styles.sTotal}>{scores[i].kamiTotal - scores[i].handTotal}</div>
                 <div className={styles.sRow}>
-                  <span>手札</span>
-                  <span>{player.hand.length} 枚</span>
+                  <span>カミ合計</span>
+                  <span>{scores[i].kamiTotal} 点</span>
+                </div>
+                <div className={styles.sRow}>
+                  <span>手札合計</span>
+                  <span>{scores[i].handTotal} 点</span>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## 概要

InfoOverlay のスコア速報セクションを改善し、カミ合計点・手札合計点・暫定スコアを表示するようにした。

Closes #102

## 変更内容

- `calculateScore` を活用して各プレイヤーの `kamiTotal` / `handTotal` を算出
- 大きい数字（`sTotal`）に暫定スコア（カミ合計 − 手札合計）を表示
- 詳細行にカミ合計点・手札合計点（点数）を表示
- 従来の「手札枚数」表示を廃止し、点数ベースの情報に更新

## テスト確認

- [ ] ゲームを進行し、カミ札が蓄積された状態で InfoOverlay を開いてカミ合計点・手札合計点・暫定スコアが正しく表示されることを手動確認
- [ ] 型チェック・lint パス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)