### PR TITLE
[Bug] バックステージ公開情報に位置情報を追加（Issue #116）

### DIFF
--- a/src/components/InfoOverlay.module.css
+++ b/src/components/InfoOverlay.module.css
@@ -256,3 +256,9 @@
   color: var(--muted, #7a8aaa);
   font-size: 10px;
 }
+
+.knownCardPos {
+  color: var(--gold, #f0c060);
+  font-size: 10px;
+  font-weight: bold;
+}

--- a/src/components/InfoOverlay.test.tsx
+++ b/src/components/InfoOverlay.test.tsx
@@ -73,6 +73,7 @@ describe('InfoOverlay', () => {
           playerId: 'A',
           card: { suit: 'spades', rank: 5, isJoker: false, isFaceUp: true },
           round: 1,
+          backstageIndex: 2,
         },
       ],
     };

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -199,6 +199,9 @@ export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
                   <span className={styles.knownCardLoc}>
                     {players.find((p) => p.id === info.playerId)?.name ?? info.playerId}
                   </span>
+                  <span className={styles.knownCardPos}>
+                    {info.backstageIndex + 1}枚目
+                  </span>
                 </div>
               ))
             )}

--- a/src/game/publicInfo.test.ts
+++ b/src/game/publicInfo.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { buildPublicInfos } from './publicInfo';
+import type { Card } from '@/types/game';
+
+const c = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+
+describe('buildPublicInfos', () => {
+  it('backstageIndex を各エントリに保持する', () => {
+    const result = buildPublicInfos([], [c(3), c(7), c(10)], 'A', 1, [2, 5, 8]);
+    expect(result[0].backstageIndex).toBe(2);
+    expect(result[1].backstageIndex).toBe(5);
+    expect(result[2].backstageIndex).toBe(8);
+  });
+
+  it('既存エントリを保持しつつ追記する', () => {
+    const existing = [{ playerId: 'A', card: c(1), round: 1, backstageIndex: 0 }];
+    const result = buildPublicInfos(existing, [c(5)], 'B', 2, [3]);
+    expect(result).toHaveLength(2);
+    expect(result[1].backstageIndex).toBe(3);
+  });
+});

--- a/src/game/publicInfo.ts
+++ b/src/game/publicInfo.ts
@@ -5,9 +5,26 @@ export function buildPublicInfos(
   cards: Card[],
   playerId: string,
   round: number,
+  indices: number[],
 ): PublicInfo[] {
   return [
     ...existing,
-    ...cards.map((card) => ({ playerId, card, round })),
+    ...cards.map((card, i) => ({ playerId, card, round, backstageIndex: indices[i] })),
   ];
+}
+
+/** backstage から index `removedIndex` のカードが削除された後、publicInfos を整合させる。
+ * 削除されたカードのエントリを取り除き、それより大きいインデックスを 1 デクリメントする。
+ */
+export function shiftPublicInfosAfterRemoval(
+  infos: PublicInfo[],
+  removedIndex: number,
+): PublicInfo[] {
+  return infos
+    .filter((info) => info.backstageIndex !== removedIndex)
+    .map((info) =>
+      info.backstageIndex > removedIndex
+        ? { ...info, backstageIndex: info.backstageIndex - 1 }
+        : info,
+    );
 }

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -578,7 +578,7 @@ describe('gameReducer', () => {
       expect(final.backstage).toHaveLength(backstageBefore - 1);
     });
 
-    it('BACKSTAGE_OPEN でペア成立時も publicInfos に3件記録される', () => {
+    it('BACKSTAGE_OPEN でペア成立時、publicInfos は +3 後にマッチ分 -1 で net +2 になる', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });
       const s3 = gameReducer(s2, { type: 'SCOUT_CARD', cardIndex: 0 });
@@ -607,18 +607,21 @@ describe('gameReducer', () => {
         cardIndices: [pairIdx, others[0], others[1]],
       });
       expect(result.backstageResult).toBe('match');
-      expect(result.publicInfos.length).toBe(before + 3);
+      // 3件追加、マッチしたカードの publicInfo が削除されるため net +2
+      expect(result.publicInfos.length).toBe(before + 2);
     });
 
-    it('BACKSTAGE_TAKE_HAND で取得したカードは publicInfos に含まれない', () => {
+    it('BACKSTAGE_TAKE_HAND で取得したカードの publicInfo が削除される', () => {
       const state = buildBackstageState();
       if (!state) return;
       const resultState = gameReducer(state, { type: 'BACKSTAGE_OPEN', cardIndices: [0, 1, 2] });
       if (resultState.backstageResult !== 'no-match') return;
       const countBefore = resultState.publicInfos.length;
       const final = gameReducer(resultState, { type: 'BACKSTAGE_TAKE_HAND', cardIndex: 0 });
-      // 手札に加えたカードで publicInfos は増えない
-      expect(final.publicInfos.length).toBe(countBefore);
+      // 手札に取ったカードの publicInfo が削除される → 1件減る
+      expect(final.publicInfos.length).toBe(countBefore - 1);
+      // 残存エントリのインデックスはすべて現在の backstage 長内に収まる
+      expect(final.publicInfos.every((p) => p.backstageIndex < final.backstage.length)).toBe(true);
     });
 
     it('BACKSTAGE_OPEN で publicInfos に backstageIndex が記録される', () => {

--- a/src/game/reducer.test.ts
+++ b/src/game/reducer.test.ts
@@ -621,6 +621,125 @@ describe('gameReducer', () => {
       expect(final.publicInfos.length).toBe(countBefore);
     });
 
+    it('BACKSTAGE_OPEN で publicInfos に backstageIndex が記録される', () => {
+      const mk = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+      const backstage: Card[] = Array.from({ length: 10 }, (_, i) => mk(i + 1));
+      const state: GameState = {
+        phase: 'backstage',
+        booResult: 'incorrect',
+        players: [
+          { id: 'A', name: 'A', hand: [mk(1)] },
+          { id: 'B', name: 'B', hand: [mk(2)] },
+        ],
+        stage: { kami: null, shimo: null },
+        deck: [],
+        backstage,
+        setRemainingCount: 0,
+        publicInfos: [],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        playerAShimo: [],
+        playerBShimo: [],
+        round: 1,
+        curtainCallReason: null,
+        spotlightCard: null,
+        backstageRevealedCards: [],
+        backstageResult: null,
+        backstagePlayerId: 'B',
+      };
+      const result = gameReducer(state, { type: 'BACKSTAGE_OPEN', cardIndices: [2, 5, 7] });
+      const indices = result.publicInfos.map((p) => p.backstageIndex);
+      expect(indices).toEqual([2, 5, 7]);
+    });
+
+    it('BACKSTAGE_OPEN でペア成立時、残存 publicInfos の backstageIndex がシフトされる', () => {
+      const mk = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+      // backstage[4] (rank=5) がスポットライト (rank=5) とペア成立
+      const backstage: Card[] = Array.from({ length: 10 }, (_, i) => mk(i + 1));
+      const state: GameState = {
+        phase: 'backstage',
+        booResult: 'incorrect',
+        players: [
+          { id: 'A', name: 'A', hand: [mk(1)] },
+          { id: 'B', name: 'B', hand: [mk(2)] },
+        ],
+        stage: { kami: null, shimo: null },
+        deck: [],
+        backstage,
+        setRemainingCount: 0,
+        // 事前に index=6, index=8 が公開済み
+        publicInfos: [
+          { playerId: 'B', card: mk(7), round: 1, backstageIndex: 6 },
+          { playerId: 'B', card: mk(9), round: 1, backstageIndex: 8 },
+        ],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        playerAShimo: [],
+        playerBShimo: [],
+        round: 2,
+        curtainCallReason: null,
+        spotlightCard: mk(5),
+        backstageRevealedCards: [],
+        backstageResult: null,
+        backstagePlayerId: 'B',
+      };
+      // cardIndices=[3,4,7]: index=4 (rank=5) がペア成立 → backstage から削除
+      const result = gameReducer(state, { type: 'BACKSTAGE_OPEN', cardIndices: [3, 4, 7] });
+      expect(result.backstageResult).toBe('match');
+      // 既存の index=6 → 5（index=4 削除により 1 シフト）
+      // 既存の index=8 → 7
+      const existing = result.publicInfos.filter((p) => p.round === 1);
+      expect(existing[0].backstageIndex).toBe(5);
+      expect(existing[1].backstageIndex).toBe(7);
+    });
+
+    it('BACKSTAGE_TAKE_HAND 後、取得カードの publicInfo が削除され残存インデックスがシフトされる', () => {
+      const mk = (rank: number): Card => ({ suit: 'spades', rank, isJoker: false, isFaceUp: false });
+      const backstage: Card[] = Array.from({ length: 8 }, (_, i) => mk(i + 1));
+      const state: GameState = {
+        phase: 'backstage-result',
+        booResult: 'incorrect',
+        players: [
+          { id: 'A', name: 'A', hand: [mk(1)] },
+          { id: 'B', name: 'B', hand: [mk(2)] },
+        ],
+        stage: { kami: null, shimo: null },
+        deck: [],
+        backstage,
+        setRemainingCount: 0,
+        // index=3,5,6 が公開済み
+        publicInfos: [
+          { playerId: 'B', card: mk(4), round: 1, backstageIndex: 3 },
+          { playerId: 'B', card: mk(6), round: 1, backstageIndex: 5 },
+          { playerId: 'B', card: mk(7), round: 1, backstageIndex: 6 },
+        ],
+        playerABooCnt: 0,
+        playerBBooCnt: 0,
+        playerAKami: [],
+        playerBKami: [],
+        playerAShimo: [],
+        playerBShimo: [],
+        round: 1,
+        curtainCallReason: null,
+        spotlightCard: null,
+        backstageRevealedCards: [mk(4), mk(6), mk(7)],
+        backstageResult: 'no-match',
+        backstagePlayerId: 'B',
+      };
+      // index=3 のカード (rank=4) を手札に取る
+      const result = gameReducer(state, { type: 'BACKSTAGE_TAKE_HAND', cardIndex: 3 });
+      // 取得したカードの publicInfo は削除される
+      expect(result.publicInfos.find((p) => p.backstageIndex === 3)).toBeUndefined();
+      // index=5 → 4
+      expect(result.publicInfos.find((p) => p.backstageIndex === 4)).toBeDefined();
+      // index=6 → 5
+      expect(result.publicInfos.find((p) => p.backstageIndex === 5)).toBeDefined();
+    });
+
     it('SPOTLIGHT_SKIP_SET 経由では backstage フェーズを経ずに intermission へ到達する', () => {
       const s1 = gameReducer(initialState, { type: 'INIT_GAME', playerAName: 'A', playerBName: 'B' });
       const s2 = gameReducer(s1, { type: 'START_SCOUT' });

--- a/src/game/reducer.ts
+++ b/src/game/reducer.ts
@@ -1,6 +1,6 @@
 import type { Card, CurtainCallReason, GamePhase, GameState, Player, Stage } from '@/types/game';
 import { createDeck, createDeckWithJoker, deal, shuffle } from '@/lib/deck';
-import { buildPublicInfos } from './publicInfo';
+import { buildPublicInfos, shiftPublicInfosAfterRemoval } from './publicInfo';
 
 export type GameAction =
   | { type: 'INIT_GAME'; playerAName: string; playerBName: string }
@@ -307,6 +307,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         selectedCards,
         backstagePlayerId,
         state.round,
+        cardIndices,
       );
 
       const spotlightCard = state.spotlightCard;
@@ -323,10 +324,11 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
           kami: { ...spotlightCard!, isFaceUp: true },
           shimo: { ...matchedCard, isFaceUp: true },
         };
+        const shiftedPublicInfos = shiftPublicInfosAfterRemoval(newPublicInfos, matchedBackstageIndex);
         const matchState = {
           ...state,
           backstage: newBackstage,
-          publicInfos: newPublicInfos,
+          publicInfos: shiftedPublicInfos,
           stage,
           backstageRevealedCards: selectedCards,
           backstageResult: 'match' as const,
@@ -371,6 +373,7 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
       return {
         ...state,
         backstage: newBackstage,
+        publicInfos: shiftPublicInfosAfterRemoval(state.publicInfos, action.cardIndex),
         players,
         spotlightCard: null,
         backstageRevealedCards: [],

--- a/src/screens/BackstageScreen.module.css
+++ b/src/screens/BackstageScreen.module.css
@@ -107,3 +107,24 @@
 .proceedBtn:active {
   background: rgba(96, 165, 250, 0.12);
 }
+
+.cardSlot {
+  position: relative;
+  display: inline-flex;
+}
+
+.knownBadge {
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--gold, #f0c060);
+  color: #0f172a;
+  font-size: 10px;
+  font-weight: bold;
+  padding: 1px 6px;
+  border-radius: 8px;
+  white-space: nowrap;
+  z-index: 1;
+  pointer-events: none;
+}

--- a/src/screens/BackstageScreen.tsx
+++ b/src/screens/BackstageScreen.tsx
@@ -8,7 +8,7 @@ export default function BackstageScreen() {
   const dispatch = useGameDispatch();
   const [selected, setSelected] = useState<number[]>([]);
 
-  const { phase, backstage, backstageRevealedCards, backstageResult, spotlightCard } = state;
+  const { phase, backstage, backstageRevealedCards, backstageResult, spotlightCard, publicInfos } = state;
 
   function toggleSelect(index: number) {
     setSelected((prev) => {
@@ -54,13 +54,18 @@ export default function BackstageScreen() {
             <p className={styles.resultNoMatch}>不一致</p>
             <p className={styles.label}>バックステージから1枚選んで手札に加える</p>
             <div className={styles.cardGrid}>
-              {backstage.map((card, index) => (
-                <Card
-                  key={index}
-                  card={{ ...card, isFaceUp: false }}
-                  onClick={() => dispatch({ type: 'BACKSTAGE_TAKE_HAND', cardIndex: index })}
-                />
-              ))}
+              {backstage.map((card, index) => {
+                const isKnown = publicInfos.some((p) => p.backstageIndex === index);
+                return (
+                  <div key={index} className={styles.cardSlot}>
+                    {isKnown && <span className={styles.knownBadge}>既知</span>}
+                    <Card
+                      card={{ ...card, isFaceUp: false }}
+                      onClick={() => dispatch({ type: 'BACKSTAGE_TAKE_HAND', cardIndex: index })}
+                    />
+                  </div>
+                );
+              })}
             </div>
           </>
         )}
@@ -101,14 +106,19 @@ export default function BackstageScreen() {
       </p>
 
       <div className={styles.cardGrid}>
-        {backstage.map((card, index) => (
-          <Card
-            key={index}
-            card={{ ...card, isFaceUp: false }}
-            isSelected={selected.includes(index)}
-            onClick={() => toggleSelect(index)}
-          />
-        ))}
+        {backstage.map((card, index) => {
+          const isKnown = publicInfos.some((p) => p.backstageIndex === index);
+          return (
+            <div key={index} className={styles.cardSlot}>
+              {isKnown && <span className={styles.knownBadge}>既知</span>}
+              <Card
+                card={{ ...card, isFaceUp: false }}
+                isSelected={selected.includes(index)}
+                onClick={() => toggleSelect(index)}
+              />
+            </div>
+          );
+        })}
       </div>
 
       <button

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -38,6 +38,7 @@ export type PublicInfo = {
   playerId: string;
   card: Card;
   round: number;
+  backstageIndex: number;
 };
 
 export type CurtainCallReason = 'joker' | 'set-last-1' | 'hand-shortage';


### PR DESCRIPTION
## 概要

`PublicInfo` に `backstageIndex` を追加し、バックステージ上のどの位置のカードが既知かを後続ラウンドでも参照できるようにした。

## 変更内容

- **型定義** (`src/types/game.ts`): `PublicInfo` に `backstageIndex: number` を追加
- **publicInfo.ts**: `buildPublicInfos` に `indices` 引数を追加。`shiftPublicInfosAfterRemoval` を新設
- **reducer.ts**:
  - `BACKSTAGE_OPEN`: `cardIndices` を `buildPublicInfos` に渡す。ペア成立時はマッチカードの publicInfo を削除しインデックスをシフト
  - `BACKSTAGE_TAKE_HAND`: 取得カードの publicInfo を削除しインデックスをシフト
- **BackstageScreen.tsx**: 既知カードに「既知」バッジを表示（選択・手札取得フェーズ両方）
- **InfoOverlay.tsx**: 公開情報リストに「N枚目」の位置情報を追加

## Acceptance Criteria

- [x] 公開済みカードに位置情報が紐づいて保持される
- [x] 次のバックステージ選択時に既知位置を参照できる
- [x] バックステージの位置更新に関するテストが追加される

## テスト

- `publicInfo.test.ts` 新規作成（`buildPublicInfos` の backstageIndex 保持を検証）
- `reducer.test.ts` にインデックス記録・シフト・削除の3テストを追加
- 全306テスト通過、lint・typecheck 通過

Closes #116