### PR TITLE
[Feature] ResultScreen にゲーム終了理由を表示する

### DIFF
--- a/src/screens/ResultScreen.module.css
+++ b/src/screens/ResultScreen.module.css
@@ -16,6 +16,13 @@
   margin: 0;
 }
 
+.reason {
+  font-size: 13px;
+  color: var(--muted, #7a8aaa);
+  margin: 0;
+  text-align: center;
+}
+
 .result {
   display: flex;
   flex-direction: column;

--- a/src/screens/ResultScreen.test.tsx
+++ b/src/screens/ResultScreen.test.tsx
@@ -44,6 +44,28 @@ function DrawWrapper() {
   return <ResultScreen />;
 }
 
+// 指定した reason で CURTAIN_CALL を発火するラッパー
+function ReasonWrapper({ reason }: { reason: 'joker' | 'set-last-1' | 'hand-shortage' }) {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase !== 'curtain-call') {
+    return (
+      <button onClick={() => dispatch({ type: 'CURTAIN_CALL', reason })}>curtain-call</button>
+    );
+  }
+  return <ResultScreen />;
+}
+
+function renderWithReason(reason: 'joker' | 'set-last-1' | 'hand-shortage') {
+  render(
+    <GameProvider>
+      <ReasonWrapper reason={reason} />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'curtain-call' }));
+}
+
 function renderResult() {
   render(
     <GameProvider>
@@ -106,5 +128,20 @@ describe('ResultScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: 'もう一度' }));
     // RESET_GAME後はstandbyフェーズ → ResultScreenが非表示
     expect(screen.queryByText('カーテンコール')).toBeNull();
+  });
+
+  it('reason=joker のとき「ジョーカーが登場しました」が表示される', () => {
+    renderWithReason('joker');
+    expect(screen.getByText('ジョーカーが登場しました')).toBeDefined();
+  });
+
+  it('reason=set-last-1 のとき正しいメッセージが表示される', () => {
+    renderWithReason('set-last-1');
+    expect(screen.getByText('セットの裏向きカードが残り1枚になりました')).toBeDefined();
+  });
+
+  it('reason=hand-shortage のとき正しいメッセージが表示される', () => {
+    renderWithReason('hand-shortage');
+    expect(screen.getByText('手札不足により継続不能となりました')).toBeDefined();
   });
 });

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -1,6 +1,13 @@
 import { useGameDispatch, useGameState } from '@/game/context';
 import { calculateScore } from '@/lib/scoring';
+import type { CurtainCallReason } from '@/types/game';
 import styles from './ResultScreen.module.css';
+
+const CURTAIN_CALL_REASON_LABEL: Record<CurtainCallReason, string> = {
+  joker: 'ジョーカーが登場しました',
+  'set-last-1': 'セットの裏向きカードが残り1枚になりました',
+  'hand-shortage': '手札不足により継続不能となりました',
+};
 
 export default function ResultScreen() {
   const state = useGameState();
@@ -18,6 +25,10 @@ export default function ResultScreen() {
   return (
     <div className={styles.screen}>
       <h1 className={styles.heading}>カーテンコール</h1>
+
+      {state.curtainCallReason && (
+        <p className={styles.reason}>{CURTAIN_CALL_REASON_LABEL[state.curtainCallReason]}</p>
+      )}
 
       <div className={styles.result}>
         {winner === 'draw' ? (


### PR DESCRIPTION
## 概要

`state.curtainCallReason` を参照し、ResultScreen のスコア表示上部にゲーム終了理由を日本語で表示する。

## 変更内容

- `ResultScreen.tsx`: `curtainCallReason` → 日本語メッセージのマッピングを定義し、`null` 以外の場合に表示
- `ResultScreen.module.css`: `.reason` スタイルを追加
- `ResultScreen.test.tsx`: 3種類の reason に対するテストを追加（計10テスト、全パス）

## Acceptance Criteria

- [x] ResultScreen に終了理由が日本語で表示される
- [x] 3種類の curtainCallReason それぞれに対して正しいメッセージが表示される
- [x] `curtainCallReason` が `null` の場合は終了理由が表示されない

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)