### PR TITLE
fix: 場のシモカードが常に裏向きになるバグを修正 (Issue #151)

### DIFF
--- a/src/components/StageOverview.tsx
+++ b/src/components/StageOverview.tsx
@@ -34,7 +34,7 @@ function PlayerStageMini({
         ) : (
           <div className={styles.cards}>
             {shimoCards.map((card, i) => (
-              <Card key={i} card={{ ...card, isFaceUp: false }} />
+              <Card key={i} card={card} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- `StageOverview.tsx` でシモカードに `isFaceUp: false` をハードコードしていたバグを修正
- Reducer が設定した `isFaceUp` をそのまま使うように変更（1行修正）

## 変更内容
```tsx
// Before（バグ）
<Card key={i} card={{ ...card, isFaceUp: false }} />

// After
<Card key={i} card={card} />
```

## Test plan
- [ ] `npx vitest run src/components/StageOverview.test.tsx` がパスする
- [ ] ブーイング→開示フローでシモカードが表向きになることを実機確認
- [ ] クラップフローではシモカードが裏向きのままであることを確認

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)