### PR TITLE
[Feature] ゲーム中に蓄積されたカミ札一覧を確認できるようにする

### DIFF
--- a/src/components/InfoOverlay.module.css
+++ b/src/components/InfoOverlay.module.css
@@ -161,6 +161,27 @@
   color: var(--gold, #f0c060);
 }
 
+.kamiList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+  justify-content: center;
+}
+
+.kamiChip {
+  font-size: 10px;
+  padding: 2px 5px;
+  background: var(--bg, #0f172a);
+  border-radius: 4px;
+  color: var(--text, #e0e6f0);
+}
+
+.kamiEmpty {
+  font-size: 10px;
+  color: var(--muted, #7a8aaa);
+}
+
 .knownCardsList {
   display: flex;
   flex-direction: column;

--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -78,6 +78,23 @@ describe('InfoOverlay', () => {
     expect(screen.getByText('♠5')).toBeDefined();
   });
 
+  it('カミ札が0枚の場合は「なし」が表示される', () => {
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={baseState} />);
+    const nasiElements = screen.getAllByText('なし');
+    expect(nasiElements.length).toBe(2);
+  });
+
+  it('カミ札がある場合はランク＋スート形式で表示される', () => {
+    const state: GameState = {
+      ...baseState,
+      playerAKami: [{ suit: 'spades', rank: 13, isJoker: false, isFaceUp: true }],
+      playerBKami: [{ suit: 'hearts', rank: 7, isJoker: false, isFaceUp: true }],
+    };
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={state} />);
+    expect(screen.getByText('♠K')).toBeDefined();
+    expect(screen.getByText('♥7')).toBeDefined();
+  });
+
   it('バックドロップタップでonCloseが呼ばれる', () => {
     const handleClose = vi.fn();
     render(<InfoOverlay isOpen={true} onClose={handleClose} gameState={baseState} />);

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -27,10 +27,11 @@ type Props = {
 };
 
 export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
-  const { players, playerABooCnt, playerBBooCnt, setRemainingCount, publicInfos } = gameState;
+  const { players, playerABooCnt, playerBBooCnt, setRemainingCount, publicInfos, playerAKami, playerBKami } = gameState;
   const [playerA, playerB] = players;
 
   const booCounts = [playerABooCnt, playerBBooCnt];
+  const kamiCards = [playerAKami, playerBKami];
   const scoreA = calculateScore(gameState, 'A');
   const scoreB = calculateScore(gameState, 'B');
   const scores = [scoreA, scoreB];
@@ -68,6 +69,17 @@ export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
                 <div className={styles.sRow}>
                   <span>手札合計</span>
                   <span>{scores[i].handTotal} 点</span>
+                </div>
+                <div className={styles.kamiList}>
+                  {kamiCards[i].length === 0 ? (
+                    <span className={styles.kamiEmpty}>なし</span>
+                  ) : (
+                    kamiCards[i].map((card, j) => (
+                      <span key={j} className={styles.kamiChip}>
+                        {suitLabel(card)}{rankLabel(card)}
+                      </span>
+                    ))
+                  )}
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## 概要

InfoOverlay のスコアセクションに、各プレイヤーが獲得したカミ札一覧を追加する。

## 変更内容

- `InfoOverlay.tsx`: `playerAKami` / `playerBKami` を各プレイヤーのスコアカラムに展開して表示
- `InfoOverlay.module.css`: `.kamiList` / `.kamiChip` / `.kamiEmpty` スタイルを追加
- `InfoOverlay.test.tsx`: カミ札0枚時「なし」表示・カードのランク+スート表示の2ケースを追加

## AC 確認

- [x] InfoOverlay を開くと各プレイヤーの獲得カミ札一覧が表示される
- [x] カミ札が0枚の場合は「なし」と表示される
- [x] カードはランク＋スートで識別できる形式で表示される（例: ♠K, ♥7）

## テスト

- lint: ✅ 通過
- test: ✅ 296 passed (25 files)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)