### PR TITLE
[Bug] InfoOverlay が役割交代後に A/B の情報を取り違えるバグを修正（Issue #115）

### DIFF
--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -6,8 +6,8 @@ import type { GameState } from '@/types/game';
 const baseState: GameState = {
   phase: 'scout',
   players: [
-    { id: 'a', name: 'アリス', hand: [] },
-    { id: 'b', name: 'ボブ', hand: [] },
+    { id: 'A', name: 'アリス', hand: [] },
+    { id: 'B', name: 'ボブ', hand: [] },
   ],
   stage: { kami: null, shimo: null },
   deck: [],
@@ -70,7 +70,7 @@ describe('InfoOverlay', () => {
       ...baseState,
       publicInfos: [
         {
-          playerId: 'a',
+          playerId: 'A',
           card: { suit: 'spades', rank: 5, isJoker: false, isFaceUp: true },
           round: 1,
         },
@@ -107,14 +107,16 @@ describe('InfoOverlay', () => {
         { id: 'B', name: 'ボブ', hand: [] },
         { id: 'A', name: 'アリス', hand: [] },
       ],
-      playerABooCnt: 0,
-      playerBBooCnt: 3,
+      playerABooCnt: 1,
+      playerBBooCnt: 2,
     };
     render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={state} />);
-    // ブーイングセクション: players[0]=B(ボブ) → 「3 / 3」、players[1]=A(アリス) → 「0 / 3」 が正しい
-    const counts = screen.getAllByText(/\d+ \/ 3/);
-    expect(counts[0].textContent).toBe('3 / 3');
-    expect(counts[1].textContent).toBe('0 / 3');
+    // 「1 / 3」(Aのブーイング数) が表示されている行に「アリス」が含まれるべき
+    // Bug時: players[0]=ボブ に Aのデータ(1)が表示されるため「ボブ」が含まれてしまう
+    const oneThirdSpan = screen.getAllByText('1 / 3')[0];
+    expect(oneThirdSpan.parentElement?.parentElement?.textContent).toContain('アリス');
+    const twoThirdSpan = screen.getAllByText('2 / 3')[0];
+    expect(twoThirdSpan.parentElement?.parentElement?.textContent).toContain('ボブ');
   });
 
   it('バックドロップタップでonCloseが呼ばれる', () => {

--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -99,6 +99,24 @@ describe('InfoOverlay', () => {
     expect(screen.getAllByText('♥7').length).toBeGreaterThan(0);
   });
 
+  it('swap後（偶数ラウンド）もA/Bのブーイング数が正しいプレイヤー欄に表示される', () => {
+    // players が swap された状態（偶数ラウンド）を再現
+    const state: GameState = {
+      ...baseState,
+      players: [
+        { id: 'B', name: 'ボブ', hand: [] },
+        { id: 'A', name: 'アリス', hand: [] },
+      ],
+      playerABooCnt: 0,
+      playerBBooCnt: 3,
+    };
+    render(<InfoOverlay isOpen={true} onClose={() => {}} gameState={state} />);
+    // ブーイングセクション: players[0]=B(ボブ) → 「3 / 3」、players[1]=A(アリス) → 「0 / 3」 が正しい
+    const counts = screen.getAllByText(/\d+ \/ 3/);
+    expect(counts[0].textContent).toBe('3 / 3');
+    expect(counts[1].textContent).toBe('0 / 3');
+  });
+
   it('バックドロップタップでonCloseが呼ばれる', () => {
     const handleClose = vi.fn();
     render(<InfoOverlay isOpen={true} onClose={handleClose} gameState={baseState} />);

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -28,7 +28,8 @@ type Props = {
 
 export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
   const { players, playerABooCnt, playerBBooCnt, setRemainingCount, publicInfos, playerAKami, playerBKami, playerAShimo, playerBShimo, stage } = gameState;
-  const [playerA, playerB] = players;
+  const playerA = players.find((p) => p.id === 'A')!;
+  const playerB = players.find((p) => p.id === 'B')!;
 
   const booCounts = [playerABooCnt, playerBBooCnt];
   const kamiCards = [playerAKami, playerBKami];


### PR DESCRIPTION
## 概要

偶数ラウンドで `players` 配列が swap されると、InfoOverlay の各セクション（スコア・ブーイング・蓄積ペア）で名前と表示データが一致しなくなるバグを修正。

## 変更内容

**`InfoOverlay.tsx`**
- `const [playerA, playerB] = players` → `players.find((p) => p.id === 'A'/'B')` に変更
- players 配列の順序に依存しない id 基準の参照に統一

**`InfoOverlay.test.tsx`**
- swap 後の再現テストを追加（`players[0]=B` 状態でブーイング数の名前対応を検証）
- `baseState` の player ID を小文字 `a/b` → 大文字 `A/B` に修正（実際の reducer と統一）

## Acceptance Criteria

- [x] 偶数ラウンドでも A/B の名前とスコア内訳が一致する
- [x] ブーイング回数と蓄積ペアが正しいプレイヤー欄に表示される
- [x] InfoOverlay のテストに swap 後ケースが追加される

## テスト

- `npx vitest run` → 301 tests passed
- `npx eslint .` → エラーなし

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)