### PR TITLE
[Bug] スポットライト中の操作プレイヤー案内をルール準拠に修正（Issue #117）

### DIFF
--- a/src/game/phaseGuide.test.ts
+++ b/src/game/phaseGuide.test.ts
@@ -53,10 +53,34 @@ describe('getPhaseGuide', () => {
     expect(getPhaseGuide({ ...baseState, phase: 'spotlight' }).phaseName).toBe('スポットライト');
   });
 
+  it('spotlight フェーズで players[0]（actor）がアクティブプレイヤー', () => {
+    expect(getPhaseGuide({ ...baseState, phase: 'spotlight' }).activePlayerName).toBe('アリス');
+  });
+
   it('spotlight-bonus フェーズで phaseName が「スポットライトボーナス」', () => {
     expect(getPhaseGuide({ ...baseState, phase: 'spotlight-bonus' }).phaseName).toBe(
       'スポットライトボーナス',
     );
+  });
+
+  it('spotlight-bonus フェーズで booResult=correct のとき players[1]（watcher）がアクティブ', () => {
+    const state: GameState = { ...baseState, phase: 'spotlight-bonus', booResult: 'correct' };
+    expect(getPhaseGuide(state).activePlayerName).toBe('ボブ');
+  });
+
+  it('spotlight-bonus フェーズで booResult=incorrect のとき players[0]（actor）がアクティブ', () => {
+    const state: GameState = { ...baseState, phase: 'spotlight-bonus', booResult: 'incorrect' };
+    expect(getPhaseGuide(state).activePlayerName).toBe('アリス');
+  });
+
+  it('spotlight-joker フェーズで booResult=correct のとき players[1]（watcher）がアクティブ', () => {
+    const state: GameState = { ...baseState, phase: 'spotlight-joker', booResult: 'correct' };
+    expect(getPhaseGuide(state).activePlayerName).toBe('ボブ');
+  });
+
+  it('spotlight-joker フェーズで booResult=incorrect のとき players[0]（actor）がアクティブ', () => {
+    const state: GameState = { ...baseState, phase: 'spotlight-joker', booResult: 'incorrect' };
+    expect(getPhaseGuide(state).activePlayerName).toBe('アリス');
   });
 
   it('backstage フェーズで phaseName が「バックステージ」', () => {

--- a/src/game/phaseGuide.ts
+++ b/src/game/phaseGuide.ts
@@ -36,10 +36,14 @@ export function getPhaseGuide(state: GameState): PhaseGuide {
       activePlayerName = p0.name;
       break;
     case 'watch':
+      activePlayerName = p1.name;
+      break;
     case 'spotlight':
+      activePlayerName = p0.name;
+      break;
     case 'spotlight-bonus':
     case 'spotlight-joker':
-      activePlayerName = p1.name;
+      activePlayerName = state.booResult === 'correct' ? p1.name : p0.name;
       break;
     case 'backstage':
     case 'backstage-result':


### PR DESCRIPTION
## 概要

`phaseGuide` がスポットライト全フェーズで常に `players[1]`（watcher）を担当者として返していたバグを修正。

## 根本原因

`src/game/phaseGuide.ts` の switch 文で `spotlight` / `spotlight-bonus` / `spotlight-joker` を同一ケースとして扱い、一律に `players[1].name` を返していた。

## 修正内容

| フェーズ | 修正前 | 修正後 |
|---|---|---|
| `spotlight`（黒子公開） | players[1]（誤） | players[0]（actor） |
| `spotlight-bonus`（セット選択） | players[1]（誤） | booResult=correct → players[1] / incorrect → players[0] |
| `spotlight-joker`（追加開示） | players[1]（誤） | booResult=correct → players[1] / incorrect → players[0] |

## テスト

- `phaseGuide.test.ts` に再現テスト 5 件追加（spotlight actor 表示、bonus/joker の booResult 分岐）
- 全 311 テスト通過、lint・typecheck エラーなし

Closes #117