### PR TITLE
feat: 場のカードを主要フェーズ画面で常時表示する (Issue #132)

### DIFF
--- a/src/components/StageOverview.module.css
+++ b/src/components/StageOverview.module.css
@@ -1,0 +1,73 @@
+.container {
+  width: 100%;
+  max-width: 360px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 8px 12px;
+  box-sizing: border-box;
+}
+
+.title {
+  font-size: 11px;
+  color: var(--muted, #7a8aaa);
+  margin: 0 0 6px;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.grid {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.divider {
+  width: 1px;
+  align-self: stretch;
+  background: rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+}
+
+.player {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.playerName {
+  font-size: 11px;
+  font-weight: bold;
+  color: var(--gold, #f0c060);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.rowLabel {
+  font-size: 10px;
+  color: var(--muted, #7a8aaa);
+  flex-shrink: 0;
+  width: 20px;
+}
+
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  /* zoom でカード全体を縮小（フォント含む）: 30/52 ≈ 0.58 */
+  zoom: 0.58;
+}
+
+.empty {
+  font-size: 12px;
+  color: var(--muted, #7a8aaa);
+}

--- a/src/components/StageOverview.test.tsx
+++ b/src/components/StageOverview.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GameProvider, useGameDispatch, useGameState } from '@/game/context';
+import StageOverview from './StageOverview';
+
+function StageOverviewWrapper() {
+  const dispatch = useGameDispatch();
+  const state = useGameState();
+
+  if (state.phase === 'standby' && state.players[0].name === '') {
+    return (
+      <button
+        onClick={() =>
+          dispatch({ type: 'INIT_GAME', playerAName: 'アリス', playerBName: 'ボブ' })
+        }
+      >
+        init
+      </button>
+    );
+  }
+  return <StageOverview />;
+}
+
+function renderOverview() {
+  render(
+    <GameProvider>
+      <StageOverviewWrapper />
+    </GameProvider>,
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'init' }));
+}
+
+describe('StageOverview', () => {
+  it('「場のカード」ラベルが表示される', () => {
+    renderOverview();
+    expect(screen.getByText('場のカード')).toBeDefined();
+  });
+
+  it('両プレイヤーの名前が表示される', () => {
+    renderOverview();
+    expect(screen.getByText('アリス')).toBeDefined();
+    expect(screen.getByText('ボブ')).toBeDefined();
+  });
+
+  it('カードがない場合は「—」が4つ表示される', () => {
+    renderOverview();
+    // 初期状態は蓄積カードなし → カミ・シモ × 2プレイヤー = 4つ
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBe(4);
+  });
+});

--- a/src/components/StageOverview.tsx
+++ b/src/components/StageOverview.tsx
@@ -1,0 +1,68 @@
+import { useGameState } from '@/game/context';
+import Card from '@/components/Card';
+import type { Card as CardType } from '@/types/game';
+import styles from './StageOverview.module.css';
+
+function PlayerStageMini({
+  name,
+  kamiCards,
+  shimoCards,
+}: {
+  name: string;
+  kamiCards: CardType[];
+  shimoCards: CardType[];
+}) {
+  return (
+    <div className={styles.player}>
+      <span className={styles.playerName}>{name}</span>
+      <div className={styles.row}>
+        <span className={styles.rowLabel}>カミ</span>
+        {kamiCards.length === 0 ? (
+          <span className={styles.empty}>—</span>
+        ) : (
+          <div className={styles.cards}>
+            {kamiCards.map((card, i) => (
+              <Card key={i} card={{ ...card, isFaceUp: true }} />
+            ))}
+          </div>
+        )}
+      </div>
+      <div className={styles.row}>
+        <span className={styles.rowLabel}>シモ</span>
+        {shimoCards.length === 0 ? (
+          <span className={styles.empty}>—</span>
+        ) : (
+          <div className={styles.cards}>
+            {shimoCards.map((card, i) => (
+              <Card key={i} card={{ ...card, isFaceUp: false }} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function StageOverview() {
+  const { players, playerAKami, playerAShimo, playerBKami, playerBShimo } =
+    useGameState();
+
+  return (
+    <div className={styles.container}>
+      <p className={styles.title}>場のカード</p>
+      <div className={styles.grid}>
+        <PlayerStageMini
+          name={players[0].name}
+          kamiCards={playerAKami}
+          shimoCards={playerAShimo}
+        />
+        <div className={styles.divider} />
+        <PlayerStageMini
+          name={players[1].name}
+          kamiCards={playerBKami}
+          shimoCards={playerBShimo}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/screens/ActionScreen.test.tsx
+++ b/src/screens/ActionScreen.test.tsx
@@ -193,6 +193,11 @@ describe('ActionScreen', () => {
     // アクター（アリス）の名前は表示されない
     expect(screen.queryByText('アリス')).toBeNull();
   });
+
+  it('場のカード欄が表示される（Issue #132 リグレッション）', () => {
+    renderAction();
+    expect(screen.getByText('場のカード')).toBeDefined();
+  });
 });
 
 // INTERMISSION でスワップされた後も PassDevice が正しいウォッチャー名を表示することを確認

--- a/src/screens/ActionScreen.tsx
+++ b/src/screens/ActionScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
 import PassDevice from '@/components/PassDevice';
+import StageOverview from '@/components/StageOverview';
 import { sortHand } from '@/lib/deck';
 import styles from './ActionScreen.module.css';
 
@@ -83,7 +84,7 @@ export default function ActionScreen() {
     <div className={styles.screen}>
       <h1 className={styles.heading}>アクション</h1>
       <p className={styles.sub}>{getInstruction()}</p>
-
+      <StageOverview />
       <div className={styles.preview}>
         <div className={styles.previewSlot}>
           <span className={styles.slotLabel}>役者（カミ）</span>

--- a/src/screens/BackstageScreen.test.tsx
+++ b/src/screens/BackstageScreen.test.tsx
@@ -202,4 +202,10 @@ describe('BackstageScreen', () => {
     // 判定前のカード選択フェーズ（backstage）で「既知」バッジが存在しないこと
     expect(screen.queryByText('既知')).toBeNull();
   });
+
+  it('場のカード欄が表示される（Issue #132 リグレッション）', () => {
+    const ready = renderBackstage();
+    if (!ready) return;
+    expect(screen.getByText('場のカード')).toBeDefined();
+  });
 });

--- a/src/screens/BackstageScreen.tsx
+++ b/src/screens/BackstageScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
+import StageOverview from '@/components/StageOverview';
 import styles from './BackstageScreen.module.css';
 
 export default function BackstageScreen() {
@@ -29,7 +30,7 @@ export default function BackstageScreen() {
     return (
       <div className={styles.screen}>
         <h1 className={styles.heading}>バックステージ</h1>
-
+        <StageOverview />
         <div className={styles.revealed}>
           <p className={styles.label}>開いた3枚</p>
           <div className={styles.cardRow}>
@@ -89,6 +90,7 @@ export default function BackstageScreen() {
     return (
       <div className={styles.screen}>
         <h1 className={styles.heading}>バックステージ</h1>
+        <StageOverview />
         <p className={styles.instruction}>
           セットをオープンしなかったため、バックステージフェーズは発生しません。
         </p>
@@ -105,7 +107,7 @@ export default function BackstageScreen() {
   return (
     <div className={styles.screen}>
       <h1 className={styles.heading}>バックステージ</h1>
-
+      <StageOverview />
       <div className={styles.spotlightCardArea}>
         <p className={styles.label}>スポットライトカード</p>
         <Card card={{ ...spotlightCard, isFaceUp: true }} />

--- a/src/screens/ScoutScreen.test.tsx
+++ b/src/screens/ScoutScreen.test.tsx
@@ -125,4 +125,9 @@ describe('ScoutScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: 'スカウト確定' }));
     expect(screen.getByTestId('after-scout').textContent).toBe('phase: scout-result');
   });
+
+  it('場のカード欄が表示される（Issue #132 リグレッション）', () => {
+    renderScout();
+    expect(screen.getByText('場のカード')).toBeDefined();
+  });
 });

--- a/src/screens/ScoutScreen.tsx
+++ b/src/screens/ScoutScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
+import StageOverview from '@/components/StageOverview';
 import { sortHand } from '@/lib/deck';
 import styles from './ScoutScreen.module.css';
 
@@ -29,6 +30,7 @@ export default function ScoutScreen() {
     <div className={styles.screen}>
       <h1 className={styles.heading}>スカウト</h1>
       <p className={styles.sub}>相手の手札から1枚選んでください</p>
+      <StageOverview />
       <div className={styles.grid}>
         {sortedOpponentHand.map((card) => {
           const i = opponentHand.indexOf(card);

--- a/src/screens/SpotlightRevealScreen.test.tsx
+++ b/src/screens/SpotlightRevealScreen.test.tsx
@@ -184,6 +184,11 @@ describe('SpotlightRevealScreen', () => {
     expect(screen.getByTestId('after-spotlight').textContent).toBe('phase: intermission');
   });
 
+  it('場のカード欄が表示される（Issue #132 リグレッション）', () => {
+    renderSpotlight();
+    expect(screen.getByText('場のカード')).toBeDefined();
+  });
+
   it('ブーイング正解時の移動先案内にウォッチャーのプレイヤー名が表示される（固定「B」でない）', () => {
     renderSpotlight();
     fireEvent.click(screen.getByRole('button', { name: '黒子札を開示' }));
@@ -206,8 +211,8 @@ describe('SpotlightRevealScreen – ブーイング不正解シナリオ', () =>
     // boo 不正解（kami=shimo=rank1）が確定していることを検証
     expect(screen.getByText('ブーイング不正解！')).toBeDefined();
 
-    // 修正後: PassDevice が役者（アリス）向けに表示される
-    expect(screen.getByText('アリス')).toBeDefined();
+    // 修正後: PassDevice が役者（アリス）向けに表示される（複数箇所にアリスが表示される場合あり）
+    expect(screen.getAllByText('アリス').length).toBeGreaterThanOrEqual(1);
     // 修正後: PassDevice 完了前はセットボタンが非表示
     expect(screen.queryByRole('button', { name: 'セットを開く' })).toBeNull();
   });

--- a/src/screens/SpotlightRevealScreen.tsx
+++ b/src/screens/SpotlightRevealScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
 import PassDevice from '@/components/PassDevice';
+import StageOverview from '@/components/StageOverview';
 import styles from './SpotlightRevealScreen.module.css';
 
 export default function SpotlightRevealScreen() {
@@ -19,7 +20,7 @@ export default function SpotlightRevealScreen() {
   return (
     <div className={styles.screen}>
       <h1 className={styles.heading}>スポットライト</h1>
-
+      <StageOverview />
       <div className={styles.stage}>
         <div className={styles.stageSlot}>
           <span className={styles.slotLabel}>役者（カミ）</span>


### PR DESCRIPTION
## Summary
- `StageOverview` コンポーネントを新規作成：両プレイヤーの蓄積ステージカード（カミ/シモ）をミニサイズで表示
- スカウト・アクション・スポットライト・バックステージの各フェーズ画面に組み込み
- カード縮小には `zoom: 0.58` を使用し、390px 幅でのレイアウト崩れを防止

## Acceptance Criteria
- [x] 主要フェーズ（スカウト・アクション・スポットライト・バックステージ）で場のカードが常時確認できる
- [x] 画面レイアウトが崩れない（390px幅）
- [x] 他プレイヤーの場のカードも表示される

## Test Plan
- [x] `StageOverview` の単体テスト（ラベル表示、プレイヤー名、空時ダッシュ表示）
- [x] 各フェーズ画面のリグレッションテスト（場のカード欄が表示されること）
- [x] 全353テスト通過確認

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)