### PR TITLE
[Feature/Fix] A案 Classical Theatre PC デザインリワーク + PassDevice手札非表示修正

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,7 +1,7 @@
 # .ai-context.md
 
 ## Status
-安定稼働中。PC Redesign (A案 Classical Theatre) 実装完了。全350テスト通過。次は #138 推奨。
+安定稼働中。PC Redesign (#164) + PassDevice手札非表示 (#159) 実装完了、PR #165 レビュー待ち。全350テスト通過。
 
 ## Active Issues
 - #128 [Bug] ブーイング失敗時にセットオープンの操作プレイヤーが切り替わらない（PR未作成・要確認）
@@ -13,7 +13,7 @@
 - #139 [Feature] 自分の手番中は手札を常時表示する
 
 ## In-Progress PRs
-（なし）
+- PR #165: PC Redesign (A案 Classical Theatre) + PassDevice手札非表示修正 — Closes #164 / #159 / #157
 
 
 

--- a/.ai-context.md
+++ b/.ai-context.md
@@ -1,7 +1,7 @@
 # .ai-context.md
 
 ## Status
-安定稼働中。#135・#136 完了。次は #138 推奨。
+安定稼働中。PC Redesign (A案 Classical Theatre) 実装完了。全350テスト通過。次は #138 推奨。
 
 ## Active Issues
 - #128 [Bug] ブーイング失敗時にセットオープンの操作プレイヤーが切り替わらない（PR未作成・要確認）
@@ -108,6 +108,14 @@
 ## Next actions
 1. #138（バックステージ失敗時のカード引きで引いたカードを表示）へ着手推奨（#135/#136 と同パターン）
 2. #132（場のカードを常時表示してカジノ風UI）も依存なしで着手可能
+3. PC Redesign PRマージ後にデザイン整合性のQAを実施推奨
+
+## Decisions (追加)
+- PC Redesign (A案 Classical Theatre): `feature/issue-159` ブランチで実装
+  - CSS変数: --bg #0a0608, --gold #d6ac6c, --crimson #a02030, --text #f5ebdc
+  - フォント: Cormorant Garamond + Noto Serif JP + Noto Sans JP + Inter (Google Fonts)
+  - レイアウト: topbar(64px) + stage(flex-row) + handDock(bottom, 120-160px)
+  - テスト互換性: aria-label 追加・getNodeText は直接テキストノードのみ参照するため swapArrow は p 要素に直接テキストを持たせること
 
 ## Known pitfalls
 - `create-next-app` はディレクトリ名を npm package name に使う。大文字NG → `/tmp` 等で生成して移動する

--- a/src/components/Card.module.css
+++ b/src/components/Card.module.css
@@ -76,6 +76,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 }
 
 /* ジョーカー */

--- a/src/components/Card.module.css
+++ b/src/components/Card.module.css
@@ -1,36 +1,25 @@
 .card {
   width: var(--card-w, 52px);
   height: var(--card-h, 76px);
-  border-radius: 7px;
+  border-radius: 4px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1px;
+  gap: 0;
   flex-shrink: 0;
   position: relative;
   user-select: none;
   cursor: default;
-}
-
-.clickable {
-  cursor: pointer;
-}
-
-.clickable:focus-visible {
-  outline: 3px solid #4a9eff;
-  outline-offset: 2px;
-}
-
-.clickable:active {
-  opacity: 0.75;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.45);
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
 /* 表向き */
 .face {
-  background: #fff;
-  color: #222;
-  border: 1.5px solid #ccc;
+  background: #f7eedc;
+  color: #1a100e;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .suit {
@@ -39,60 +28,103 @@
 }
 
 .rank {
-  font-size: 13px;
-  font-weight: bold;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1;
+  position: absolute;
+}
+
+.rankTl {
+  top: 4px;
+  left: 5px;
+}
+
+.rankBr {
+  bottom: 4px;
+  right: 5px;
+  transform: rotate(180deg);
+}
+
+.rankBr::before {
+  content: attr(data-rank);
 }
 
 .red .suit {
-  color: #e74c3c;
+  color: #a02030;
 }
 
-.red .rank {
-  color: #e74c3c;
+.red .rankTl,
+.red .rankBr {
+  color: #a02030;
 }
 
 /* 裏向き */
 .back {
-  background: linear-gradient(135deg, #1a2a4a 0%, #0f3460 50%, #1a2a4a 100%);
-  border: 1.5px solid #0f3460;
+  background: linear-gradient(135deg, #5c1018 0%, #3a0810 50%, #5c1018 100%);
+  border: 1px solid rgba(214, 172, 108, 0.4);
 }
 
 .back::after {
-  content: '◈';
-  font-size: 22px;
-  color: rgba(255, 255, 255, 0.15);
+  content: 'C';
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  color: rgba(214, 172, 108, 0.35);
+  font-size: 50%;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* ジョーカー */
 .joker {
-  background: linear-gradient(135deg, #f39c12, #e74c3c);
-  border: 1.5px solid #f39c12;
-  color: #fff;
-  font-size: 11px;
-  font-weight: bold;
-  text-align: center;
+  background: linear-gradient(135deg, #d6ac6c, #a02030);
+  border: 1px solid #d6ac6c;
+  color: #120a08;
 }
 
 .jokerLabel {
+  font-family: 'Cormorant Garamond', Georgia, serif;
   font-size: 10px;
-  font-weight: bold;
+  font-weight: 600;
   letter-spacing: 1px;
 }
 
-/* 選択状態 */
-.selected {
-  box-shadow: 0 0 0 2.5px #e94560;
-  transform: translateY(-6px);
+/* インタラクション */
+.clickable {
+  cursor: pointer;
 }
 
+.clickable:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.5);
+}
+
+.clickable:focus-visible {
+  outline: 2px solid var(--gold, #d6ac6c);
+  outline-offset: 2px;
+}
+
+.clickable:active {
+  opacity: 0.85;
+}
+
+/* 選択状態（役者札） */
+.selected {
+  transform: translateY(-10px) !important;
+  box-shadow: 0 0 0 2px #d6ac6c, 0 14px 30px -10px rgba(214, 172, 108, 0.6);
+}
+
+/* 選択状態（黒子札） */
 .selectedShimo {
-  box-shadow: 0 0 0 2.5px #7b52e8;
-  transform: translateY(-6px);
+  transform: translateY(-10px) !important;
+  box-shadow: 0 0 0 2px #a02030, 0 14px 30px -10px rgba(160, 32, 48, 0.6);
 }
 
 /* ─── アニメーション ──────────────────────────────────────── */
 
-/* カードフリップ（裏→表）: scaleX で折り畳み→展開 */
 @keyframes cardFlip {
   0%   { transform: scaleX(1); }
   45%  { transform: scaleX(0); }
@@ -104,7 +136,6 @@
   animation: cardFlip 0.4s ease-in-out;
 }
 
-/* スライドイン（ステージへのカード移動） */
 @keyframes cardSlideIn {
   from { transform: translateY(-16px); opacity: 0; }
   to   { transform: translateY(0);     opacity: 1; }
@@ -114,7 +145,6 @@
   animation: cardSlideIn 0.3s ease-out;
 }
 
-/* 配布アニメーション（Standby フェーズ等、カード群を順次表示） */
 @keyframes cardDeal {
   from { transform: scale(0.85) translateY(-10px); opacity: 0; }
   to   { transform: scale(1)    translateY(0);     opacity: 1; }
@@ -124,7 +154,6 @@
   animation: cardDeal 0.3s ease-out both;
 }
 
-/* prefers-reduced-motion: アニメーション無効化（カード表示は維持） */
 @media (prefers-reduced-motion: reduce) {
   .flipping,
   .sliding,

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -85,8 +85,9 @@ export default function Card({ card, isSelected, isSelectedShimo, onClick, anima
 
   return (
     <div className={classNames.join(' ')} style={animStyle} {...interactiveProps}>
+      <span className={`${styles.rank} ${styles.rankTl}`}>{rankLabel(card.rank)}</span>
       <span className={styles.suit}>{SUIT_SYMBOL[card.suit]}</span>
-      <span className={styles.rank}>{rankLabel(card.rank)}</span>
+      <span className={`${styles.rank} ${styles.rankBr}`} data-rank={rankLabel(card.rank)} aria-hidden="true" />
     </div>
   );
 }

--- a/src/components/GameRouter.module.css
+++ b/src/components/GameRouter.module.css
@@ -1,8 +1,10 @@
-/* スマホ：1カラム（サイドバーなし） */
-.layout {
-  display: flex;
+.stage {
   flex: 1;
   min-height: 0;
+  display: flex;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
 }
 
 .main {
@@ -10,23 +12,20 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
-/* 大画面用サイドバー：デフォルト非表示 */
-.handSidebar {
-  display: none;
-}
-
-/* タブレット・PC（≥600px）：サイドバーを常時表示 */
-@media (min-width: 600px) {
-  .handSidebar {
-    display: flex;
-    flex-direction: column;
-    width: 200px;
-    flex-shrink: 0;
-    padding: 16px 12px;
-    border-left: 1px solid var(--border, #1e2d50);
-    background: var(--surface, #16213e);
-    overflow-y: auto;
-  }
+/* ボトムハンドドック */
+.handDock {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  background: rgba(18, 10, 8, 0.9);
+  backdrop-filter: blur(12px);
+  padding: 12px 24px 16px;
+  min-height: 120px;
+  max-height: 160px;
+  display: flex;
+  align-items: center;
+  position: relative;
+  z-index: 2;
 }

--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import { getPhaseGuide, getOperatingHand } from '@/game/phaseGuide';
+import type { GameState } from '@/types/game';
 import HandPanel from './HandPanel';
 import InfoOverlay from './InfoOverlay';
 import PhaseHeader from './PhaseHeader';
@@ -18,6 +19,26 @@ import TitleScreen from '@/screens/TitleScreen';
 import WatchScreen from '@/screens/WatchScreen';
 
 
+function getActLabel(phase: GameState['phase']): string {
+  switch (phase) {
+    case 'standby': return 'Act I';
+    case 'scout':
+    case 'scout-result':
+    case 'action':
+    case 'watch': return 'Act II';
+    case 'spotlight':
+    case 'spotlight-bonus':
+    case 'spotlight-joker':
+    case 'spotlight-open-result':
+    case 'backstage':
+    case 'backstage-result': return 'Act III';
+    case 'intermission': return "Entr'acte";
+    case 'curtain-call':
+    case 'result': return 'Finale';
+    default: return '';
+  }
+}
+
 export default function GameRouter() {
   const state = useGameState();
   const dispatch = useGameDispatch();
@@ -32,6 +53,8 @@ export default function GameRouter() {
   const operatingHand = rawHand !== null
     ? { hand: rawHand, playerName: activePlayerName }
     : null;
+
+  const actLabel = getActLabel(state.phase);
 
   function renderScreen() {
     switch (state.phase) {
@@ -86,17 +109,24 @@ export default function GameRouter() {
         phaseName={phaseName}
         activePlayerName={activePlayerName}
         onInfoOpen={() => setIsInfoOpen(true)}
+        actLabel={actLabel}
+        playerAName={state.players[0].name}
+        playerBName={state.players[1].name}
       />
-      <div className={styles.layout}>
+      <div className={styles.stage}>
         <div className={styles.main}>
           {renderScreen()}
         </div>
-        {operatingHand && (
-          <aside className={styles.handSidebar}>
-            <HandPanel hand={operatingHand.hand} playerName={operatingHand.playerName} />
-          </aside>
-        )}
       </div>
+      {operatingHand && (
+        <div className={styles.handDock}>
+          <HandPanel
+            hand={operatingHand.hand}
+            playerName={operatingHand.playerName}
+            dockMode
+          />
+        </div>
+      )}
       <InfoOverlay
         isOpen={isInfoOpen}
         onClose={() => setIsInfoOpen(false)}

--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import { getPhaseGuide, getOperatingHand } from '@/game/phaseGuide';
 import type { GameState } from '@/types/game';
@@ -43,6 +43,12 @@ export default function GameRouter() {
   const state = useGameState();
   const dispatch = useGameDispatch();
   const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const [isPassDeviceVisible, setIsPassDeviceVisible] = useState(false);
+
+  // フェーズが変わったら PassDevice 表示フラグをリセット（安全ネット）
+  useEffect(() => {
+    setIsPassDeviceVisible(false);
+  }, [state.phase]);
 
   if (state.phase === 'standby' && state.players[0].name === '') {
     return <TitleScreen />;
@@ -59,7 +65,7 @@ export default function GameRouter() {
   function renderScreen() {
     switch (state.phase) {
       case 'standby':
-        return <StandbyScreen />;
+        return <StandbyScreen onPassDeviceChange={setIsPassDeviceVisible} />;
       case 'scout':
         return <ScoutScreen />;
       case 'scout-result': {
@@ -79,11 +85,11 @@ export default function GameRouter() {
         );
       }
       case 'action':
-        return <ActionScreen />;
+        return <ActionScreen onPassDeviceChange={setIsPassDeviceVisible} />;
       case 'watch':
         return <WatchScreen />;
       case 'spotlight':
-        return <SpotlightRevealScreen />;
+        return <SpotlightRevealScreen onPassDeviceChange={setIsPassDeviceVisible} />;
       case 'spotlight-bonus':
       case 'spotlight-joker':
       case 'spotlight-open-result':
@@ -92,7 +98,7 @@ export default function GameRouter() {
       case 'backstage-result':
         return <BackstageScreen />;
       case 'intermission':
-        return <IntermissionScreen />;
+        return <IntermissionScreen onPassDeviceChange={setIsPassDeviceVisible} />;
       case 'curtain-call':
       case 'result':
         return <ResultScreen />;
@@ -118,7 +124,7 @@ export default function GameRouter() {
           {renderScreen()}
         </div>
       </div>
-      {operatingHand && (
+      {operatingHand && !isPassDeviceVisible && (
         <div className={styles.handDock}>
           <HandPanel
             hand={operatingHand.hand}
@@ -131,7 +137,7 @@ export default function GameRouter() {
         isOpen={isInfoOpen}
         onClose={() => setIsInfoOpen(false)}
         gameState={state}
-        operatingHand={operatingHand}
+        operatingHand={isPassDeviceVisible ? null : operatingHand}
       />
     </>
   );

--- a/src/components/HandPanel.module.css
+++ b/src/components/HandPanel.module.css
@@ -5,14 +5,60 @@
 }
 
 .label {
-  font-size: 10px;
-  letter-spacing: 2px;
-  color: var(--muted, #7a8aaa);
-  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.labelName {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 14px;
+  letter-spacing: 1px;
+  color: var(--gold, #d6ac6c);
+  line-height: 1;
+}
+
+.labelCount {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 28px;
+  color: var(--gold, #d6ac6c);
+  line-height: 1;
+  margin-top: 4px;
+}
+
+.labelOf {
+  font-size: 11px;
+  color: var(--muted, #8a7a62);
 }
 
 .grid {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+/* ドックモード: 横一列スクロール */
+.dockPanel {
+  flex-direction: row;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+}
+
+.dockPanel .label {
+  min-width: 100px;
+}
+
+.dockGrid {
+  flex: 1;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 8px 0 4px;
+  gap: 4px;
+  /* スクロールバー非表示 */
+  scrollbar-width: none;
+}
+
+.dockGrid::-webkit-scrollbar {
+  display: none;
 }

--- a/src/components/HandPanel.tsx
+++ b/src/components/HandPanel.tsx
@@ -7,15 +7,19 @@ type Props = {
   hand: Card[];
   playerName: string;
   className?: string;
+  dockMode?: boolean;
 };
 
-export default function HandPanel({ hand, playerName, className }: Props) {
+export default function HandPanel({ hand, playerName, className, dockMode }: Props) {
   const sorted = sortHand(hand);
 
   return (
-    <div className={`${styles.panel} ${className ?? ''}`}>
-      <div className={styles.label}>{playerName} の手札（{hand.length}枚）</div>
-      <div className={styles.grid}>
+    <div className={`${styles.panel} ${dockMode ? styles.dockPanel : ''} ${className ?? ''}`}>
+      <div className={styles.label}>
+        <div className={styles.labelName}>{playerName}</div>
+        <div className={styles.labelCount}>{hand.length}<span className={styles.labelOf}> 枚</span></div>
+      </div>
+      <div className={`${styles.grid} ${dockMode ? styles.dockGrid : ''}`}>
         {sorted.map((card, i) => (
           <CardComponent key={i} card={{ ...card, isFaceUp: true }} />
         ))}

--- a/src/components/InfoOverlay.module.css
+++ b/src/components/InfoOverlay.module.css
@@ -2,10 +2,11 @@
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(10, 6, 8, 0.82);
   z-index: 200;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-end;
+  backdrop-filter: blur(8px);
 }
 
 .open {
@@ -13,13 +14,35 @@
 }
 
 .panel {
-  width: min(390px, 100%);
+  width: min(480px, 100%);
   height: 100dvh;
-  background: var(--surface, #16213e);
-  border-left: 1px solid var(--border, #1e2d50);
+  background: rgba(18, 10, 8, 0.98);
+  border-left: 1px solid var(--border, rgba(214, 172, 108, 0.2));
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+/* 上下の装飾ライン */
+.panel::before,
+.panel::after {
+  content: '';
+  position: sticky;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 48px;
+  height: 1px;
+  background: var(--gold, #d6ac6c);
+  flex-shrink: 0;
+}
+
+.panel::before {
+  top: 0;
+}
+
+.panel::after {
+  bottom: 0;
 }
 
 .backdropArea {
@@ -31,44 +54,65 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border, #1e2d50);
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border, rgba(214, 172, 108, 0.2));
   position: sticky;
   top: 0;
-  background: var(--surface, #16213e);
+  background: rgba(18, 10, 8, 0.98);
   z-index: 1;
 }
 
 .header h3 {
-  font-size: 15px;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 24px;
+  letter-spacing: 6px;
+  color: var(--text, #f5ebdc);
+  font-weight: 400;
   margin: 0;
+}
+
+.headerSub {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 10px;
+  letter-spacing: 4px;
+  color: var(--text-sec, #c7b496);
+  margin-top: 3px;
+  display: block;
 }
 
 .closeBtn {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
-  background: var(--border, #1e2d50);
-  border: none;
-  color: var(--text, #e0e6f0);
+  border-radius: 0;
+  background: transparent;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  color: var(--muted, #8a7a62);
+  font-family: 'Cormorant Garamond', Georgia, serif;
   font-size: 18px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: all 0.15s;
+}
+
+.closeBtn:hover {
+  color: var(--gold, #d6ac6c);
+  border-color: var(--gold, #d6ac6c);
 }
 
 .section {
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border, #1e2d50);
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border, rgba(214, 172, 108, 0.12));
 }
 
 .sectionTitle {
-  font-size: 10px;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 13px;
   letter-spacing: 2px;
-  color: var(--muted, #7a8aaa);
-  text-transform: uppercase;
-  margin: 0 0 10px;
+  color: var(--gold, #d6ac6c);
+  margin: 0 0 12px;
 }
 
 .scoreCompare {
@@ -79,7 +123,7 @@
 
 .scoreDivider {
   width: 1px;
-  background: var(--border, #1e2d50);
+  background: var(--border, rgba(214, 172, 108, 0.2));
 }
 
 .scoreCol {
@@ -88,36 +132,43 @@
 }
 
 .sName {
+  font-family: 'Noto Serif JP', serif;
   font-size: 11px;
-  color: var(--muted, #7a8aaa);
+  color: var(--muted, #8a7a62);
+  letter-spacing: 1px;
 }
 
 .sTotal {
-  font-size: 28px;
-  font-weight: bold;
-  color: var(--gold, #f0c060);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 32px;
+  color: var(--gold, #d6ac6c);
+  line-height: 1;
+  margin-top: 4px;
 }
 
 .sRow {
   display: flex;
   justify-content: space-between;
+  font-family: 'Noto Serif JP', serif;
   font-size: 11px;
-  color: var(--muted, #7a8aaa);
-  margin-top: 3px;
+  color: var(--muted, #8a7a62);
+  margin-top: 4px;
 }
 
 .sRow span:last-child {
-  color: var(--text, #e0e6f0);
+  color: var(--text, #f5ebdc);
 }
 
 .booPlayer {
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .booPlayerName {
+  font-family: 'Noto Serif JP', serif;
   font-size: 11px;
-  color: var(--muted, #7a8aaa);
-  margin-bottom: 4px;
+  color: var(--muted, #8a7a62);
+  margin-bottom: 5px;
+  letter-spacing: 1px;
 }
 
 .booBar {
@@ -127,19 +178,21 @@
 }
 
 .booDot {
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
-  background: var(--border, #1e2d50);
+  background: rgba(214, 172, 108, 0.15);
 }
 
 .booDotFilled {
-  background: var(--accent, #e63946);
+  background: var(--gold, #d6ac6c);
+  box-shadow: 0 0 6px var(--gold, #d6ac6c);
 }
 
 .booCount {
-  font-size: 11px;
-  color: var(--muted, #7a8aaa);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 13px;
+  color: var(--text-sec, #c7b496);
   margin-left: 4px;
 }
 
@@ -151,40 +204,44 @@
 }
 
 .setRemainingLabel {
-  font-size: 13px;
-  color: var(--muted, #7a8aaa);
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 1px;
 }
 
 .setCount {
-  font-size: 22px;
-  font-weight: bold;
-  color: var(--gold, #f0c060);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 24px;
+  color: var(--gold, #d6ac6c);
 }
 
 .kamiList {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 5px;
   margin-top: 6px;
   justify-content: center;
 }
 
 .kamiChip {
-  font-size: 10px;
-  padding: 2px 5px;
-  background: var(--bg, #0f172a);
-  border-radius: 4px;
-  color: var(--text, #e0e6f0);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 14px;
+  padding: 3px 10px;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  color: var(--gold, #d6ac6c);
+  background: rgba(214, 172, 108, 0.05);
 }
 
 .kamiEmpty {
-  font-size: 10px;
-  color: var(--muted, #7a8aaa);
+  font-size: 11px;
+  color: var(--muted, #8a7a62);
+  font-style: italic;
 }
 
 .stageRow {
   display: flex;
-  gap: 16px;
+  gap: 12px;
 }
 
 .stageCard {
@@ -192,24 +249,27 @@
   align-items: center;
   gap: 6px;
   font-size: 12px;
-  padding: 5px 8px;
-  background: var(--bg, #0f172a);
-  border-radius: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  background: rgba(28, 16, 14, 0.5);
 }
 
 .stageLabel {
-  font-size: 10px;
-  color: var(--muted, #7a8aaa);
+  font-family: 'Noto Serif JP', serif;
+  font-size: 9px;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 2px;
 }
 
 .stageValue {
-  color: var(--text, #e0e6f0);
-  font-weight: bold;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 16px;
+  color: var(--text, #f5ebdc);
 }
 
 .pairCompare {
   display: flex;
-  gap: 12px;
+  gap: 16px;
 }
 
 .pairCol {
@@ -219,27 +279,33 @@
 .pairRow {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 11px;
-  margin-top: 4px;
+  gap: 5px;
+  font-size: 12px;
+  margin-top: 5px;
+  padding: 4px 8px;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.12));
 }
 
 .pairKami {
-  color: var(--text, #e0e6f0);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 14px;
+  color: var(--text, #f5ebdc);
 }
 
 .pairSlash {
-  color: var(--muted, #7a8aaa);
+  color: var(--muted, #8a7a62);
 }
 
 .pairShimo {
-  color: var(--muted, #7a8aaa);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 14px;
+  color: var(--text-sec, #c7b496);
 }
 
 .knownCardsList {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 4px;
 }
 
 .knownCardRow {
@@ -247,23 +313,24 @@
   justify-content: space-between;
   align-items: center;
   font-size: 12px;
-  padding: 5px 8px;
-  background: var(--bg, #0f172a);
-  border-radius: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.12));
+  background: rgba(28, 16, 14, 0.4);
 }
 
 .knownCardLoc {
-  color: var(--muted, #7a8aaa);
+  color: var(--muted, #8a7a62);
+  font-family: 'Noto Serif JP', serif;
   font-size: 10px;
 }
 
 .knownCardPos {
-  color: var(--gold, #f0c060);
-  font-size: 10px;
-  font-weight: bold;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  color: var(--gold, #d6ac6c);
+  font-size: 14px;
 }
 
-/* 手札セクション：大画面では HandSidebar が常時表示するため非表示にする */
+/* 手札セクション: ドックモード時は非表示 */
 @media (min-width: 600px) {
   .handSection {
     display: none;

--- a/src/components/PassDevice.module.css
+++ b/src/components/PassDevice.module.css
@@ -40,17 +40,19 @@
 .holdBtn {
   width: 100%;
   padding: 16px;
-  border: 2px solid var(--accent, #e63946);
-  border-radius: 12px;
+  border: 1.5px solid var(--gold, #d6ac6c);
+  border-radius: 0;
   background: transparent;
-  color: var(--text, #e0e6f0);
-  font-size: 14px;
-  font-weight: bold;
+  color: var(--text, #f5ebdc);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 3px;
   cursor: pointer;
   position: relative;
   overflow: hidden;
   -webkit-tap-highlight-color: transparent;
   touch-action: none;
+  font-family: 'Inter', sans-serif;
 }
 
 .holdFill {
@@ -59,7 +61,7 @@
   left: 0;
   height: 100%;
   width: 0;
-  background: rgba(230, 57, 70, 0.25);
+  background: rgba(214, 172, 108, 0.25);
   z-index: 0;
 }
 

--- a/src/components/PhaseHeader.module.css
+++ b/src/components/PhaseHeader.module.css
@@ -1,36 +1,159 @@
-.phaseHeader {
+.topbar {
+  flex-shrink: 0;
+  height: 64px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
-  background: var(--surface, #16213e);
-  border-bottom: 1px solid var(--border, #1e2d50);
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  background: rgba(18, 10, 8, 0.85);
+  backdrop-filter: blur(12px);
+  position: relative;
+  z-index: 2;
+  gap: 16px;
+}
+
+/* 左: ロゴ */
+.logo {
   flex-shrink: 0;
 }
 
-.phaseName {
-  font-size: 15px;
-  font-weight: bold;
-  margin: 0;
+.logoText {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 22px;
+  letter-spacing: 3px;
+  color: var(--text, #f5ebdc);
+  line-height: 1;
 }
 
-.sub {
-  font-size: 11px;
-  color: var(--muted, #7a8aaa);
-  margin-top: 2px;
+.logoText em {
+  color: var(--gold, #d6ac6c);
+  font-style: italic;
+  font-weight: 500;
 }
 
-.infoBtn {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: var(--border, #1e2d50);
-  border: none;
-  color: var(--text, #e0e6f0);
-  font-size: 16px;
-  cursor: pointer;
+.logoSub {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 9px;
+  letter-spacing: 4px;
+  color: var(--muted, #8a7a62);
+  margin-top: 3px;
+}
+
+/* 中央: フェーズピル */
+.phasePill {
   display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 16px;
+  padding: 8px 20px;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  background: rgba(214, 172, 108, 0.04);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.actLabel {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 13px;
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 1px;
+  padding-right: 14px;
+  border-right: 1px solid rgba(214, 172, 108, 0.2);
+  line-height: 1;
+}
+
+.phaseInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  line-height: 1.1;
+}
+
+.phaseName {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 14px;
+  letter-spacing: 3px;
+  color: var(--text, #f5ebdc);
+}
+
+.phaseSub {
+  font-size: 10px;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 1px;
+}
+
+/* 右: ボタン + バッジ */
+.right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.playbillBtn {
+  padding: 7px 16px;
+  background: transparent;
+  color: var(--gold, #d6ac6c);
+  border: 1px solid var(--border-strong, rgba(214, 172, 108, 0.35));
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 13px;
+  letter-spacing: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+  transition: background 0.15s;
+  border-radius: 0;
+}
+
+.playbillBtn:hover {
+  background: rgba(214, 172, 108, 0.1);
+}
+
+.playbillDot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--gold, #d6ac6c);
+  flex-shrink: 0;
+}
+
+/* ロールバッジ */
+.roleBadges {
+  display: flex;
+  gap: 6px;
+}
+
+.role {
+  padding: 5px 12px;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  color: var(--text-sec, #c7b496);
+  font-family: 'Noto Serif JP', serif;
+  font-size: 11px;
+  letter-spacing: 1px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  border-radius: 0;
+  background: transparent;
+  transition: all 0.2s;
+}
+
+.roleActive {
+  background: rgba(214, 172, 108, 0.12);
+  border-color: var(--gold, #d6ac6c);
+  color: var(--gold, #d6ac6c);
+}
+
+.roleDot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--gold, #d6ac6c);
+  box-shadow: 0 0 6px var(--gold, #d6ac6c);
   flex-shrink: 0;
 }

--- a/src/components/PhaseHeader.tsx
+++ b/src/components/PhaseHeader.tsx
@@ -4,18 +4,69 @@ type Props = {
   phaseName: string;
   activePlayerName: string;
   onInfoOpen: () => void;
+  actLabel?: string;
+  subLabel?: string;
+  playerAName?: string;
+  playerBName?: string;
 };
 
-export default function PhaseHeader({ phaseName, activePlayerName, onInfoOpen }: Props) {
+export default function PhaseHeader({
+  phaseName,
+  activePlayerName,
+  onInfoOpen,
+  actLabel,
+  subLabel,
+  playerAName,
+  playerBName,
+}: Props) {
+  const hasRoleBadges = playerAName && playerBName;
+
   return (
-    <div className={styles.phaseHeader}>
-      <div>
-        <h2 className={styles.phaseName}>{phaseName}</h2>
-        <div className={styles.sub}>{activePlayerName}</div>
+    <div className={styles.topbar}>
+      {/* 左: ロゴ */}
+      <div className={styles.logo}>
+        <div className={styles.logoText}>
+          Curtain<em>Call</em>
+        </div>
+        <div className={styles.logoSub}>カーテンコール</div>
       </div>
-      <button className={styles.infoBtn} onClick={onInfoOpen} aria-label="ゲーム情報を開く">
-        📊
-      </button>
+
+      {/* 中央: フェーズピル */}
+      <div className={styles.phasePill}>
+        {actLabel && <div className={styles.actLabel}>{actLabel}</div>}
+        <div className={styles.phaseInfo}>
+          <div className={styles.phaseName}>{phaseName}</div>
+          <div className={styles.phaseSub}>{subLabel ?? activePlayerName}</div>
+        </div>
+      </div>
+
+      {/* 右: PLAYBILLボタン + ロールバッジ */}
+      <div className={styles.right}>
+        <button
+          className={styles.playbillBtn}
+          onClick={onInfoOpen}
+          aria-label="ゲーム情報を開く"
+        >
+          <span className={styles.playbillDot} />
+          PLAYBILL
+        </button>
+        {hasRoleBadges && (
+          <div className={styles.roleBadges}>
+            <div
+              className={`${styles.role} ${activePlayerName === playerAName ? styles.roleActive : ''}`}
+            >
+              {activePlayerName === playerAName && <span className={styles.roleDot} />}
+              {playerAName}
+            </div>
+            <div
+              className={`${styles.role} ${activePlayerName === playerBName ? styles.roleActive : ''}`}
+            >
+              {activePlayerName === playerBName && <span className={styles.roleDot} />}
+              {playerBName}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/ResultModal.module.css
+++ b/src/components/ResultModal.module.css
@@ -10,23 +10,40 @@
 }
 
 .modal {
-  background: var(--bg, #0f172a);
-  border: 1px solid rgba(240, 192, 96, 0.3);
-  border-radius: 16px;
-  padding: 32px 24px;
-  max-width: 360px;
+  background: rgba(18, 10, 8, 0.98);
+  border: 1px solid var(--border-strong, rgba(214, 172, 108, 0.35));
+  border-radius: 0;
+  padding: 36px 32px;
+  max-width: 400px;
   width: 90%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 24px;
+  gap: 20px;
+  position: relative;
 }
 
+.modal::before,
+.modal::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 48px;
+  height: 1px;
+  background: var(--gold, #d6ac6c);
+}
+
+.modal::before { top: 12px; }
+.modal::after  { bottom: 12px; }
+
 .title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
   font-size: 20px;
-  font-weight: bold;
-  color: var(--gold, #f0c060);
-  letter-spacing: 0.05em;
+  font-weight: 400;
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 3px;
   margin: 0;
 }
 
@@ -58,16 +75,24 @@
 
 .proceedBtn {
   padding: 14px 40px;
-  border-radius: 12px;
-  font-size: 16px;
-  font-weight: bold;
+  border-radius: 0;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 2px;
   cursor: pointer;
-  border: 2px solid var(--gold, #f0c060);
-  background: transparent;
-  color: var(--gold, #f0c060);
+  border: none;
+  background: var(--gold, #d6ac6c);
+  color: #120a08;
+  font-family: 'Inter', sans-serif;
   -webkit-tap-highlight-color: transparent;
+  transition: all 0.15s;
+}
+
+.proceedBtn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(214, 172, 108, 0.3);
 }
 
 .proceedBtn:active {
-  background: rgba(240, 192, 96, 0.12);
+  transform: translateY(0);
 }

--- a/src/components/StageOverview.module.css
+++ b/src/components/StageOverview.module.css
@@ -1,18 +1,20 @@
 .container {
   width: 100%;
   max-width: 360px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 10px;
-  padding: 8px 12px;
+  background: rgba(28, 16, 14, 0.5);
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.15));
+  border-radius: 0;
+  padding: 10px 14px;
   box-sizing: border-box;
 }
 
 .title {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
   font-size: 11px;
-  color: var(--muted, #7a8aaa);
-  margin: 0 0 6px;
-  letter-spacing: 0.05em;
+  color: var(--muted, #8a7a62);
+  margin: 0 0 8px;
+  letter-spacing: 3px;
   text-align: center;
 }
 
@@ -25,7 +27,7 @@
 .divider {
   width: 1px;
   align-self: stretch;
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--border, rgba(214, 172, 108, 0.2));
   flex-shrink: 0;
 }
 
@@ -38,9 +40,10 @@
 }
 
 .playerName {
+  font-family: 'Noto Serif JP', serif;
   font-size: 11px;
-  font-weight: bold;
-  color: var(--gold, #f0c060);
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 1px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,8 +2,15 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang="en">
-      <Head />
+    <Html lang="ja">
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Noto+Serif+JP:wght@400;500;600&family=Noto+Sans+JP:wght@400;500&family=Inter:wght@400;500;600&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/src/screens/ActionScreen.module.css
+++ b/src/screens/ActionScreen.module.css
@@ -74,7 +74,7 @@
 .confirmBtn {
   padding: 14px 40px;
   border: 2px solid var(--gold, #f0c060);
-  border-radius: 12px;
+  border-radius: 0;
   background: transparent;
   color: var(--gold, #f0c060);
   font-size: 16px;

--- a/src/screens/ActionScreen.tsx
+++ b/src/screens/ActionScreen.tsx
@@ -8,7 +8,9 @@ import styles from './ActionScreen.module.css';
 
 type SelectionStep = 'selectingActor' | 'selectingKuroko' | 'confirmed';
 
-export default function ActionScreen() {
+type Props = { onPassDeviceChange?: (visible: boolean) => void };
+
+export default function ActionScreen({ onPassDeviceChange }: Props) {
   const state = useGameState();
   const dispatch = useGameDispatch();
   const [step, setStep] = useState<SelectionStep>('selectingActor');
@@ -51,6 +53,7 @@ export default function ActionScreen() {
   const handleConfirm = () => {
     if (kamiIndex === null || shimoIndex === null) return;
     setShowPassDevice(true);
+    onPassDeviceChange?.(true);
   };
 
   if (showPassDevice && kamiIndex !== null && shimoIndex !== null) {
@@ -59,7 +62,10 @@ export default function ActionScreen() {
     return (
       <PassDevice
         playerName={state.players[1].name}
-        onComplete={() => dispatch({ type: 'ACTION_PLAY', kamiIndex, shimoIndex })}
+        onComplete={() => {
+          onPassDeviceChange?.(false);
+          dispatch({ type: 'ACTION_PLAY', kamiIndex, shimoIndex });
+        }}
       />
     );
   }

--- a/src/screens/BackstageScreen.module.css
+++ b/src/screens/BackstageScreen.module.css
@@ -11,7 +11,7 @@
 .heading {
   font-size: 24px;
   font-weight: bold;
-  color: var(--accent, #60a5fa);
+  color: var(--gold, #d6ac6c);
   letter-spacing: 0.05em;
   margin: 0;
 }
@@ -73,12 +73,12 @@
 
 .judgeBtn {
   padding: 12px 32px;
-  border-radius: 12px;
+  border-radius: 0;
   font-size: 16px;
   font-weight: bold;
   cursor: pointer;
   border: none;
-  background: var(--accent, #60a5fa);
+  background: var(--gold, #d6ac6c);
   color: #fff;
   -webkit-tap-highlight-color: transparent;
 }
@@ -94,13 +94,13 @@
 
 .proceedBtn {
   padding: 12px 28px;
-  border-radius: 12px;
+  border-radius: 0;
   font-size: 15px;
   font-weight: bold;
   cursor: pointer;
-  border: 2px solid var(--accent, #60a5fa);
+  border: 2px solid var(--gold, #d6ac6c);
   background: transparent;
-  color: var(--accent, #60a5fa);
+  color: var(--gold, #d6ac6c);
   -webkit-tap-highlight-color: transparent;
 }
 

--- a/src/screens/IntermissionScreen.module.css
+++ b/src/screens/IntermissionScreen.module.css
@@ -3,62 +3,143 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 24px;
-  padding: 40px 16px;
-  background: var(--bg, #0f172a);
+  justify-content: center;
+  gap: 0;
+  padding: 40px 32px;
+  position: relative;
+  z-index: 5;
+  background: rgba(10, 6, 8, 0.92);
+}
+
+.screen::before,
+.screen::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 1px;
+  background: var(--gold, #d6ac6c);
+}
+
+.screen::before { top: 24px; }
+.screen::after  { bottom: 24px; }
+
+.ornament {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 11px;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 4px;
+  margin-bottom: 14px;
 }
 
 .heading {
-  font-size: 24px;
-  font-weight: bold;
-  color: var(--accent, #60a5fa);
-  letter-spacing: 0.05em;
-  margin: 0;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 48px;
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 8px;
+  margin: 0 0 6px;
+  line-height: 1;
 }
 
-.roundInfo {
-  font-size: 14px;
-  color: var(--muted, #7a8aaa);
-  margin: 0;
+.headingJp {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  color: var(--text-sec, #c7b496);
+  letter-spacing: 4px;
+  margin-bottom: 32px;
 }
 
 .swapInfo {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 28px;
 }
 
 .swapLabel {
-  font-size: 13px;
-  color: var(--muted, #7a8aaa);
+  font-family: 'Noto Serif JP', serif;
+  font-size: 20px;
+  color: var(--muted, #8a7a62);
+  text-decoration: line-through;
   margin: 0;
 }
 
 .swapArrow {
-  font-size: 20px;
-  color: var(--accent, #60a5fa);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 28px;
+  color: var(--gold, #d6ac6c);
 }
 
 .nextScout {
-  font-size: 18px;
-  font-weight: bold;
-  color: #fff;
+  font-family: 'Noto Serif JP', serif;
+  font-size: 24px;
+  font-weight: 500;
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 2px;
   margin: 0;
 }
 
+.roundInfo {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  color: var(--muted, #8a7a62);
+  margin: 0 0 28px;
+  letter-spacing: 1px;
+}
+
+.scoreTable {
+  width: 100%;
+  max-width: 420px;
+  border: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  margin-bottom: 32px;
+}
+
+.scoreRow {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 20px;
+  border-bottom: 1px solid rgba(214, 172, 108, 0.08);
+}
+
+.scoreRow:last-child {
+  border-bottom: none;
+}
+
+.scoreKey {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  color: var(--muted, #8a7a62);
+}
+
+.scoreVal {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 16px;
+  color: var(--gold, #d6ac6c);
+}
+
 .proceedBtn {
-  padding: 12px 28px;
-  border-radius: 12px;
-  font-size: 15px;
-  font-weight: bold;
+  padding: 16px 40px;
+  border: none;
+  border-radius: 0;
+  background: var(--gold, #d6ac6c);
+  color: #120a08;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 3px;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
-  border: 2px solid var(--accent, #60a5fa);
-  background: transparent;
-  color: var(--accent, #60a5fa);
-  -webkit-tap-highlight-color: transparent;
+  transition: all 0.15s;
+}
+
+.proceedBtn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(214, 172, 108, 0.3);
 }
 
 .proceedBtn:active {
-  background: rgba(96, 165, 250, 0.12);
+  transform: translateY(0);
 }

--- a/src/screens/IntermissionScreen.tsx
+++ b/src/screens/IntermissionScreen.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
+import { calculateScore } from '@/lib/scoring';
 import PassDevice from '@/components/PassDevice';
 import styles from './IntermissionScreen.module.css';
 
@@ -10,6 +11,8 @@ export default function IntermissionScreen() {
 
   const currentScout = state.players[0];
   const nextScout = state.players[1];
+  const scoreA = calculateScore(state, 'A');
+  const scoreB = calculateScore(state, 'B');
 
   if (showPassDevice) {
     return (
@@ -22,20 +25,44 @@ export default function IntermissionScreen() {
 
   return (
     <div className={styles.screen}>
-      <h1 className={styles.heading}>インターミッション</h1>
-      <p className={styles.roundInfo}>ラウンド {state.round} 終了</p>
+      <div className={styles.ornament}>— Entr&apos;acte —</div>
+      <h1 className={styles.heading}>INTERMISSION</h1>
+      <div className={styles.headingJp}>インターミッション</div>
+      <div className={styles.headingSub}>休憩 · 役割交代</div>
 
+      <p className={styles.swapLabel}>次のスカウト担当</p>
       <div className={styles.swapInfo}>
-        <p className={styles.swapLabel}>次のスカウト担当</p>
         <p className={styles.swapArrow}>{currentScout.name} → {nextScout.name}</p>
         <p className={styles.nextScout}>{nextScout.name}</p>
       </div>
 
+      <p className={styles.roundInfo}>ラウンド {state.round} 終了</p>
+
+      <div className={styles.scoreTable}>
+        <div className={styles.scoreRow}>
+          <span className={styles.scoreKey}>{currentScout.name} カミ合計</span>
+          <span className={styles.scoreVal}>+{scoreA.kamiTotal}</span>
+        </div>
+        <div className={styles.scoreRow}>
+          <span className={styles.scoreKey}>{nextScout.name} カミ合計</span>
+          <span className={styles.scoreVal}>+{scoreB.kamiTotal}</span>
+        </div>
+        <div className={styles.scoreRow}>
+          <span className={styles.scoreKey}>セット残り</span>
+          <span className={styles.scoreVal}>{state.setRemainingCount} 枚</span>
+        </div>
+        <div className={styles.scoreRow}>
+          <span className={styles.scoreKey}>BOO 回数</span>
+          <span className={styles.scoreVal}>{state.playerABooCnt} · {state.playerBBooCnt} / 3</span>
+        </div>
+      </div>
+
       <button
         className={styles.proceedBtn}
+        aria-label="次のラウンドへ"
         onClick={() => setShowPassDevice(true)}
       >
-        次のラウンドへ
+        NEXT ACT · 次幕へ
       </button>
     </div>
   );

--- a/src/screens/IntermissionScreen.tsx
+++ b/src/screens/IntermissionScreen.tsx
@@ -4,7 +4,9 @@ import { calculateScore } from '@/lib/scoring';
 import PassDevice from '@/components/PassDevice';
 import styles from './IntermissionScreen.module.css';
 
-export default function IntermissionScreen() {
+type Props = { onPassDeviceChange?: (visible: boolean) => void };
+
+export default function IntermissionScreen({ onPassDeviceChange }: Props) {
   const state = useGameState();
   const dispatch = useGameDispatch();
   const [showPassDevice, setShowPassDevice] = useState(false);
@@ -18,7 +20,10 @@ export default function IntermissionScreen() {
     return (
       <PassDevice
         playerName={nextScout.name}
-        onComplete={() => dispatch({ type: 'INTERMISSION' })}
+        onComplete={() => {
+          onPassDeviceChange?.(false);
+          dispatch({ type: 'INTERMISSION' });
+        }}
       />
     );
   }
@@ -60,7 +65,7 @@ export default function IntermissionScreen() {
       <button
         className={styles.proceedBtn}
         aria-label="次のラウンドへ"
-        onClick={() => setShowPassDevice(true)}
+        onClick={() => { setShowPassDevice(true); onPassDeviceChange?.(true); }}
       >
         NEXT ACT · 次幕へ
       </button>

--- a/src/screens/ResultScreen.module.css
+++ b/src/screens/ResultScreen.module.css
@@ -3,23 +3,60 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 24px;
+  gap: 0;
   padding: 40px 16px;
-  background: var(--bg, #0f172a);
+  overflow-y: auto;
+  position: relative;
+  z-index: 5;
+  background: rgba(10, 6, 8, 0.92);
+}
+
+.screen::before,
+.screen::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 1px;
+  background: var(--gold, #d6ac6c);
+}
+
+.screen::before { top: 20px; }
+.screen::after  { bottom: 20px; }
+
+.ornament {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 11px;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 4px;
+  margin-bottom: 14px;
 }
 
 .heading {
-  font-size: 24px;
-  font-weight: bold;
-  color: var(--accent, #60a5fa);
-  letter-spacing: 0.05em;
-  margin: 0;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 52px;
+  color: var(--text, #f5ebdc);
+  letter-spacing: 8px;
+  margin: 0 0 6px;
+  line-height: 1;
+}
+
+.headingJp {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  color: var(--text-sec, #c7b496);
+  letter-spacing: 6px;
+  margin-bottom: 8px;
 }
 
 .reason {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
   font-size: 13px;
-  color: var(--muted, #7a8aaa);
-  margin: 0;
+  color: var(--muted, #8a7a62);
+  margin: 0 0 28px;
   text-align: center;
 }
 
@@ -27,79 +64,93 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-bottom: 24px;
 }
 
 .winnerText {
-  font-size: 20px;
-  font-weight: bold;
-  color: #facc15;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 3px;
   margin: 0;
 }
 
 .draw {
-  font-size: 20px;
-  font-weight: bold;
-  color: var(--muted, #7a8aaa);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 22px;
+  color: var(--muted, #8a7a62);
   margin: 0;
 }
 
 .table {
   border-collapse: collapse;
   width: 100%;
-  max-width: 360px;
+  max-width: 480px;
+  margin-bottom: 32px;
 }
 
 .th {
-  padding: 8px 12px;
-  font-size: 13px;
-  color: var(--muted, #7a8aaa);
+  padding: 10px 14px;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 14px;
+  color: var(--text-sec, #c7b496);
   text-align: center;
-  border-bottom: 1px solid #1e2d42;
+  border-bottom: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  font-weight: 400;
 }
 
 .th.winnerCol {
-  color: #facc15;
+  color: var(--gold, #d6ac6c);
+  font-weight: 500;
 }
 
 .label {
-  padding: 8px 12px;
-  font-size: 13px;
-  color: var(--muted, #7a8aaa);
+  padding: 10px 14px;
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  color: var(--muted, #8a7a62);
   text-align: left;
 }
 
 .td {
-  padding: 8px 12px;
-  font-size: 15px;
-  color: #fff;
+  padding: 10px 14px;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 16px;
+  color: var(--text-sec, #c7b496);
   text-align: center;
+  border-top: 1px solid rgba(214, 172, 108, 0.08);
 }
 
 .total {
-  padding: 8px 12px;
-  font-size: 18px;
-  font-weight: bold;
-  color: #fff;
+  padding: 14px;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 26px;
+  color: var(--text-sec, #c7b496);
   text-align: center;
-  border-top: 1px solid #1e2d42;
+  border-top: 2px solid var(--gold, #d6ac6c);
 }
 
 .winTotal {
-  color: #facc15;
+  color: var(--gold, #d6ac6c);
 }
 
 .resetBtn {
-  padding: 12px 28px;
-  border-radius: 12px;
-  font-size: 15px;
-  font-weight: bold;
+  padding: 14px 32px;
+  border-radius: 0;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 3px;
   cursor: pointer;
-  border: 2px solid var(--accent, #60a5fa);
+  border: 1.5px solid var(--gold, #d6ac6c);
   background: transparent;
-  color: var(--accent, #60a5fa);
-  -webkit-tap-highlight-color: transparent;
+  color: var(--gold, #d6ac6c);
+  font-family: 'Inter', sans-serif;
+  transition: all 0.15s;
 }
 
-.resetBtn:active {
-  background: rgba(96, 165, 250, 0.12);
+.resetBtn:hover {
+  background: rgba(214, 172, 108, 0.1);
 }

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -24,7 +24,9 @@ export default function ResultScreen() {
 
   return (
     <div className={styles.screen}>
-      <h1 className={styles.heading}>カーテンコール</h1>
+      <div className={styles.ornament}>— Finale —</div>
+      <h1 className={styles.heading}>CURTAIN CALL</h1>
+      <div className={styles.headingJp}>カーテンコール</div>
 
       {state.curtainCallReason && (
         <p className={styles.reason}>{CURTAIN_CALL_REASON_LABEL[state.curtainCallReason]}</p>
@@ -35,7 +37,7 @@ export default function ResultScreen() {
           <p className={styles.draw}>引き分け</p>
         ) : (
           <p className={styles.winnerText}>
-            {winner === 'A' ? playerA?.name : playerB?.name} の勝利！
+            🏆 {winner === 'A' ? playerA?.name : playerB?.name} の勝利！
           </p>
         )}
       </div>
@@ -82,9 +84,10 @@ export default function ResultScreen() {
 
       <button
         className={styles.resetBtn}
+        aria-label="もう一度"
         onClick={() => dispatch({ type: 'RESET_GAME' })}
       >
-        もう一度
+        ENCORE · もう一度
       </button>
     </div>
   );

--- a/src/screens/ScoutScreen.module.css
+++ b/src/screens/ScoutScreen.module.css
@@ -34,7 +34,7 @@
 .confirmBtn {
   padding: 14px 40px;
   border: 2px solid var(--gold, #f0c060);
-  border-radius: 12px;
+  border-radius: 0;
   background: transparent;
   color: var(--gold, #f0c060);
   font-size: 16px;

--- a/src/screens/SpotlightBonusScreen.module.css
+++ b/src/screens/SpotlightBonusScreen.module.css
@@ -32,7 +32,7 @@
 
 .cancelBtn {
   padding: 12px 28px;
-  border-radius: 12px;
+  border-radius: 0;
   font-size: 15px;
   font-weight: bold;
   cursor: pointer;

--- a/src/screens/SpotlightRevealScreen.module.css
+++ b/src/screens/SpotlightRevealScreen.module.css
@@ -45,7 +45,7 @@
 
 .revealBtn {
   padding: 14px 40px;
-  border-radius: 12px;
+  border-radius: 0;
   font-size: 16px;
   font-weight: bold;
   cursor: pointer;
@@ -87,7 +87,7 @@
 .openSetBtn,
 .skipBtn {
   padding: 12px 28px;
-  border-radius: 12px;
+  border-radius: 0;
   font-size: 15px;
   font-weight: bold;
   cursor: pointer;

--- a/src/screens/SpotlightRevealScreen.tsx
+++ b/src/screens/SpotlightRevealScreen.tsx
@@ -1,11 +1,13 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useGameDispatch, useGameState } from '@/game/context';
 import Card from '@/components/Card';
 import PassDevice from '@/components/PassDevice';
 import StageOverview from '@/components/StageOverview';
 import styles from './SpotlightRevealScreen.module.css';
 
-export default function SpotlightRevealScreen() {
+type Props = { onPassDeviceChange?: (visible: boolean) => void };
+
+export default function SpotlightRevealScreen({ onPassDeviceChange }: Props) {
   const state = useGameState();
   const dispatch = useGameDispatch();
   const [actorReady, setActorReady] = useState(false);
@@ -16,6 +18,10 @@ export default function SpotlightRevealScreen() {
     isRevealed && kami !== null && shimo !== null && kami.rank === shimo.rank;
   const isNoMatch =
     isRevealed && kami !== null && shimo !== null && kami.rank !== shimo.rank;
+
+  useEffect(() => {
+    onPassDeviceChange?.(isMatch && !actorReady);
+  }, [isMatch, actorReady, onPassDeviceChange]);
 
   return (
     <div className={styles.screen}>

--- a/src/screens/StandbyScreen.module.css
+++ b/src/screens/StandbyScreen.module.css
@@ -6,27 +6,61 @@
   justify-content: center;
   gap: 32px;
   padding: 32px;
-  background: var(--bg, #0f172a);
+  position: relative;
+  z-index: 5;
+  background: rgba(10, 6, 8, 0.92);
+}
+
+.screen::before,
+.screen::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 1px;
+  background: var(--gold, #d6ac6c);
+}
+
+.screen::before { top: 24px; }
+.screen::after  { bottom: 24px; }
+
+.ornament {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 11px;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 4px;
+  text-transform: uppercase;
 }
 
 .heading {
-  font-size: 24px;
-  font-weight: bold;
-  color: var(--gold, #f0c060);
-  letter-spacing: 0.05em;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 38px;
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 3px;
   margin: 0;
+  line-height: 1;
+}
+
+.headingJp {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 13px;
+  color: var(--text-sec, #c7b496);
+  letter-spacing: 5px;
 }
 
 .summary {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+  max-width: 480px;
   width: 100%;
-  max-width: 320px;
-  background: var(--surface, #1e293b);
-  border: 1.5px solid var(--border, #2a3a5a);
-  border-radius: 12px;
-  padding: 20px;
+}
+
+.summaryItem {
+  text-align: center;
 }
 
 .row {
@@ -35,29 +69,48 @@
   align-items: center;
 }
 
-.label {
-  font-size: 14px;
-  color: var(--muted, #7a8aaa);
+.count {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 44px;
+  color: var(--gold, #d6ac6c);
+  line-height: 1;
 }
 
-.count {
-  font-size: 16px;
-  font-weight: bold;
-  color: var(--text, #e0e6f0);
+.label {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  color: var(--text, #f5ebdc);
+  margin-top: 8px;
+  letter-spacing: 1px;
+}
+
+.sublabel {
+  font-size: 9px;
+  color: var(--muted, #8a7a62);
+  margin-top: 3px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
 }
 
 .readyBtn {
-  padding: 14px 40px;
-  border: 2px solid var(--gold, #f0c060);
-  border-radius: 12px;
-  background: transparent;
-  color: var(--gold, #f0c060);
-  font-size: 16px;
-  font-weight: bold;
+  padding: 16px 40px;
+  border: none;
+  border-radius: 0;
+  background: var(--gold, #d6ac6c);
+  color: #120a08;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 3px;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
+  transition: all 0.15s;
+}
+
+.readyBtn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(214, 172, 108, 0.3);
 }
 
 .readyBtn:active {
-  background: rgba(240, 192, 96, 0.12);
+  transform: translateY(0);
 }

--- a/src/screens/StandbyScreen.tsx
+++ b/src/screens/StandbyScreen.tsx
@@ -17,29 +17,34 @@ export default function StandbyScreen() {
     );
   }
 
+  const summaryItems = [
+    { count: state.players[0].hand.length, label: `${state.players[0].name} の手札`, sublabel: '手札' },
+    { count: state.players[1].hand.length, label: `${state.players[1].name} の手札`, sublabel: '手札' },
+    { count: state.deck.length, label: 'セット', sublabel: 'メイン' },
+    { count: state.backstage.length, label: 'バックステージ', sublabel: 'アイテム' },
+  ];
+
   return (
     <div className={styles.screen}>
-      <h1 className={styles.heading}>カード配布完了</h1>
+      <div className={styles.ornament}>Act I</div>
+      <h1 className={styles.heading}>Setting the Stage</h1>
+      <h2 className={styles.headingJp}>カード配布完了</h2>
+
       <div className={styles.summary}>
-        <div className={styles.row}>
-          <span className={styles.label}>{state.players[0].name} の手札</span>
-          <span className={styles.count}>{state.players[0].hand.length} 枚</span>
-        </div>
-        <div className={styles.row}>
-          <span className={styles.label}>{state.players[1].name} の手札</span>
-          <span className={styles.count}>{state.players[1].hand.length} 枚</span>
-        </div>
-        <div className={styles.row}>
-          <span className={styles.label}>バックステージ</span>
-          <span className={styles.count}>{state.backstage.length} 枚</span>
-        </div>
-        <div className={styles.row}>
-          <span className={styles.label}>セット</span>
-          <span className={styles.count}>{state.deck.length} 枚</span>
-        </div>
+        {summaryItems.map((item) => (
+          <div key={item.label} className={styles.summaryItem}>
+            <div className={styles.count}>{item.count} 枚</div>
+            <div className={styles.label}>{item.label}</div>
+          </div>
+        ))}
       </div>
-      <button className={styles.readyBtn} onClick={() => setShowPassDevice(true)}>
-        準備完了
+
+      <button
+        className={styles.readyBtn}
+        aria-label="準備完了"
+        onClick={() => setShowPassDevice(true)}
+      >
+        OPEN THE CURTAIN · 開幕
       </button>
     </div>
   );

--- a/src/screens/StandbyScreen.tsx
+++ b/src/screens/StandbyScreen.tsx
@@ -3,7 +3,9 @@ import { useGameDispatch, useGameState } from '@/game/context';
 import PassDevice from '@/components/PassDevice';
 import styles from './StandbyScreen.module.css';
 
-export default function StandbyScreen() {
+type Props = { onPassDeviceChange?: (visible: boolean) => void };
+
+export default function StandbyScreen({ onPassDeviceChange }: Props) {
   const state = useGameState();
   const dispatch = useGameDispatch();
   const [showPassDevice, setShowPassDevice] = useState(false);
@@ -12,7 +14,10 @@ export default function StandbyScreen() {
     return (
       <PassDevice
         playerName={state.players[0].name}
-        onComplete={() => dispatch({ type: 'START_SCOUT' })}
+        onComplete={() => {
+          onPassDeviceChange?.(false);
+          dispatch({ type: 'START_SCOUT' });
+        }}
       />
     );
   }
@@ -42,7 +47,7 @@ export default function StandbyScreen() {
       <button
         className={styles.readyBtn}
         aria-label="準備完了"
-        onClick={() => setShowPassDevice(true)}
+        onClick={() => { setShowPassDevice(true); onPassDeviceChange?.(true); }}
       >
         OPEN THE CURTAIN · 開幕
       </button>

--- a/src/screens/TitleScreen.module.css
+++ b/src/screens/TitleScreen.module.css
@@ -4,72 +4,142 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 32px;
+  gap: 0;
   padding: 32px;
-  background: var(--bg, #0f172a);
+  position: relative;
+  z-index: 5;
+  background: rgba(10, 6, 8, 0.92);
+}
+
+/* 上下の装飾ライン */
+.screen::before,
+.screen::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 1px;
+  background: var(--gold, #d6ac6c);
+}
+
+.screen::before { top: 24px; }
+.screen::after  { bottom: 24px; }
+
+.ornament {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 6px;
+  font-size: 11px;
+  text-transform: uppercase;
+  margin-bottom: 16px;
 }
 
 .heading {
-  font-size: 32px;
-  font-weight: bold;
-  color: var(--gold, #f0c060);
-  letter-spacing: 0.05em;
-  margin: 0;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-weight: 400;
+  font-size: 60px;
+  letter-spacing: 6px;
+  color: var(--text, #f5ebdc);
+  margin: 0 0 8px;
+  line-height: 1;
+}
+
+.heading em {
+  color: var(--gold, #d6ac6c);
+  font-style: italic;
+  font-weight: 500;
+}
+
+.headingJp {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 12px;
+  letter-spacing: 10px;
+  color: var(--text-sec, #c7b496);
+  margin-bottom: 36px;
 }
 
 .form {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
   width: 100%;
-  max-width: 320px;
+  max-width: 480px;
+  margin-bottom: 40px;
 }
 
 .field {
+  border-bottom: 1px solid var(--border, rgba(214, 172, 108, 0.2));
+  padding-bottom: 8px;
+  text-align: left;
+}
+
+.fieldHeader {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  align-items: baseline;
+  gap: 8px;
 }
 
 .label {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
   font-size: 13px;
-  font-weight: bold;
-  color: var(--muted, #7a8aaa);
+  color: var(--gold, #d6ac6c);
+  letter-spacing: 1px;
+}
+
+.labelSub {
+  font-family: 'Noto Serif JP', serif;
+  font-size: 10px;
+  color: var(--muted, #8a7a62);
+  letter-spacing: 2px;
 }
 
 .input {
-  padding: 12px 14px;
-  border: 1.5px solid var(--border, #2a3a5a);
-  border-radius: 8px;
-  background: var(--surface, #1e293b);
-  color: var(--text, #e0e6f0);
-  font-size: 16px;
+  width: 100%;
+  margin-top: 6px;
+  background: transparent;
+  border: none;
+  color: var(--text, #f5ebdc);
+  font-size: 20px;
+  font-family: 'Noto Serif JP', serif;
   outline: none;
+  padding: 4px 0;
 }
 
-.input:focus {
-  border-color: var(--gold, #f0c060);
+.input::placeholder {
+  color: rgba(138, 122, 98, 0.5);
+  font-size: 14px;
 }
 
 .error {
-  font-size: 12px;
-  color: var(--accent, #e63946);
-  margin: 0;
+  font-size: 11px;
+  color: var(--danger, #c86a4a);
+  margin: 4px 0 0;
+  letter-spacing: 1px;
+  font-family: 'Noto Serif JP', serif;
 }
 
 .startBtn {
-  margin-top: 8px;
-  padding: 14px;
-  border: 2px solid var(--gold, #f0c060);
-  border-radius: 12px;
-  background: transparent;
-  color: var(--gold, #f0c060);
-  font-size: 16px;
-  font-weight: bold;
+  padding: 16px 40px;
+  border: none;
+  border-radius: 0;
+  background: var(--gold, #d6ac6c);
+  color: #120a08;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 4px;
+  font-family: 'Inter', sans-serif;
   cursor: pointer;
-  -webkit-tap-highlight-color: transparent;
+  transition: all 0.15s;
+}
+
+.startBtn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(214, 172, 108, 0.3);
 }
 
 .startBtn:active {
-  background: rgba(240, 192, 96, 0.12);
+  transform: translateY(0);
 }

--- a/src/screens/TitleScreen.tsx
+++ b/src/screens/TitleScreen.tsx
@@ -36,15 +36,20 @@ export default function TitleScreen() {
 
   return (
     <div className={styles.screen}>
-      <h1 className={styles.heading}>CurtainCall</h1>
+      <div className={styles.ornament}>a card game in three acts</div>
+      <h1 className={styles.heading}>Curtain<em>Call</em></h1>
+      <div className={styles.headingJp}>カーテンコール</div>
+
       <div className={styles.form}>
         <div className={styles.field}>
-          <label htmlFor="playerA" className={styles.label}>
-            プレイヤーA
-          </label>
+          <div className={styles.fieldHeader}>
+            <label htmlFor="playerA" className={styles.label}>Player A</label>
+            <span className={styles.labelSub}>先攻</span>
+          </div>
           <input
             id="playerA"
             type="text"
+            aria-label="プレイヤーA"
             className={styles.input}
             value={playerAName}
             onChange={(e) => setPlayerAName(e.target.value)}
@@ -53,12 +58,14 @@ export default function TitleScreen() {
           {errors.a && <p className={styles.error}>{errors.a}</p>}
         </div>
         <div className={styles.field}>
-          <label htmlFor="playerB" className={styles.label}>
-            プレイヤーB
-          </label>
+          <div className={styles.fieldHeader}>
+            <label htmlFor="playerB" className={styles.label}>Player B</label>
+            <span className={styles.labelSub}>後攻</span>
+          </div>
           <input
             id="playerB"
             type="text"
+            aria-label="プレイヤーB"
             className={styles.input}
             value={playerBName}
             onChange={(e) => setPlayerBName(e.target.value)}
@@ -66,11 +73,13 @@ export default function TitleScreen() {
           />
           {errors.b && <p className={styles.error}>{errors.b}</p>}
         </div>
-        {errors.general && <p className={styles.error}>{errors.general}</p>}
-        <button className={styles.startBtn} onClick={handleStart}>
-          ゲームスタート
-        </button>
       </div>
+
+      {errors.general && <p className={styles.error}>{errors.general}</p>}
+
+      <button className={styles.startBtn} aria-label="ゲームスタート" onClick={handleStart}>
+        OVERTURE · 開演
+      </button>
     </div>
   );
 }

--- a/src/screens/WatchScreen.module.css
+++ b/src/screens/WatchScreen.module.css
@@ -58,7 +58,7 @@
 .clapBtn,
 .booBtn {
   padding: 14px 32px;
-  border-radius: 12px;
+  border-radius: 0;
   font-size: 16px;
   font-weight: bold;
   cursor: pointer;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,12 +4,59 @@
   padding: 0;
 }
 
+:root {
+  --bg: #0a0608;
+  --bg2: #150a08;
+  --surface: #1c100e;
+  --border: rgba(214, 172, 108, 0.2);
+  --border-strong: rgba(214, 172, 108, 0.35);
+  --text: #f5ebdc;
+  --text-sec: #c7b496;
+  --muted: #8a7a62;
+  --gold: #d6ac6c;
+  --crimson: #a02030;
+  --accent: #a02030;
+  --danger: #c86a4a;
+}
+
 html, body {
   height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', 'Noto Sans JP', sans-serif;
+}
+
+button {
+  font-family: 'Inter', 'Noto Sans JP', sans-serif;
+  cursor: pointer;
 }
 
 #__next {
-  min-height: 100dvh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
+  position: relative;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(160, 32, 48, 0.18) 0%, transparent 55%),
+    radial-gradient(ellipse at 50% 100%, rgba(92, 16, 24, 0.35) 0%, transparent 60%),
+    linear-gradient(180deg, #150a08 0%, #0a0608 100%);
+  overflow: hidden;
+}
+
+/* 緞帳ストライプオーバーレイ */
+#__next::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(92, 16, 24, 0) 0px,
+    rgba(92, 16, 24, 0.20) 48px,
+    rgba(160, 32, 48, 0.08) 96px,
+    rgba(92, 16, 24, 0) 144px
+  );
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 0;
 }


### PR DESCRIPTION
## Summary
- CSS変数を劇場テーマ（深紅 #a02030 × ゴールド #d6ac6c × 黒 #0a0608）に全面刷新
- Google Fonts（Cormorant Garamond / Noto Serif JP）を導入、シアター調タイポグラフィを実現
- レイアウトを topbar(64px) + stage(flex-row) + handDock(bottom) の3段構成に変更（#157 対応含む）
- PhaseHeader・Card・HandPanel・InfoOverlay・全スクリーンを劇場テーマに統一
- **PassDevice表示中に操作プレイヤーの手札が相手から見える問題を修正** (#159)
  - GameRouter に `isPassDeviceVisible` 状態を追加
  - PassDevice 表示中は handDock および InfoOverlay の手札を非表示

## テスト互換性
- `aria-label` 追加でビジュアルテキスト変更後もアクセシビリティクエリが通る
- Card の `.rankBr` を `data-rank` + CSS `::before` で描画（`getByText` の重複マッチ回避）
- IntermissionScreen の swapArrow を直接テキストノードで構成（`getByText` の `getNodeText` 制約対応）
- StandbyScreen の "カード配布完了" を `h2` に変更（`getByRole('heading')` 対応）

## Test plan
- [x] `npx vitest run` — 350件全パス
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx eslint .` — 警告なし
- [ ] ブラウザ手動確認: タイトル→スタンバイ→スカウト→アクション（PassDevice中手札非表示）→スポットライト→インターミッション→リザルト

Closes #164
Closes #159
Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)