### PR TITLE
[Feature] アクションフェーズで直前のスカウトで引いたカードを表示 (#136)

### DIFF
--- a/src/screens/ActionScreen.module.css
+++ b/src/screens/ActionScreen.module.css
@@ -50,6 +50,19 @@
   opacity: 0.4;
 }
 
+.scoutedCardArea {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.scoutedLabel {
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+  letter-spacing: 0.05em;
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);

--- a/src/screens/ActionScreen.test.tsx
+++ b/src/screens/ActionScreen.test.tsx
@@ -65,6 +65,11 @@ describe('ActionScreen', () => {
     expect(buttons.length).toBeGreaterThanOrEqual(16);
   });
 
+  it('直前のスカウトで引いたカードが表示される', () => {
+    renderAction();
+    expect(screen.getByText('直前のスカウト')).toBeDefined();
+  });
+
   it('初期状態で「ステージへ出す」ボタンはdisabled', () => {
     renderAction();
     const btn = screen.getByRole('button', { name: 'ステージへ出す' });

--- a/src/screens/ActionScreen.tsx
+++ b/src/screens/ActionScreen.tsx
@@ -18,6 +18,7 @@ export default function ActionScreen() {
   const hand = state.players[0].hand;
   const sortedHand = sortHand(hand);
   const actionPlayer = state.players[0];
+  const lastScoutedCard = state.lastScoutedCard;
 
   const handleCardClick = (index: number) => {
     if (step === 'selectingActor') {
@@ -101,6 +102,13 @@ export default function ActionScreen() {
           )}
         </div>
       </div>
+
+      {lastScoutedCard !== null && (
+        <div className={styles.scoutedCardArea}>
+          <span className={styles.scoutedLabel}>直前のスカウト</span>
+          <Card card={{ ...lastScoutedCard, isFaceUp: true }} />
+        </div>
+      )}
 
       <div className={styles.grid}>
         {sortedHand.map((card) => {


### PR DESCRIPTION
## 概要

アクションフェーズで、直前のスカウトで引いたカードを手札グリッド上部に表示する。

Closes #136

## 変更内容

- `ActionScreen.tsx`: `state.lastScoutedCard` を参照し「直前のスカウト」ラベル付きで表示。`null` の場合は非表示
- `ActionScreen.module.css`: `scoutedCardArea` / `scoutedLabel` スタイル追加
- `ActionScreen.test.tsx`: 表示確認テスト追加

## テスト

- [x] `直前のスカウトで引いたカードが表示される` テスト追加
- [x] 全テスト通過 (341/341)

🤖 Generated with [Claude Code](https://claude.com/claude-code)