### PR TITLE
[Bug] ジョーカー公開時の追加セット処理を実装（Issue #114）

### DIFF
--- a/.claude/hooks/guardrail.py
+++ b/.claude/hooks/guardrail.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import sys
+import json
+import re
+import os
+import fnmatch
+
+# デフォルトの機密ファイル遮断パターン（os-template.yml 未設定時のフォールバック）
+_DEFAULT_BLOCKED_PATTERNS = [
+    ".env",
+    ".env.*",
+    "**/.env",
+    "**/.env.*",
+    "credentials*",
+    "**/secret*",
+]
+
+def _load_blocked_patterns():
+    """os-template.yml から security.blocked_file_patterns を読み込む。
+    未設定・読み込み失敗時はデフォルトパターンを返す。"""
+    try:
+        hooks_dir = os.path.dirname(os.path.abspath(__file__))
+        repo_root = os.path.dirname(hooks_dir)
+        scripts_lib = os.path.join(repo_root, "scripts", "lib")
+        os_template = os.path.join(repo_root, "os-template.yml")
+
+        sys.path.insert(0, scripts_lib)
+        from config import get_value
+        patterns = get_value(os_template, "security.blocked_file_patterns")
+        if patterns and isinstance(patterns, list) and len(patterns) > 0:
+            return patterns
+    except Exception:
+        pass
+    return _DEFAULT_BLOCKED_PATTERNS
+
+def _is_blocked(path, patterns):
+    """path が patterns のいずれかにマッチすれば True を返す。"""
+    name = os.path.basename(str(path))
+    full = str(path)
+    for p in patterns:
+        # ファイル名マッチ（glob プレフィックスを除いた末尾パターンで照合）
+        basename_pattern = p.lstrip("**/").lstrip("/")
+        if fnmatch.fnmatch(name, basename_pattern):
+            return True
+        # フルパスマッチ
+        if fnmatch.fnmatch(full, p):
+            return True
+    return False
+
+def main():
+    try:
+        input_data = sys.stdin.read()
+        if not input_data.strip():
+            sys.exit(0)
+
+        payload = json.loads(input_data)
+        tool_name = payload.get("tool_name", "")
+        tool_input = payload.get("tool_input", {})
+
+        # We care about tools that could modify or read files, or execute commands
+        file_tools = {"Read", "Write", "Edit", "Glob", "LS", "ViewDocument"}
+
+        # Tools that access files uses either file_path, path, file, or pattern
+        target_path = tool_input.get("file_path", "") or tool_input.get("path", "") or tool_input.get("pattern", "") or tool_input.get("file", "")
+
+        blocked_patterns = _load_blocked_patterns()
+
+        is_secret = False
+        if target_path:
+            is_secret = _is_blocked(target_path, blocked_patterns)
+
+        if tool_name in file_tools and is_secret:
+            print(f"SECURITY BLOCK: Access to secret file '{target_path}' is strictly prohibited by AI-First-Development-Operating-System rules.", file=sys.stderr)
+            sys.exit(2)
+
+        if tool_name == "Bash":
+            command = tool_input.get("command", "")
+            # Check for secrets passing in command
+            if any(re.search(r'\b' + p + r'\b', str(command), re.IGNORECASE) for p in ["\.env", "credentials"]):
+                print(f"SECURITY BLOCK: Bash command references a secret file. Command blocked.", file=sys.stderr)
+                sys.exit(2)
+
+            # Check for external URLs via bash
+            url_tools = ["curl", "wget"]
+            if any(tool in str(command) for tool in url_tools):
+                print(f"SECURITY WARNING: External network request detected in Bash command. Proceed with caution.", file=sys.stderr)
+
+        if tool_name == "Fetch":
+            print(f"SECURITY WARNING: External network request (Fetch tool) detected. Proceed with caution.", file=sys.stderr)
+
+        sys.exit(0)
+
+    except Exception as e:
+        # If the hook fails for any reason, don't crash Claude Code
+        print(f"Hook Execution Warning: {e}", file=sys.stderr)
+        sys.exit(0)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)  # 最終安全網: 想定外のクラッシュでも fail-open

--- a/.claude/skills/istart/SKILL.md
+++ b/.claude/skills/istart/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: istart
+description: 次に着手すべき Issue を自動判断して作業を開始する。コンテキスト同期・Issue選定・ブランチ作成・計画立案まで一気通貫で行う。
+disable-model-invocation: true
+allowed-tools: Read, Bash(gh issue list *), Bash(gh issue view *), Bash(git checkout *), Bash(git pull *), EnterPlanMode
+---
+
+# Issue スタート
+
+次に着手すべき Issue を自動判断して、作業を即開始する。
+
+## 手順
+
+### 1. コンテキスト把握
+
+`.ai-context.md` を読んで以下を確認する：
+- 現在の Status（works / broken）
+- Active Issues（すでに進行中のものがないか）
+- Completed（完了済みの Issue 番号）
+- Next actions（推奨されている次の手）
+
+### 2. オープン Issue を取得
+
+```
+gh issue list --state open --limit 50 --json number,title,labels,milestone,assignees
+```
+
+取得したリストから **着手すべき Issue** を以下の優先順位で選ぶ：
+
+1. `.ai-context.md` の `Next actions` に明示されているもの
+2. 依存 Issue がすべて完了しているもの（本文の "依存" / "Depends on" を確認）
+3. Issue 番号が若いもの（小さい数字 = 古い Issue = 先行依存を満たしている可能性が高い）
+
+**スキップ条件（以下は選ばない）**：
+- すでに Active Issues に含まれている（進行中）
+- PR が作成済みでマージ待ち
+- ラベルに `blocked` や `wontfix` がついている
+- タイトルや本文に「依存：#N」があり、#N が未完了
+
+### 3. 選定した Issue の詳細を読む
+
+```
+gh issue view <number>
+```
+
+Issue の以下を把握する：
+- 概要・背景
+- Acceptance Criteria（AC）
+- Non-goals
+- Commit Plan（実装コミット分割）
+
+### 4. ブランチを作成して作業開始
+
+```bash
+# main を最新化
+git checkout main && git pull origin main
+
+# feature ブランチを作成
+git checkout -b feature/issue-<number>
+```
+
+### 5. 計画を立案してユーザーに提示
+
+`/plan` モードに入り、以下を提示する：
+
+- **対象 Issue**: #番号 タイトル
+- **AC まとめ**: 何を満たせば完了か
+- **実装方針**: どのファイルを変更するか、アーキテクチャ上の注意点
+- **Commit Plan**: 何を何回のコミットに分けるか
+- **懸念事項**: Known pitfalls に関連するリスク
+
+ユーザーの承認を得てから実装に入る。
+
+## 出力フォーマット
+
+```
+## istart: Issue #<N> を開始します
+
+### 選定理由
+- <なぜこの Issue を選んだか>
+
+### Issue 概要
+- タイトル: ...
+- AC:
+  - [ ] ...
+  - [ ] ...
+
+### 実装計画
+...
+
+### ブランチ
+`feature/issue-<N>` を作成済み
+
+---
+計画に問題がなければ実装を始めます。修正があれば教えてください。
+```
+
+## ルール
+
+- **Active Issues がすでに存在する場合**は、その Issue の状態（PR作成済み？マージ待ち？）を確認し、ユーザーに報告してから次の Issue を選ぶ
+- 着手すべき Issue が見つからない場合（全部 blocked / 全完了）は、ユーザーにその旨を報告して止まる
+- Issue を選んだ理由は必ず明示する（ブラックボックスにしない）
+- ブランチが既に存在する場合は `git checkout feature/issue-<N>` で切り替え（強制削除しない）
+- 計画提示後、ユーザーの承認なしに実装を始めない

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -43,6 +43,7 @@ export default function GameRouter() {
       case 'spotlight':
         return <SpotlightRevealScreen />;
       case 'spotlight-bonus':
+      case 'spotlight-joker':
         return <SpotlightBonusScreen />;
       case 'backstage':
       case 'backstage-result':

--- a/src/game/phaseGuide.ts
+++ b/src/game/phaseGuide.ts
@@ -14,6 +14,7 @@ const PHASE_NAMES: Record<GameState['phase'], string> = {
   watch: 'ウォッチフェーズ',
   spotlight: 'スポットライト',
   'spotlight-bonus': 'スポットライトボーナス',
+  'spotlight-joker': 'スポットライト（ジョーカー）',
   backstage: 'バックステージ',
   'backstage-result': 'バックステージ結果',
   intermission: '幕間',
@@ -37,6 +38,7 @@ export function getPhaseGuide(state: GameState): PhaseGuide {
     case 'watch':
     case 'spotlight':
     case 'spotlight-bonus':
+    case 'spotlight-joker':
       activePlayerName = p1.name;
       break;
     case 'backstage':

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -250,12 +250,12 @@ describe('gameReducer', () => {
       expect(result).toBe(initialState);
     });
 
-    it('ジョーカーを開いたとき curtain-call に遷移する', () => {
+    it('ジョーカーを開いたとき spotlight-joker に遷移し、ジョーカーが stage.shimo に格納される', () => {
       const jokerIndex = bonusState.deck.findIndex((c) => c.isJoker);
       if (jokerIndex === -1) return; // jokerがない場合はスキップ
       const result = gameReducer(bonusState, { type: 'SPOTLIGHT_OPEN_SET', setCardIndex: jokerIndex });
-      expect(result.phase).toBe('curtain-call');
-      expect(result.curtainCallReason).toBe('joker');
+      expect(result.phase).toBe('spotlight-joker');
+      expect(result.stage.shimo?.isJoker).toBe(true);
     });
 
     it('setRemainingCount が減少する', () => {
@@ -392,6 +392,67 @@ describe('gameReducer', () => {
       const result = gameReducer(s8, { type: 'SPOTLIGHT_SKIP_SET' });
       expect(result.phase).toBe('intermission');
       expect(result.backstagePlayerId).toBeNull();
+    });
+  });
+
+  describe('SPOTLIGHT_OPEN_JOKER_EXTRA', () => {
+    const mk = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+    const joker: Card = { suit: 'spades', rank: 0, isJoker: true, isFaceUp: true };
+
+    // spotlight-joker 状態：ジョーカーが stage.shimo に格納されている
+    const jokerPhaseState: GameState = {
+      phase: 'spotlight-joker',
+      booResult: 'incorrect',
+      players: [
+        { id: 'A', name: 'A', hand: [mk(3), mk(7)] },
+        { id: 'B', name: 'B', hand: [mk(5), mk(9)] },
+      ],
+      stage: { kami: { ...mk(4), isFaceUp: true }, shimo: joker },
+      deck: [mk(6), mk(11), mk(8)],
+      backstage: [],
+      setRemainingCount: 3,
+      publicInfos: [],
+      playerABooCnt: 0,
+      playerBBooCnt: 0,
+      playerAKami: [],
+      playerBKami: [],
+      playerAShimo: [],
+      playerBShimo: [],
+      round: 1,
+      curtainCallReason: null,
+      spotlightCard: null,
+      backstageRevealedCards: [],
+      backstageResult: null,
+      backstagePlayerId: null,
+    };
+
+    it('SPOTLIGHT_OPEN_JOKER_EXTRA で curtain-call に遷移する', () => {
+      const result = gameReducer(jokerPhaseState, { type: 'SPOTLIGHT_OPEN_JOKER_EXTRA', setCardIndex: 0 });
+      expect(result.phase).toBe('curtain-call');
+      expect(result.curtainCallReason).toBe('joker');
+    });
+
+    it('booResult=incorrect のとき追加カードが players[0] のカミに、ジョーカーがシモに記録される', () => {
+      const result = gameReducer(jokerPhaseState, { type: 'SPOTLIGHT_OPEN_JOKER_EXTRA', setCardIndex: 0 });
+      expect(result.playerAKami).toHaveLength(1);
+      expect(result.playerAKami[0].rank).toBe(6);
+      expect(result.playerAShimo).toHaveLength(1);
+      expect(result.playerAShimo[0].isJoker).toBe(true);
+      expect(result.playerBKami).toHaveLength(0);
+    });
+
+    it('booResult=correct のとき追加カードが players[1] のカミに、ジョーカーがシモに記録される', () => {
+      const correctState: GameState = { ...jokerPhaseState, booResult: 'correct' };
+      const result = gameReducer(correctState, { type: 'SPOTLIGHT_OPEN_JOKER_EXTRA', setCardIndex: 0 });
+      expect(result.playerBKami).toHaveLength(1);
+      expect(result.playerBShimo).toHaveLength(1);
+      expect(result.playerBShimo[0].isJoker).toBe(true);
+      expect(result.playerAKami).toHaveLength(0);
+    });
+
+    it('spotlight-joker 以外では無効', () => {
+      const result = gameReducer(initialState, { type: 'SPOTLIGHT_OPEN_JOKER_EXTRA', setCardIndex: 0 });
+      expect(result).toBe(initialState);
     });
   });
 

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -14,6 +14,7 @@ export type GameAction =
   | { type: 'SPOTLIGHT_REVEAL' }
   | { type: 'SPOTLIGHT_ENTER_BONUS' }
   | { type: 'SPOTLIGHT_OPEN_SET'; setCardIndex: number }
+  | { type: 'SPOTLIGHT_OPEN_JOKER_EXTRA'; setCardIndex: number }
   | { type: 'SPOTLIGHT_SKIP_SET' }
   | { type: 'BACKSTAGE_OPEN'; cardIndices: [number, number, number] }
   | { type: 'BACKSTAGE_PROCEED' }
@@ -207,8 +208,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
           ...state,
           deck: newDeck,
           setRemainingCount: newSetRemainingCount,
-          phase: 'curtain-call',
-          curtainCallReason: 'joker',
+          stage: { ...state.stage, shimo: openedCard },
+          phase: 'spotlight-joker',
         };
       }
       if (newSetRemainingCount <= 1) {
@@ -258,6 +259,31 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         phase: 'backstage',
         backstagePlayerId,
       };
+    }
+
+    case 'SPOTLIGHT_OPEN_JOKER_EXTRA': {
+      if (state.phase !== 'spotlight-joker') return state;
+      const setCard = state.deck[action.setCardIndex];
+      if (setCard === undefined) return state;
+
+      const openedCard: Card = { ...setCard, isFaceUp: true };
+      const newDeck = [...state.deck];
+      newDeck[action.setCardIndex] = openedCard;
+
+      // boo 正解: watcher(players[1])が勝者、不正解: actor(players[0])が勝者
+      const booCorrect = state.booResult === 'correct';
+      const winnerId = booCorrect ? state.players[1].id : state.players[0].id;
+
+      // stage.shimo にジョーカーが格納されているので addKamiToPlayer でそのまま記録される
+      const jokerState = {
+        ...state,
+        deck: newDeck,
+        setRemainingCount: state.setRemainingCount - 1,
+        stage: { kami: openedCard, shimo: state.stage.shimo },
+        phase: 'curtain-call' as const,
+        curtainCallReason: 'joker' as const,
+      };
+      return addKamiToPlayer(jokerState, winnerId, openedCard);
     }
 
     case 'SPOTLIGHT_SKIP_SET': {

--- a/src/screens/SpotlightBonusScreen.tsx
+++ b/src/screens/SpotlightBonusScreen.tsx
@@ -6,6 +6,8 @@ export default function SpotlightBonusScreen() {
   const state = useGameState();
   const dispatch = useGameDispatch();
 
+  const isJokerPhase = state.phase === 'spotlight-joker';
+
   const faceDownCards = state.deck
     .map((card, index) => ({ card, index }))
     .filter(({ card }) => !card.isFaceUp);
@@ -13,24 +15,34 @@ export default function SpotlightBonusScreen() {
   return (
     <div className={styles.screen}>
       <h1 className={styles.heading}>セットを開く</h1>
-      <p className={styles.instruction}>裏向きのカードを1枚選んでください</p>
+      {isJokerPhase ? (
+        <p className={styles.instruction}>ジョーカーが出ました！追加で1枚開いてください</p>
+      ) : (
+        <p className={styles.instruction}>裏向きのカードを1枚選んでください</p>
+      )}
 
       <div className={styles.cardGrid}>
         {faceDownCards.map(({ card, index }) => (
           <Card
             key={index}
             card={card}
-            onClick={() => dispatch({ type: 'SPOTLIGHT_OPEN_SET', setCardIndex: index })}
+            onClick={() =>
+              isJokerPhase
+                ? dispatch({ type: 'SPOTLIGHT_OPEN_JOKER_EXTRA', setCardIndex: index })
+                : dispatch({ type: 'SPOTLIGHT_OPEN_SET', setCardIndex: index })
+            }
           />
         ))}
       </div>
 
-      <button
-        className={styles.cancelBtn}
-        onClick={() => dispatch({ type: 'SPOTLIGHT_SKIP_SET' })}
-      >
-        開かない
-      </button>
+      {!isJokerPhase && (
+        <button
+          className={styles.cancelBtn}
+          onClick={() => dispatch({ type: 'SPOTLIGHT_SKIP_SET' })}
+        >
+          開かない
+        </button>
+      )}
     </div>
   );
 }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -27,6 +27,7 @@ export type GamePhase =
   | 'watch'
   | 'spotlight'
   | 'spotlight-bonus'
+  | 'spotlight-joker'
   | 'backstage'
   | 'backstage-result'
   | 'intermission'


### PR DESCRIPTION
## 概要

スポットライトボーナスでジョーカーを開いた場合、ルールに従った追加処理（もう1枚セットを開く→カミ/シモ記録→カーテンコール）を実装した。

## 変更内容

- `GamePhase` に `spotlight-joker` を追加
- `SPOTLIGHT_OPEN_SET` のジョーカー分岐を `curtain-call` 即遷移から `spotlight-joker` 遷移に変更（ジョーカーを `stage.shimo` に格納）
- `SPOTLIGHT_OPEN_JOKER_EXTRA` アクションを追加（追加カード選択 → カミ/シモ記録 → `curtain-call`）
- `SpotlightBonusScreen` を `spotlight-joker` フェーズに対応（別メッセージ・別dispatch・キャンセル非表示）
- `GameRouter` / `phaseGuide` に `spotlight-joker` を追加

## テスト

- `SPOTLIGHT_OPEN_SET` ジョーカーテスト更新（curtain-call → spotlight-joker 遷移）
- `SPOTLIGHT_OPEN_JOKER_EXTRA` テスト4件追加
- 全300テストパス / lint・typecheck クリーン

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)