### PR TITLE
fix: インターミッション後のラウンド交代時に PassDevice を挟む（Issue #118）

### DIFF
--- a/src/components/PassDevice.tsx
+++ b/src/components/PassDevice.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styles from './PassDevice.module.css';
 
 const INTERVAL_MS = 20;
@@ -30,6 +30,14 @@ export default function PassDevice({ playerName, onComplete }: Props) {
       }
     }, INTERVAL_MS);
   };
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
 
   const cancelHold = () => {
     if (intervalRef.current) {

--- a/src/screens/IntermissionScreen.test.tsx
+++ b/src/screens/IntermissionScreen.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
 import IntermissionScreen from './IntermissionScreen';
 
@@ -96,9 +96,29 @@ describe('IntermissionScreen', () => {
     expect(screen.getByText('アリス → ボブ')).toBeDefined();
   });
 
-  it('「次のラウンドへ」ボタンで scout フェーズに遷移する', () => {
+  it('「次のラウンドへ」ボタン押下後に PassDevice が表示される', () => {
     renderIntermission();
     fireEvent.click(screen.getByRole('button', { name: '次のラウンドへ' }));
-    expect(screen.getByTestId('after-intermission').textContent).toBe('phase: scout');
+    expect(screen.getByText('さんに渡してください')).toBeDefined();
+  });
+
+  it('「次のラウンドへ」ボタン押下後に scout フェーズへ直接遷移しない', () => {
+    renderIntermission();
+    fireEvent.click(screen.getByRole('button', { name: '次のラウンドへ' }));
+    expect(screen.queryByTestId('after-intermission')).toBeNull();
+  });
+
+  describe('PassDevice 経由でのフェーズ遷移', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('PassDevice 完了後に scout フェーズへ遷移する', () => {
+      renderIntermission();
+      fireEvent.click(screen.getByRole('button', { name: '次のラウンドへ' }));
+      const btn = screen.getByRole('button', { name: '長押しで進む' });
+      fireEvent.pointerDown(btn);
+      act(() => { vi.advanceTimersByTime(2000); });
+      expect(screen.getByTestId('after-intermission').textContent).toBe('phase: scout');
+    });
   });
 });

--- a/src/screens/IntermissionScreen.tsx
+++ b/src/screens/IntermissionScreen.tsx
@@ -1,12 +1,24 @@
+import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
+import PassDevice from '@/components/PassDevice';
 import styles from './IntermissionScreen.module.css';
 
 export default function IntermissionScreen() {
   const state = useGameState();
   const dispatch = useGameDispatch();
+  const [showPassDevice, setShowPassDevice] = useState(false);
 
   const currentScout = state.players[0];
   const nextScout = state.players[1];
+
+  if (showPassDevice) {
+    return (
+      <PassDevice
+        playerName={nextScout.name}
+        onComplete={() => dispatch({ type: 'INTERMISSION' })}
+      />
+    );
+  }
 
   return (
     <div className={styles.screen}>
@@ -21,7 +33,7 @@ export default function IntermissionScreen() {
 
       <button
         className={styles.proceedBtn}
-        onClick={() => dispatch({ type: 'INTERMISSION' })}
+        onClick={() => setShowPassDevice(true)}
       >
         次のラウンドへ
       </button>


### PR DESCRIPTION
## Summary
- `IntermissionScreen` の「次のラウンドへ」ボタン押下後に PassDevice を表示するよう修正
- 長押し完了後にのみ `INTERMISSION` アクションを dispatch して `scout` フェーズへ遷移
- `StandbyScreen` と同様の `useState` パターンで実装

## 変更ファイル
- `src/screens/IntermissionScreen.tsx` — PassDevice 挿入
- `src/screens/IntermissionScreen.test.tsx` — 再現テスト追加・旧テスト更新

## Test plan
- [x] 再現テスト3件追加（PassDevice 表示・直接遷移なし・PassDevice 完了後遷移）
- [x] `npx vitest run` → 313件パス
- [x] `npx eslint .` → エラーなし
- [x] `npx tsc --noEmit` → エラーなし

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)