### PR TITLE
feat: アクション画面に直前スカウトで引いたカードを表示 (Issue #136)

### DIFF
--- a/src/screens/ActionScreen.test.tsx
+++ b/src/screens/ActionScreen.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import * as gameContext from '@/game/context';
 import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
 import ActionScreen from './ActionScreen';
+import type { GameState } from '@/types/game';
 
 // INIT_GAME → START_SCOUT → SCOUT_CARD → action フェーズまで進めるラッパー
 function ActionWrapper() {
@@ -261,5 +263,45 @@ describe('ActionScreen ラウンド2', () => {
     expect(screen.getByText('アリス')).toBeDefined();
     // アクター（ボブ）の名前は表示されない
     expect(screen.queryByText('ボブ')).toBeNull();
+  });
+});
+
+describe('ActionScreen lastScoutedCard=null', () => {
+  const nullScoutState: GameState = {
+    phase: 'action',
+    players: [
+      { id: 'A', name: 'アリス', hand: [] },
+      { id: 'B', name: 'ボブ', hand: [] },
+    ],
+    stage: { kami: null, shimo: null },
+    deck: [],
+    backstage: [],
+    setRemainingCount: 9,
+    publicInfos: [],
+    playerABooCnt: 0,
+    playerBBooCnt: 0,
+    playerAKami: [],
+    playerBKami: [],
+    playerAShimo: [],
+    playerBShimo: [],
+    round: 1,
+    curtainCallReason: null,
+    booResult: null,
+    spotlightCard: null,
+    backstageRevealedCards: [],
+    backstageResult: null,
+    backstagePlayerId: null,
+    lastOpenedCard: null,
+    spotlightOpenResultNextPhase: null,
+    lastScoutedCard: null,
+  };
+
+  it('lastScoutedCard が null の場合は「直前のスカウト」が表示されない', () => {
+    const spy = vi.spyOn(gameContext, 'useGameState').mockReturnValue(nullScoutState);
+
+    render(<ActionScreen />);
+    expect(screen.queryByText('直前のスカウト')).toBeNull();
+
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
## 概要
アクションフェーズで直前のスカウトで引いたカードを確認できるUIを追加。

## 変更内容
- アクション画面に `lastScoutedCard` を表示
- `lastScoutedCard` が null の場合は表示しない

## テスト
- `lastScoutedCard` が表示されることを確認するレンダリングテスト追加
- `lastScoutedCard=null` 時に非表示になることを確認

Closes #136