### PR TITLE
feat: 📊オーバーレイで両プレイヤーの情報を見やすく表示 (Issue #133)

### DIFF
--- a/src/components/InfoOverlay.module.css
+++ b/src/components/InfoOverlay.module.css
@@ -13,7 +13,7 @@
 }
 
 .panel {
-  width: min(360px, 100%);
+  width: min(390px, 100%);
   height: 100dvh;
   background: var(--surface, #16213e);
   border-left: 1px solid var(--border, #1e2d50);


### PR DESCRIPTION
## 概要

📊ボタンで開く InfoOverlay のパネル幅を 360px → 390px に拡張し、両プレイヤーの情報を見やすく表示する。

Closes #133

## 変更内容

- `InfoOverlay.module.css`: パネル幅を `min(360px, 100%)` → `min(390px, 100%)` に変更

## AC 確認

- [x] 📊ボタンで自分と相手、両方の場のカードが確認できる（既実装）
- [x] 相手の手札は表示されない（既実装・テスト済み）
- [x] 390px幅で両者の情報が見やすく表示される（本PRで対応）

## テスト

- `InfoOverlay.test.tsx` 14件全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)