### PR TITLE
[Feature] 自分の手番中は手札を常時表示する

### DIFF
--- a/src/components/GameRouter.module.css
+++ b/src/components/GameRouter.module.css
@@ -1,0 +1,32 @@
+/* スマホ：1カラム（サイドバーなし） */
+.layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* 大画面用サイドバー：デフォルト非表示 */
+.handSidebar {
+  display: none;
+}
+
+/* タブレット・PC（≥600px）：サイドバーを常時表示 */
+@media (min-width: 600px) {
+  .handSidebar {
+    display: flex;
+    flex-direction: column;
+    width: 200px;
+    flex-shrink: 0;
+    padding: 16px 12px;
+    border-left: 1px solid var(--border, #1e2d50);
+    background: var(--surface, #16213e);
+    overflow-y: auto;
+  }
+}

--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
-import { getPhaseGuide } from '@/game/phaseGuide';
+import { getPhaseGuide, getOperatingHand } from '@/game/phaseGuide';
+import HandPanel from './HandPanel';
 import InfoOverlay from './InfoOverlay';
 import PhaseHeader from './PhaseHeader';
+import styles from './GameRouter.module.css';
 import ResultModal from './ResultModal';
 import ActionScreen from '@/screens/ActionScreen';
 import BackstageScreen from '@/screens/BackstageScreen';
@@ -26,6 +28,10 @@ export default function GameRouter() {
   }
 
   const { phaseName, activePlayerName } = getPhaseGuide(state);
+  const rawHand = getOperatingHand(state);
+  const operatingHand = rawHand !== null
+    ? { hand: rawHand, playerName: activePlayerName }
+    : null;
 
   function renderScreen() {
     switch (state.phase) {
@@ -81,11 +87,21 @@ export default function GameRouter() {
         activePlayerName={activePlayerName}
         onInfoOpen={() => setIsInfoOpen(true)}
       />
-      {renderScreen()}
+      <div className={styles.layout}>
+        <div className={styles.main}>
+          {renderScreen()}
+        </div>
+        {operatingHand && (
+          <aside className={styles.handSidebar}>
+            <HandPanel hand={operatingHand.hand} playerName={operatingHand.playerName} />
+          </aside>
+        )}
+      </div>
       <InfoOverlay
         isOpen={isInfoOpen}
         onClose={() => setIsInfoOpen(false)}
         gameState={state}
+        operatingHand={operatingHand}
       />
     </>
   );

--- a/src/components/HandPanel.module.css
+++ b/src/components/HandPanel.module.css
@@ -1,0 +1,18 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 10px;
+  letter-spacing: 2px;
+  color: var(--muted, #7a8aaa);
+  text-transform: uppercase;
+}
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}

--- a/src/components/HandPanel.tsx
+++ b/src/components/HandPanel.tsx
@@ -1,0 +1,25 @@
+import type { Card } from '@/types/game';
+import { sortHand } from '@/lib/deck';
+import CardComponent from '@/components/Card';
+import styles from './HandPanel.module.css';
+
+type Props = {
+  hand: Card[];
+  playerName: string;
+  className?: string;
+};
+
+export default function HandPanel({ hand, playerName, className }: Props) {
+  const sorted = sortHand(hand);
+
+  return (
+    <div className={`${styles.panel} ${className ?? ''}`}>
+      <div className={styles.label}>{playerName} の手札（{hand.length}枚）</div>
+      <div className={styles.grid}>
+        {sorted.map((card, i) => (
+          <CardComponent key={i} card={{ ...card, isFaceUp: true }} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/InfoOverlay.module.css
+++ b/src/components/InfoOverlay.module.css
@@ -262,3 +262,10 @@
   font-size: 10px;
   font-weight: bold;
 }
+
+/* 手札セクション：大画面では HandSidebar が常時表示するため非表示にする */
+@media (min-width: 600px) {
+  .handSection {
+    display: none;
+  }
+}

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -1,5 +1,6 @@
 import type { GameState, Card } from '@/types/game';
 import { calculateScore } from '@/lib/scoring';
+import HandPanel from './HandPanel';
 import styles from './InfoOverlay.module.css';
 
 const BOO_MAX = 3;
@@ -24,9 +25,10 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   gameState: GameState;
+  operatingHand?: { hand: Card[]; playerName: string } | null;
 };
 
-export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
+export default function InfoOverlay({ isOpen, onClose, gameState, operatingHand }: Props) {
   const { players, playerABooCnt, playerBBooCnt, setRemainingCount, publicInfos, playerAKami, playerBKami, playerAShimo, playerBShimo, stage } = gameState;
   const playerA = players.find((p) => p.id === 'A')!;
   const playerB = players.find((p) => p.id === 'B')!;
@@ -55,6 +57,13 @@ export default function InfoOverlay({ isOpen, onClose, gameState }: Props) {
             ×
           </button>
         </div>
+
+        {/* 自分の手札（スマホのみ表示。大画面は HandSidebar で常時表示） */}
+        {operatingHand && (
+          <div className={`${styles.section} ${styles.handSection}`}>
+            <HandPanel hand={operatingHand.hand} playerName={operatingHand.playerName} />
+          </div>
+        )}
 
         {/* スコア速報 */}
         <div className={styles.section}>

--- a/src/game/phaseGuide.ts
+++ b/src/game/phaseGuide.ts
@@ -1,4 +1,4 @@
-import type { GameState } from '@/types/game';
+import type { GameState, Card } from '@/types/game';
 
 export type PhaseGuide = {
   phaseName: string;
@@ -55,4 +55,33 @@ export function getPhaseGuide(state: GameState): PhaseGuide {
   }
 
   return { phaseName, activePlayerName };
+}
+
+/**
+ * 現在のフェーズで操作プレイヤーの手札を返す。
+ * 手番外フェーズ（watch・intermission 等）では null を返す。
+ */
+export function getOperatingHand(state: GameState): Card[] | null {
+  const [p0, p1] = state.players;
+
+  switch (state.phase) {
+    case 'scout':
+    case 'scout-result':
+    case 'action':
+      return p0.hand;
+    case 'spotlight':
+      // watch フェーズ後も players[1] がデバイスを持つ
+      return p1.hand;
+    case 'spotlight-bonus':
+    case 'spotlight-joker':
+    case 'spotlight-open-result':
+      return state.booResult === 'correct' ? p1.hand : p0.hand;
+    case 'backstage':
+    case 'backstage-result': {
+      const backstagePlayer = state.players.find((p) => p.id === state.backstagePlayerId);
+      return backstagePlayer?.hand ?? null;
+    }
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
## 概要

Issue #139 の実装。手番中（スカウト・アクション・スポットライト・バックステージ）に操作プレイヤーの手札を表示する。

## 変更内容

- `phaseGuide.ts` に `getOperatingHand(state)` を追加
  - 各フェーズに応じて操作プレイヤーの手札（または `null`）を返す
- `HandPanel` コンポーネントを新規作成（手札カード一覧の表示専用）
- `InfoOverlay` に手札セクションを追加（スマホ向け 📊 オーバーレイ内表示）
- `GameRouter` に大画面用サイドバー（`<aside>`）を追加
  - `≥600px`：右カラムに手札を常時表示
  - `<600px`：サイドバー非表示、📊 オーバーレイで確認

## AC 確認

- [x] 自分の手番中、手札が確認できる
- [x] 相手の手番中（`watch` フェーズ）、手札が表示されない
- [x] PassDevice 画面では手札が表示されない
- [x] タブレット・PC（≥600px）では手札が常時表示される
- [x] スマホ幅（390px）では 📊 オーバーレイ内で手札が確認できる

## テスト

- typecheck: ✅ エラーなし
- lint: ✅ エラーなし
- vitest: ✅ 350 tests passed

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)